### PR TITLE
Fix reading multiline Po comments

### DIFF
--- a/src/Yarhl.Media/Text/Po2Binary.cs
+++ b/src/Yarhl.Media/Text/Po2Binary.cs
@@ -190,10 +190,16 @@ namespace Yarhl.Media.Text
 
             switch (fields[0]) {
                 case "#":
-                    entry.TranslatorComment = fields[1].TrimStart();
+                    entry.TranslatorComment = ReadMultiLineComment(
+                        reader,
+                        fields[1].TrimStart(),
+                        "# ");
                     break;
                 case "#.":
-                    entry.ExtractedComments = fields[1];
+                    entry.ExtractedComments = ReadMultiLineComment(
+                        reader,
+                        fields[1],
+                        "#.");
                     break;
                 case "#:":
                     entry.Reference = fields[1];
@@ -295,6 +301,18 @@ namespace Yarhl.Media.Text
 
                     throw new FormatException("Unknown header key: " + key);
             }
+        }
+
+        static string ReadMultiLineComment(TextReader reader, string line, string comment)
+        {
+            StringBuilder builder = new StringBuilder(line);
+            while (reader.PeekToToken(" ") == comment) {
+                // We just remove the comment token and take advantage that
+                // there is an space after it.
+                builder.Append(reader.ReadLine().Substring(comment.Length));
+            }
+
+            return builder.ToString();
         }
 
         static string ReadMultiLineContent(TextReader reader, string currentLine)

--- a/src/Yarhl.UnitTests/Media/Text/Po2BinaryTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/Po2BinaryTests.cs
@@ -439,6 +439,42 @@ msgstr """"
             Assert.AreEqual("test", newPo.Entries[0].Original);
         }
 
+        [Test]
+        public void EntryWithMultiLineExtractedComments()
+        {
+            var testPo = new Po();
+            testPo.Add(new PoEntry {
+                Original = "The Quick Brown Fox Jumps Over The Lazy Dog",
+                ExtractedComments =
+                    "TRANSLATORS: A test phrase with all letters of the English alphabet." +
+                    " Replace it with a sample text in your language, such that it is" +
+                    " representative of language's writing system.",
+                TranslatorComment =
+                    "NOTE: This is a very long comment that I am writting to test if" +
+                    " this is working properly.",
+                Reference = "kdeui/fonts/kfontchooser.cpp:382",
+            });
+
+            string text = @"
+#  NOTE: This is a very long comment that I am writting to test if
+#  this is working properly.
+#. TRANSLATORS: A test phrase with all letters of the English alphabet.
+#. Replace it with a sample text in your language, such that it is
+#. representative of language's writing system.
+#: kdeui/fonts/kfontchooser.cpp:382
+msgid ""The Quick Brown Fox Jumps Over The Lazy Dog""
+msgstr """"
+";
+            text = text.Replace("\r\n", "\n");
+
+            // TODO #85: CompareText(testPo.ConvertTo<BinaryFormat>(), text);
+            Po newPo = ConvertStringToPo(text);
+            Assert.AreEqual(1, newPo.Entries.Count);
+            Assert.AreEqual(testPo.Entries[0].Original, newPo.Entries[0].Original);
+            Assert.AreEqual(testPo.Entries[0].ExtractedComments, newPo.Entries[0].ExtractedComments);
+            Assert.AreEqual(testPo.Entries[0].Reference, newPo.Entries[0].Reference);
+        }
+
         static void CompareText(BinaryFormat binary, string expected)
         {
             binary.Stream.Position = 0;

--- a/src/Yarhl/IO/TextReader.cs
+++ b/src/Yarhl/IO/TextReader.cs
@@ -31,7 +31,7 @@ namespace Yarhl.IO
     using System.Text;
 
     /// <summary>
-    /// Text reader for <cref href="DataStream" />.
+    /// Text reader for <see cref="DataStream" />.
     /// </summary>
     public class TextReader
     {

--- a/src/Yarhl/IO/TextWriter.cs
+++ b/src/Yarhl/IO/TextWriter.cs
@@ -30,7 +30,7 @@ namespace Yarhl.IO
     using System.Text;
 
     /// <summary>
-    /// Text writer for <cref href="DataStream" />.
+    /// Text writer for <see cref="DataStream" />.
     /// </summary>
     public class TextWriter
     {


### PR DESCRIPTION
### Description
If a PO entry contained a comment or a translator comment wraped into multiple lines, reading the file will just get the latest line. Now it appends all the lines with spaces.

Linked issue: #80
