### PR TITLE
Fix build system updates for AltCover and ReportGenerator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,11 @@ StyleCopViolations.xml
 StyleCop.Cache
 coverage_unit.xml
 coverage_integration.xml
-coveragereport/
+coverage_report/
 
 # Cake
-tools/
+tools/*
+!tools/packages.config
 
 # Docs
 docs/_site/

--- a/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
+++ b/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://scenegate.github.io/Yarhl/</PackageProjectUrl>
     <PackageTags>translation;localization;romhacking;fan-translation</PackageTags>
 
-    <TargetFrameworks>net47;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>Yarhl.IntegrationTests</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>StyleCop.ruleset</CodeAnalysisRuleSet>

--- a/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
+++ b/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://scenegate.github.io/Yarhl/</PackageProjectUrl>
     <PackageTags>translation;localization;romhacking;fan-translation</PackageTags>
 
-    <TargetFrameworks>net47;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>Yarhl.UnitTests</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>StyleCop.ruleset</CodeAnalysisRuleSet>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.32.1" />
+</packages>


### PR DESCRIPTION
### Description
We weren't using pinned version of the dependencias and cake and the latest version broke compatibility. I updated the API usage for AltCover and a change of behavior in ReportGenerator. I have also simplified a few paths. I have pinned the version to prevent these problems in the future.