### PR TITLE
Support BOM in TextReader and TextWriter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Output
 bin/
 obj/
+artifacts/
 
 # IDE
 *.userprefs

--- a/build.cake
+++ b/build.cake
@@ -112,6 +112,11 @@ Task("Run-Unit-Tests")
         NoBuild = true,
         Framework = $"netcoreapp{netcoreVersion}"
     };
+
+    if (tests != string.Empty) {
+        netcoreSettings.Filter = $"FullyQualifiedName~{tests}";
+    }
+
     DotNetCoreTest(
         $"src/Yarhl.UnitTests/Yarhl.UnitTests.csproj",
         netcoreSettings);
@@ -217,10 +222,6 @@ public void TestWithAltCover(string projectPath, string assembly, string outputX
 
     NUnit3($"{outputDir}/{assembly}", new NUnit3Settings { NoResults = true });
 }
-
-Task("Test-Quality")
-    .IsDependentOn("Run-Linter-Gendarme")
-    .IsDependentOn("Run-AltCover");
 
 Task("Run-Sonar")
     .IsDependentOn("Build")
@@ -347,12 +348,13 @@ Task("Deploy")
 Task("Default")
     .IsDependentOn("Build")
     .IsDependentOn("Run-Unit-Tests")
-    .IsDependentOn("Test-Quality");
+    .IsDependentOn("Run-AltCover");
 
 Task("Travis")
     .IsDependentOn("Build")
     .IsDependentOn("Run-Unit-Tests")
-    .IsDependentOn("Test-Quality")
+    .IsDependentOn("Run-AltCover")
+    .IsDependentOn("Run-Linter-Gendarme")
     .IsDependentOn("Build-Doc");  // Try to build the doc but don't deploy
 
 Task("AppVeyor")

--- a/src/Yarhl.IntegrationTests/StyleCop.ruleset
+++ b/src/Yarhl.IntegrationTests/StyleCop.ruleset
@@ -2,9 +2,7 @@
 <RuleSet Name="Rules for Yarhl.IntegrationTests" ToolsVersion="12.0">
   <Include Path="..\StyleCop.ruleset" Action="Default" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-    <!-- Disable documentation for public types and members. -->
-    <Rule Id="CS1591" Action="None" />
-    <!-- Disable documentation for methods. -->
-    <Rule Id="SA1600" Action="None" />
+    <!-- Disable documentation in unit tests. -->
+    <Rule Id="SA0001" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
+++ b/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Yarhl.IntegrationTests</AssemblyName>
     <Product>SceneGate</Product>
-    <Version>2.0-alpha.1</Version>
+    <Version>2.0-alpha.2</Version>
     <Description>Plugin integration tests for Yarhl.</Description>
 
     <Authors>pleonex</Authors>
@@ -17,7 +17,6 @@
 
     <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>Yarhl.IntegrationTests</RootNamespace>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>StyleCop.ruleset</CodeAnalysisRuleSet>
     <!-- Mark the project as being a test project -->
     <SonarQubeTestProject>true</SonarQubeTestProject>

--- a/src/Yarhl.Media/Yarhl.Media.csproj
+++ b/src/Yarhl.Media/Yarhl.Media.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Yarhl.Media</AssemblyName>
     <Product>SceneGate</Product>
-    <Version>2.0-alpha.1</Version>
+    <Version>2.0-alpha.2</Version>
     <Description>Yarhl plugin with support of text converters.</Description>
 
     <Authors>pleonex</Authors>

--- a/src/Yarhl.UnitTests/IO/TextReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/TextReaderTests.cs
@@ -121,6 +121,20 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void ReadCharWithPreamble()
+        {
+            stream.WriteByte(0xFF);
+            stream.WriteByte(0xFE);
+            stream.WriteByte(0x61);
+            stream.WriteByte(0x00);
+            stream.Position = 0;
+
+            var reader = new TextReader(stream, Encoding.Unicode);
+            Assert.AreEqual('a', reader.Read());
+            Assert.AreEqual(4, stream.Position);
+        }
+
+        [Test]
         public void ReadEndOfStreamThrowsException()
         {
             var reader = new TextReader(stream);
@@ -160,6 +174,27 @@ namespace Yarhl.UnitTests.IO
             Assert.AreEqual('1', chars[0]);
             Assert.AreEqual('9', chars[1]);
             Assert.AreEqual(4, stream.Position);
+        }
+
+        [Test]
+        public void ReadArrayWithPreamble()
+        {
+            stream.WriteByte(0xFF);
+            stream.WriteByte(0xFE);
+            stream.WriteByte(0x31);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0x39);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0x35);
+            stream.WriteByte(0x00);
+            stream.Position = 0;
+
+            var reader = new TextReader(stream, Encoding.Unicode);
+            var chars = reader.Read(2);
+
+            Assert.AreEqual('1', chars[0]);
+            Assert.AreEqual('9', chars[1]);
+            Assert.AreEqual(6, stream.Position);
         }
 
         [Test]
@@ -228,6 +263,26 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void ReadToCharWithPreamble()
+        {
+            stream.WriteByte(0xFF);
+            stream.WriteByte(0xFE);
+            stream.WriteByte(0x31);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0x39);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0x35);
+            stream.WriteByte(0x00);
+            stream.Position = 0;
+
+            var reader = new TextReader(stream, Encoding.Unicode);
+            var text = reader.ReadToToken("9");
+
+            Assert.AreEqual("1", text);
+            Assert.AreEqual(6, stream.Position);
+        }
+
+        [Test]
         public void ReadToPartialToken()
         {
             stream.WriteByte(0x31);
@@ -255,6 +310,26 @@ namespace Yarhl.UnitTests.IO
 
             Assert.AreEqual("1", text);
             Assert.AreEqual(3, stream.Position);
+        }
+
+        [Test]
+        public void ReadToTokenWithPreamble()
+        {
+            stream.WriteByte(0xFF);
+            stream.WriteByte(0xFE);
+            stream.WriteByte(0x31);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0x39);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0x35);
+            stream.WriteByte(0x00);
+            stream.Position = 0;
+
+            var reader = new TextReader(stream, Encoding.Unicode);
+            string text = reader.ReadToToken("95");
+
+            Assert.AreEqual("1", text);
+            Assert.AreEqual(8, stream.Position);
         }
 
         [Test]
@@ -349,6 +424,30 @@ namespace Yarhl.UnitTests.IO
 
             Assert.AreEqual("59", line);
             Assert.AreEqual(3, stream.Position);
+        }
+
+        [Test]
+        public void ReadLineWithPreamble()
+        {
+            stream.WriteByte(0xFF);
+            stream.WriteByte(0xFE);
+            stream.WriteByte(0x35);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0x39);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0x0A);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0x31);
+            stream.WriteByte(0x00);
+            stream.Position = 0;
+
+            var reader = new TextReader(stream, Encoding.Unicode);
+            reader.AutoNewLine = false;
+            reader.NewLine = "\n";
+            var line = reader.ReadLine();
+
+            Assert.AreEqual("59", line);
+            Assert.AreEqual(8, stream.Position);
         }
 
         [Test]
@@ -478,6 +577,24 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void ReadToEndWithPreamble()
+        {
+            stream.WriteByte(0xFF);
+            stream.WriteByte(0xFE);
+            stream.WriteByte(0x31);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0x35);
+            stream.WriteByte(0x00);
+            stream.Position = 0;
+
+            var reader = new TextReader(stream, Encoding.Unicode);
+            var text = reader.ReadToEnd();
+
+            Assert.AreEqual("15", text);
+            Assert.AreEqual(6, stream.Position);
+        }
+
+        [Test]
         public void ReadToEndStartingAtSomePos()
         {
             stream.WriteByte(0x31);
@@ -515,6 +632,20 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void PeekCharWithEncoding()
         {
+            stream.WriteByte(0x61);
+            stream.WriteByte(0x00);
+            stream.Position = 0;
+
+            var reader = new TextReader(stream, Encoding.Unicode);
+            Assert.AreEqual('a', reader.Peek());
+            Assert.AreEqual(0, stream.Position);
+        }
+
+        [Test]
+        public void PeekCharWithPreamble()
+        {
+            stream.WriteByte(0xFF);
+            stream.WriteByte(0xFE);
             stream.WriteByte(0x61);
             stream.WriteByte(0x00);
             stream.Position = 0;

--- a/src/Yarhl.UnitTests/IO/TextReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/TextReaderTests.cs
@@ -34,13 +34,11 @@ namespace Yarhl.UnitTests.IO
     public class TextReaderTests
     {
         DataStream stream;
-        TextReader reader;
 
         [SetUp]
         public void SetUp()
         {
             stream = new DataStream();
-            reader = new TextReader(stream);
         }
 
         [TearDown]
@@ -52,6 +50,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void PropertyValuesWithConstructorOneArgument()
         {
+            var reader = new TextReader(stream);
             Assert.AreSame(stream, reader.Stream);
             Assert.AreSame(Encoding.UTF8, reader.Encoding);
             Assert.AreEqual(Environment.NewLine, reader.NewLine);
@@ -61,7 +60,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void PropertyValuesWithConstructorEncoding()
         {
-            reader = new TextReader(stream, Encoding.ASCII);
+            var reader = new TextReader(stream, Encoding.ASCII);
             Assert.AreSame(stream, reader.Stream);
             Assert.AreSame(Encoding.ASCII, reader.Encoding);
             Assert.AreEqual(Environment.NewLine, reader.NewLine);
@@ -80,9 +79,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void PropertyActuallyChangesValues()
         {
-            reader.Encoding = Encoding.BigEndianUnicode;
-            Assert.AreSame(Encoding.BigEndianUnicode, reader.Encoding);
-
+            var reader = new TextReader(stream);
             reader.NewLine = "a";
             Assert.AreEqual("a", reader.NewLine);
 
@@ -93,6 +90,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void AutoNewLineIsFalseAfterSettingNewLine()
         {
+            var reader = new TextReader(stream);
             Assert.IsTrue(reader.AutoNewLine);
             reader.NewLine = "a";
             Assert.IsFalse(reader.AutoNewLine);
@@ -105,6 +103,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x30);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             Assert.AreEqual('a', reader.Read());
             Assert.AreEqual(1, stream.Position);
         }
@@ -116,7 +115,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            reader.Encoding = Encoding.GetEncoding("utf-16");
+            var reader = new TextReader(stream, Encoding.Unicode);
             Assert.AreEqual('a', reader.Read());
             Assert.AreEqual(2, stream.Position);
         }
@@ -124,6 +123,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadEndOfStreamThrowsException()
         {
+            var reader = new TextReader(stream);
             Assert.Throws<System.IO.EndOfStreamException>(() => reader.Read());
         }
 
@@ -135,6 +135,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             var chars = reader.Read(2);
 
             Assert.AreEqual('1', chars[0]);
@@ -153,7 +154,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            reader.Encoding = Encoding.GetEncoding("utf-16");
+            var reader = new TextReader(stream, Encoding.Unicode);
             var chars = reader.Read(2);
 
             Assert.AreEqual('1', chars[0]);
@@ -164,6 +165,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadArrayThrowsExceptionIfNegative()
         {
+            var reader = new TextReader(stream);
             Assert.Throws<ArgumentOutOfRangeException>(() => reader.Read(-3));
         }
 
@@ -173,6 +175,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x31);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             Assert.Throws<System.IO.EndOfStreamException>(() => reader.Read(3));
         }
 
@@ -184,6 +187,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             string text = reader.ReadToToken("9");
 
             Assert.AreEqual("1", text);
@@ -197,6 +201,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x39);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             string text = string.Empty;
             Assert.DoesNotThrow(() => text = reader.ReadToToken("5"));
 
@@ -215,7 +220,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            reader.Encoding = Encoding.GetEncoding("utf-16");
+            var reader = new TextReader(stream, Encoding.Unicode);
             var text = reader.ReadToToken("9");
 
             Assert.AreEqual("1", text);
@@ -230,6 +235,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             string text = reader.ReadToToken("5.");
 
             Assert.AreEqual("195", text);
@@ -244,6 +250,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             string text = reader.ReadToToken("95");
 
             Assert.AreEqual("1", text);
@@ -253,12 +260,14 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadToTokenWhenEOFReturnsNull()
         {
+            var reader = new TextReader(stream);
             Assert.IsNull(reader.ReadToToken("3"));
         }
 
         [Test]
         public void ReadToNullOrEmptyToken()
         {
+            var reader = new TextReader(stream);
             Assert.That(() => reader.ReadToToken(null), Throws.ArgumentNullException);
             Assert.That(() => reader.ReadToToken(string.Empty), Throws.ArgumentNullException);
         }
@@ -273,6 +282,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x38);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             string text = reader.ReadToToken("5");
 
             Assert.That(text, Is.EqualTo(new string('0', 150)));
@@ -294,7 +304,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0xe5);  // half encoded
             stream.Position = 0;
 
-            reader.Encoding = Encoding.GetEncoding("utf-16");
+            var reader = new TextReader(stream, Encoding.Unicode);
             string text = reader.ReadToToken("a");
 
             Assert.That(text, Is.EqualTo("01"));
@@ -316,6 +326,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x30);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             string text = reader.ReadToToken("\x08");
 
             Assert.That(text, Is.EqualTo(new string('0', 127) + '漢'));
@@ -331,6 +342,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x31);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             reader.AutoNewLine = false;
             reader.NewLine = "\n";
             var line = reader.ReadLine();
@@ -354,9 +366,9 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
+            var reader = new TextReader(stream, Encoding.Unicode);
             reader.AutoNewLine = false;
             reader.NewLine = "\r\n";
-            reader.Encoding = Encoding.GetEncoding("utf-16");
             var line = reader.ReadLine();
 
             Assert.AreEqual("51", line);
@@ -376,6 +388,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x30);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             Assert.That(reader.ReadLine(), Is.EqualTo("51"));
             Assert.AreEqual(4, stream.Position);
 
@@ -399,6 +412,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte((byte)'0');
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             reader.NewLine = "<br/>";
             reader.AutoNewLine = false;
 
@@ -416,6 +430,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x39);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             var line = string.Empty;
             Assert.DoesNotThrow(() => line = reader.ReadLine());
             Assert.AreEqual("19", line);
@@ -425,6 +440,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadLineWhenEOFReturnsNull()
         {
+            var reader = new TextReader(stream);
             Assert.IsNull(reader.ReadLine());
 
             reader.AutoNewLine = false;
@@ -438,6 +454,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             var text = reader.ReadToEnd();
 
             Assert.AreEqual("15", text);
@@ -453,7 +470,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            reader.Encoding = Encoding.GetEncoding("utf-16");
+            var reader = new TextReader(stream, Encoding.Unicode);
             var text = reader.ReadToEnd();
 
             Assert.AreEqual("15", text);
@@ -467,6 +484,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 1;
 
+            var reader = new TextReader(stream);
             var text = reader.ReadToEnd();
 
             Assert.AreEqual("5", text);
@@ -476,6 +494,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadToEndIfEmpty()
         {
+            var reader = new TextReader(stream);
             Assert.AreEqual(string.Empty, reader.ReadToEnd());
         }
 
@@ -486,6 +505,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x42);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             char ch = reader.Peek();
 
             Assert.AreEqual('A', ch);
@@ -499,7 +519,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            reader.Encoding = Encoding.GetEncoding("utf-16");
+            var reader = new TextReader(stream, Encoding.Unicode);
             Assert.AreEqual('a', reader.Peek());
             Assert.AreEqual(0, stream.Position);
         }
@@ -507,6 +527,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void PeekEndOfStreamThrowsException()
         {
+            var reader = new TextReader(stream);
             Assert.Throws<System.IO.EndOfStreamException>(() => reader.Peek());
         }
 
@@ -518,6 +539,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             var chars = reader.Peek(2);
 
             Assert.AreEqual('1', chars[0]);
@@ -533,6 +555,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             string text = reader.PeekToToken("5");
 
             Assert.AreEqual("19", text);
@@ -549,6 +572,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x31);
             stream.Position = 0;
 
+            var reader = new TextReader(stream);
             reader.NewLine = "\r\n";
             var line = reader.PeekLine();
 

--- a/src/Yarhl.UnitTests/IO/TextWriterTests.cs
+++ b/src/Yarhl.UnitTests/IO/TextWriterTests.cs
@@ -34,13 +34,11 @@ namespace Yarhl.UnitTests.IO
     public class TextWriterTests
     {
         DataStream stream;
-        TextWriter writer;
 
         [SetUp]
         public void SetUp()
         {
             stream = new DataStream();
-            writer = new TextWriter(stream);
         }
 
         [TearDown]
@@ -52,15 +50,17 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void DefaultPropertyValues()
         {
+            var writer = new TextWriter(stream);
             Assert.AreSame(stream, writer.Stream);
             Assert.AreSame(Encoding.UTF8, writer.Encoding);
+            Assert.IsFalse(writer.AutoPreamble);
             Assert.AreEqual("\n", writer.NewLine);
         }
 
         [Test]
         public void ConstructorWithEncoding()
         {
-            writer = new TextWriter(stream, Encoding.ASCII);
+            var writer = new TextWriter(stream, Encoding.ASCII);
             Assert.AreSame(Encoding.ASCII, writer.Encoding);
         }
 
@@ -78,16 +78,19 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void PropertiesChangeValues()
         {
-            writer.Encoding = Encoding.ASCII;
-            Assert.AreSame(Encoding.ASCII, writer.Encoding);
-
+            var writer = new TextWriter(stream);
             writer.NewLine = "a";
             Assert.AreEqual("a", writer.NewLine);
+
+            writer.AutoPreamble = true;
+            Assert.IsTrue(writer.AutoPreamble);
         }
 
         [Test]
         public void WriteChar()
         {
+            var writer = new TextWriter(stream);
+            writer.AutoPreamble = false;
             writer.Write('c');
 
             stream.Position = 0;
@@ -98,7 +101,8 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteCharWithEncoding()
         {
-            writer.Encoding = Encoding.GetEncoding("utf-16");
+            var writer = new TextWriter(stream, Encoding.Unicode);
+            writer.AutoPreamble = false;
             writer.Write('c');
 
             stream.Position = 0;
@@ -110,6 +114,8 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteCharArray()
         {
+            var writer = new TextWriter(stream);
+            writer.AutoPreamble = false;
             writer.Write(new char[] { 'z', 'w' });
 
             stream.Position = 0;
@@ -121,7 +127,8 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteCharArrayWithEncoding()
         {
-            writer.Encoding = Encoding.GetEncoding("utf-16");
+            var writer = new TextWriter(stream, Encoding.Unicode);
+            writer.AutoPreamble = false;
             writer.Write(new char[] { 'z', 'w' });
 
             stream.Position = 0;
@@ -135,12 +142,15 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteNullCharArrayThrowsException()
         {
+            var writer = new TextWriter(stream);
             Assert.Throws<ArgumentNullException>(() => writer.Write((char[])null));
         }
 
         [Test]
         public void WriteString()
         {
+            var writer = new TextWriter(stream);
+            writer.AutoPreamble = false;
             writer.Write("he");
 
             stream.Position = 0;
@@ -152,7 +162,8 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteStringWithEncoding()
         {
-            writer.Encoding = Encoding.GetEncoding("utf-16");
+            var writer = new TextWriter(stream, Encoding.Unicode);
+            writer.AutoPreamble = false;
             writer.Write("he");
 
             stream.Position = 0;
@@ -166,12 +177,15 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteNullStringThrowsException()
         {
+            var writer = new TextWriter(stream);
             Assert.Throws<ArgumentNullException>(() => writer.Write((string)null));
         }
 
         [Test]
         public void WriteStringFormat()
         {
+            var writer = new TextWriter(stream);
+            writer.AutoPreamble = false;
             writer.Write("a{0}", 3);
 
             stream.Position = 0;
@@ -183,6 +197,8 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteStringFormatEscaping()
         {
+            var writer = new TextWriter(stream);
+            writer.AutoPreamble = false;
             writer.Write("a{{0}}", 3);
 
             stream.Position = 0;
@@ -196,7 +212,8 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteStringFormatWithEncoding()
         {
-            writer.Encoding = Encoding.GetEncoding("utf-16");
+            var writer = new TextWriter(stream, Encoding.Unicode);
+            writer.AutoPreamble = false;
             writer.Write("a{0}", 3);
 
             stream.Position = 0;
@@ -210,6 +227,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteNullStringFormatThrowsException()
         {
+            var writer = new TextWriter(stream);
             Assert.Throws<ArgumentNullException>(() => writer.Write(null, "a"));
             Assert.Throws<ArgumentNullException>(() => writer.Write("a", null));
         }
@@ -217,6 +235,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteStringFormatWithLessFormatsThrows()
         {
+            var writer = new TextWriter(stream);
             Assert.Throws<FormatException>(() => writer.Write("a{0}{1}", 3));
             Assert.Throws<FormatException>(() => writer.Write("a{1}", 3));
             Assert.Throws<FormatException>(() => writer.Write("a{0}", new object[0]));
@@ -225,12 +244,15 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteStringFormatWithMoreArgsDoesNotThrow()
         {
+            var writer = new TextWriter(stream);
             Assert.DoesNotThrow(() => writer.Write("a{0}", 3, 4, 5));
         }
 
         [Test]
         public void WriteLineOnly()
         {
+            var writer = new TextWriter(stream);
+            writer.AutoPreamble = false;
             writer.WriteLine();
 
             stream.Position = 0;
@@ -241,7 +263,8 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineOnlyWithEncoding()
         {
-            writer.Encoding = Encoding.GetEncoding("utf-16");
+            var writer = new TextWriter(stream, Encoding.Unicode);
+            writer.AutoPreamble = false;
             writer.WriteLine();
 
             stream.Position = 0;
@@ -253,6 +276,8 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineOnlyWithNewLine()
         {
+            var writer = new TextWriter(stream);
+            writer.AutoPreamble = false;
             writer.NewLine = "NL";
             writer.WriteLine();
 
@@ -265,6 +290,8 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineString()
         {
+            var writer = new TextWriter(stream);
+            writer.AutoPreamble = false;
             writer.WriteLine("za");
 
             stream.Position = 0;
@@ -277,7 +304,8 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineStringWithEncoding()
         {
-            writer.Encoding = Encoding.GetEncoding("utf-16");
+            var writer = new TextWriter(stream, Encoding.Unicode);
+            writer.AutoPreamble = false;
             writer.WriteLine("a");
 
             stream.Position = 0;
@@ -291,12 +319,15 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineNullStringThrowsException()
         {
+            var writer = new TextWriter(stream);
             Assert.Throws<ArgumentNullException>(() => writer.WriteLine(null));
         }
 
         [Test]
         public void WriteLineStringFormat()
         {
+            var writer = new TextWriter(stream);
+            writer.AutoPreamble = false;
             writer.WriteLine("a{0}", 3);
 
             stream.Position = 0;
@@ -309,6 +340,8 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineStringFormatEscaping()
         {
+            var writer = new TextWriter(stream);
+            writer.AutoPreamble = false;
             writer.WriteLine("a{{0}}", 3);
 
             stream.Position = 0;
@@ -323,7 +356,8 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineStringFormatWithEncoding()
         {
-            writer.Encoding = Encoding.GetEncoding("utf-16");
+            var writer = new TextWriter(stream, Encoding.Unicode);
+            writer.AutoPreamble = false;
             writer.WriteLine("a{0}", 3);
 
             stream.Position = 0;
@@ -339,6 +373,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineNullStringFormatThrowsException()
         {
+            var writer = new TextWriter(stream);
             Assert.Throws<ArgumentNullException>(() => writer.WriteLine(null, "a"));
             Assert.Throws<ArgumentNullException>(() => writer.WriteLine("a", null));
         }
@@ -346,6 +381,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineStringFormatWithLessFormatsThrows()
         {
+            var writer = new TextWriter(stream);
             Assert.Throws<FormatException>(() => writer.WriteLine("a{0}{1}", 3));
             Assert.Throws<FormatException>(() => writer.WriteLine("a{1}", 3));
             Assert.Throws<FormatException>(() => writer.WriteLine("a{0}", new object[0]));
@@ -354,6 +390,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineStringFormatWithMoreArgsDoesNotThrow()
         {
+            var writer = new TextWriter(stream);
             Assert.DoesNotThrow(() => writer.WriteLine("a{0}", 3, 4, 5));
         }
     }

--- a/src/Yarhl.UnitTests/StyleCop.ruleset
+++ b/src/Yarhl.UnitTests/StyleCop.ruleset
@@ -2,9 +2,7 @@
 <RuleSet Name="Rules for Yarhl.UnitTests" ToolsVersion="12.0">
   <Include Path="..\StyleCop.ruleset" Action="Default" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-    <!-- Disable documentation for public types and members. -->
-    <Rule Id="CS1591" Action="None" />
-    <!-- Disable documentation for methods. -->
-    <Rule Id="SA1600" Action="None" />
+    <!-- Disable documentation in unit tests. -->
+    <Rule Id="SA0001" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
+++ b/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Yarhl.UnitTests</AssemblyName>
     <Product>SceneGate</Product>
-    <Version>2.0-alpha.1</Version>
+    <Version>2.0-alpha.2</Version>
     <Description>Yarhl unit tests.</Description>
 
     <Authors>pleonex</Authors>
@@ -17,7 +17,6 @@
 
     <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>Yarhl.UnitTests</RootNamespace>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>StyleCop.ruleset</CodeAnalysisRuleSet>
     <!-- Mark the project as being a test project -->
     <SonarQubeTestProject>true</SonarQubeTestProject>

--- a/src/Yarhl/IO/TextReader.cs
+++ b/src/Yarhl/IO/TextReader.cs
@@ -31,7 +31,7 @@ namespace Yarhl.IO
     using System.Text;
 
     /// <summary>
-    /// Text reader for DataStreams.
+    /// Text reader for <cref href="DataStream" />.
     /// </summary>
     public class TextReader
     {
@@ -55,11 +55,14 @@ namespace Yarhl.IO
         /// <param name="encoding">Encoding to use.</param>
         public TextReader(DataStream stream, Encoding encoding)
         {
-            reader = new DataReader(stream);
             Stream = stream ?? throw new ArgumentNullException(nameof(stream));
             Encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
             NewLine = Environment.NewLine;
             AutoNewLine = true;
+
+            reader = new DataReader(stream) {
+                DefaultEncoding = Encoding,
+            };
         }
 
         /// <summary>
@@ -72,12 +75,12 @@ namespace Yarhl.IO
         }
 
         /// <summary>
-        /// Gets or sets the encoding.
+        /// Gets the encoding.
         /// </summary>
         /// <value>The encoding.</value>
         public Encoding Encoding {
             get;
-            set;
+            private set;
         }
 
         /// <summary>
@@ -116,7 +119,7 @@ namespace Yarhl.IO
         public char Read()
         {
             SkipPreamble();
-            return reader.ReadChar(Encoding);
+            return reader.ReadChar();
         }
 
         /// <summary>
@@ -130,7 +133,7 @@ namespace Yarhl.IO
                 throw new ArgumentOutOfRangeException(nameof(count));
 
             SkipPreamble();
-            return reader.ReadChars(count, Encoding);
+            return reader.ReadChars(count);
         }
 
         /// <summary>
@@ -159,6 +162,7 @@ namespace Yarhl.IO
             List<byte> textBuffer = new List<byte>();
             string text = string.Empty;
             int matchIndex = -1;
+
             while (matchIndex == -1) {
                 if (Stream.EndOfStream)
                     break;
@@ -216,9 +220,7 @@ namespace Yarhl.IO
         public string ReadToEnd()
         {
             SkipPreamble();
-            return reader.ReadString(
-                (int)(Stream.Length - Stream.Position),
-                Encoding);
+            return reader.ReadString((int)(Stream.Length - Stream.Position));
         }
 
         /// <summary>
@@ -273,6 +275,7 @@ namespace Yarhl.IO
 
         void SkipPreamble()
         {
+            // Preambles can only be at the beginning of the stream.
             if (Stream.Position > 0) {
                 return;
             }

--- a/src/Yarhl/IO/TextWriter.cs
+++ b/src/Yarhl/IO/TextWriter.cs
@@ -206,7 +206,7 @@ namespace Yarhl.IO
         {
             if (Stream.Position > 0) {
                 throw new InvalidOperationException(
-                    "Preamble can be written only in Position 0.");
+                    "Preamble can be written only in position 0.");
             }
 
             writer.Write(Encoding.GetPreamble());

--- a/src/Yarhl/IO/TextWriter.cs
+++ b/src/Yarhl/IO/TextWriter.cs
@@ -61,6 +61,7 @@ namespace Yarhl.IO
             Stream = stream;
             Encoding = encoding;
             NewLine = "\n";
+            AutoPreamble = true;
             writer = new DataWriter(stream);
         }
 
@@ -93,11 +94,24 @@ namespace Yarhl.IO
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether write automatically
+        /// the encoding preamble.
+        /// </summary>
+        /// <value>
+        /// True to write the preamble if the stream is empty, otherwise false.
+        /// </value>
+        public bool AutoPreamble {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Write the specified char.
         /// </summary>
         /// <param name="ch">Char to write.</param>
         public void Write(char ch)
         {
+            CheckWritePreamble();
             writer.Write(ch, Encoding);
         }
 
@@ -110,6 +124,7 @@ namespace Yarhl.IO
             if (chars == null)
                 throw new ArgumentNullException(nameof(chars));
 
+            CheckWritePreamble();
             writer.Write(chars, Encoding);
         }
 
@@ -122,6 +137,7 @@ namespace Yarhl.IO
             if (text == null)
                 throw new ArgumentNullException(nameof(text));
 
+            CheckWritePreamble();
             writer.Write(text, false, Encoding);
         }
 
@@ -137,6 +153,7 @@ namespace Yarhl.IO
             if (args == null)
                 throw new ArgumentNullException(nameof(args));
 
+            CheckWritePreamble();
             string text = string.Format(CultureInfo.InvariantCulture, format, args);
             writer.Write(text, false, Encoding);
         }
@@ -146,6 +163,7 @@ namespace Yarhl.IO
         /// </summary>
         public void WriteLine()
         {
+            CheckWritePreamble();
             writer.Write(NewLine, false, Encoding);
         }
 
@@ -158,6 +176,7 @@ namespace Yarhl.IO
             if (text == null)
                 throw new ArgumentNullException(nameof(text));
 
+            CheckWritePreamble();
             writer.Write(text + NewLine, false, Encoding);
         }
 
@@ -173,8 +192,24 @@ namespace Yarhl.IO
             if (args == null)
                 throw new ArgumentNullException(nameof(args));
 
+            CheckWritePreamble();
             string text = string.Format(CultureInfo.InvariantCulture, format, args);
             writer.Write(text + NewLine, false, Encoding);
+        }
+
+        /// <summary>
+        /// Write the encoding preamble.
+        /// </summary>
+        public void WritePreamble()
+        {
+            writer.Write(Encoding.GetPreamble());
+        }
+
+        void CheckWritePreamble()
+        {
+            if (AutoPreamble && Stream.Position == 0) {
+                WritePreamble();
+            }
         }
     }
 }

--- a/src/Yarhl/IO/TextWriter.cs
+++ b/src/Yarhl/IO/TextWriter.cs
@@ -30,7 +30,7 @@ namespace Yarhl.IO
     using System.Text;
 
     /// <summary>
-    /// Text writer for DataStreams.
+    /// Text writer for <cref href="DataStream" />.
     /// </summary>
     public class TextWriter
     {
@@ -61,8 +61,10 @@ namespace Yarhl.IO
             Stream = stream;
             Encoding = encoding;
             NewLine = "\n";
-            AutoPreamble = true;
-            writer = new DataWriter(stream);
+            AutoPreamble = false;
+            writer = new DataWriter(stream) {
+                DefaultEncoding = Encoding,
+            };
         }
 
         /// <summary>
@@ -75,12 +77,12 @@ namespace Yarhl.IO
         }
 
         /// <summary>
-        /// Gets or sets the encoding.
+        /// Gets the encoding.
         /// </summary>
         /// <value>The encoding.</value>
         public Encoding Encoding {
             get;
-            set;
+            private set;
         }
 
         /// <summary>
@@ -112,7 +114,7 @@ namespace Yarhl.IO
         public void Write(char ch)
         {
             CheckWritePreamble();
-            writer.Write(ch, Encoding);
+            writer.Write(ch);
         }
 
         /// <summary>
@@ -125,7 +127,7 @@ namespace Yarhl.IO
                 throw new ArgumentNullException(nameof(chars));
 
             CheckWritePreamble();
-            writer.Write(chars, Encoding);
+            writer.Write(chars);
         }
 
         /// <summary>
@@ -138,7 +140,7 @@ namespace Yarhl.IO
                 throw new ArgumentNullException(nameof(text));
 
             CheckWritePreamble();
-            writer.Write(text, false, Encoding);
+            writer.Write(text, false);
         }
 
         /// <summary>
@@ -155,7 +157,7 @@ namespace Yarhl.IO
 
             CheckWritePreamble();
             string text = string.Format(CultureInfo.InvariantCulture, format, args);
-            writer.Write(text, false, Encoding);
+            writer.Write(text, false);
         }
 
         /// <summary>
@@ -164,7 +166,7 @@ namespace Yarhl.IO
         public void WriteLine()
         {
             CheckWritePreamble();
-            writer.Write(NewLine, false, Encoding);
+            writer.Write(NewLine, false);
         }
 
         /// <summary>
@@ -177,7 +179,7 @@ namespace Yarhl.IO
                 throw new ArgumentNullException(nameof(text));
 
             CheckWritePreamble();
-            writer.Write(text + NewLine, false, Encoding);
+            writer.Write(text + NewLine, false);
         }
 
         /// <summary>
@@ -194,7 +196,7 @@ namespace Yarhl.IO
 
             CheckWritePreamble();
             string text = string.Format(CultureInfo.InvariantCulture, format, args);
-            writer.Write(text + NewLine, false, Encoding);
+            writer.Write(text + NewLine, false);
         }
 
         /// <summary>
@@ -202,6 +204,11 @@ namespace Yarhl.IO
         /// </summary>
         public void WritePreamble()
         {
+            if (Stream.Position > 0) {
+                throw new InvalidOperationException(
+                    "Preamble can be written only in Position 0.");
+            }
+
             writer.Write(Encoding.GetPreamble());
         }
 

--- a/src/Yarhl/Yarhl.csproj
+++ b/src/Yarhl/Yarhl.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Yarhl</AssemblyName>
     <Product>SceneGate</Product>
-    <Version>2.0-alpha.1</Version>
+    <Version>2.0-alpha.2</Version>
     <Description>Library to translation projects. It provides features for implementing file formats, converters and a virtual file system.</Description>
 
     <Authors>pleonex</Authors>


### PR DESCRIPTION
### Description
Encoding preamble / BOM wasn't supported. This pull request allows to write automatically and manually the BOM from the TextWriter and ignore it on the TextReader.

### Example
The text reader behavior doesn't change. It will skip the BOM automatically if found at the beginning of the stream.

On the writer side, there are two new behaviors. If the property `AutoPreamble` is set, the writer will automatically write the BOM on the first write if the stream position is at 0. There is also a new method `WritePreamble` that writes the preamble if the stream is at 0.


This closes #70 