### PR TITLE
Avoid changing size of substreams

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet-test-explorer.testProjectPath": "src/Yarhl.UnitTests/Yarhl.UnitTests.csproj"
+}

--- a/build.cake
+++ b/build.cake
@@ -30,7 +30,7 @@
 #tool nuget:?package=ReportGenerator&version=4.1.2
 
 // SonarQube quality checks
-#addin nuget:?package=Cake.Sonar&version=1.1.18
+#addin nuget:?package=Cake.Sonar&version=1.1.22
 #tool nuget:?package=MSBuild.SonarQube.Runner.Tool&version=4.6.0
 #addin nuget:?package=Cake.Git&version=0.19.0
 

--- a/build.cake
+++ b/build.cake
@@ -240,9 +240,9 @@ Task("Run-Sonar")
     var sonarToken = EnvironmentVariable("SONAR_TOKEN");
     var sonarSettings = new SonarBeginSettings {
         Url = "https://sonarqube.com",
-        Key = "yarhl",
+        Key = "SceneGate_Yarhl",
         Login = sonarToken,
-        Organization = "pleonex-github",
+        Organization = "scenegate",
         Verbose = true,
      };
 

--- a/build.cake
+++ b/build.cake
@@ -238,8 +238,12 @@ Task("Run-Sonar")
     .Does(() =>
 {
     var sonarToken = EnvironmentVariable("SONAR_TOKEN");
+    if (string.IsNullOrWhiteSpace(sonarToken)) {
+        throw new Exception("Missing Sonar token");
+    }
+
     var sonarSettings = new SonarBeginSettings {
-        Url = "https://sonarqube.com",
+        Url = "https://sonarcloud.io",
         Key = "SceneGate_Yarhl",
         Login = sonarToken,
         Organization = "scenegate",

--- a/src/Common.props
+++ b/src/Common.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>3.0.0-alpha04</Version>
+        <Version>3.0.0-alpha05</Version>
         <Product>SceneGate</Product>
 
         <Authors>SceneGate Team</Authors>

--- a/src/Yarhl.UnitTests/IO/DataReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataReaderTests.cs
@@ -646,7 +646,8 @@ namespace Yarhl.UnitTests.IO
         public void ReadPaddingAbsoluteMode()
         {
             stream.WriteByte(0xAF);
-            using (var stream2 = new DataStream(stream, 1, 0)) {
+            stream.Write(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, 0, 7);
+            using (var stream2 = new DataStream(stream, 1, 7)) {
                 reader = new DataReader(stream2);
 
                 byte[] buffer = { 0xCA, 0xFE, 0x00, 0x00, 0xFF, 0xFF, 0xFF };

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -451,25 +451,31 @@ namespace Yarhl.UnitTests.IO
             Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
-            DataStream stream = new DataStream(baseStream, 0, 2);
+            DataStream stream = new DataStream(baseStream);
             Assert.AreEqual(2, stream.Length);
             stream.Length = 1;
             Assert.AreEqual(1, stream.Length);
         }
 
         [Test]
-        public void SetLengthUpdatesParentStream()
+        public void CannotIncreaseLengthFromSubStream()
         {
             DataStream parentStream = new DataStream();
-            parentStream.WriteByte(0xFF);
-            parentStream.WriteByte(0xFF);
+            parentStream.WriteByte(0x00);
+            parentStream.WriteByte(0x00);
 
-            DataStream parentStream2 = new DataStream(parentStream, 0, 0);
-            DataStream stream = new DataStream(parentStream2, 0, 0);
-            stream.WriteByte(0xFF);
-            Assert.AreEqual(1, stream.Length);
-            Assert.AreEqual(1, parentStream2.Length);
-            Assert.AreEqual(2, parentStream.Length);
+            DataStream childStream = new DataStream(parentStream, 1, 1);
+            childStream.WriteByte(0x01);
+            Assert.That(
+                () => childStream.WriteByte(0x01),
+                Throws.InvalidOperationException);
+
+            DataStream childStream2 = new DataStream(parentStream, 0, 2);
+            childStream2.WriteByte(0x02);
+            childStream2.WriteByte(0x02);
+            Assert.That(
+                () => childStream2.WriteByte(0x02),
+                Throws.InvalidOperationException);
         }
 
         [Test]
@@ -498,7 +504,7 @@ namespace Yarhl.UnitTests.IO
             Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
-            DataStream stream = new DataStream(baseStream, 0, 2);
+            DataStream stream = new DataStream(baseStream);
             stream.Seek(2, SeekMode.Start);
             Assert.AreEqual(2, stream.Position);
             stream.Length = 1;

--- a/src/Yarhl.UnitTests/IO/DataWriterTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataWriterTests.cs
@@ -963,15 +963,15 @@ namespace Yarhl.UnitTests.IO
         {
             DataStream stream = new DataStream();
             stream.WriteByte(0xAF);
+            stream.Write(new byte[] { 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA }, 0, 7);
 
-            DataStream stream2 = new DataStream(stream, 1, 0);
+            DataStream stream2 = new DataStream(stream, 1, 7);
             DataWriter writer = new DataWriter(stream2);
 
             writer.Write(0xCAFEu);
             writer.WritePadding(0xFF, 4);
 
             byte[] expected = { 0xAF, 0xFE, 0xCA, 0x00, 0x00 };
-            Assert.AreEqual(expected.Length, stream.Length);
 
             stream.Position = 0;
             byte[] actual = new byte[expected.Length];

--- a/src/Yarhl/Gendarme.ignore
+++ b/src/Yarhl/Gendarme.ignore
@@ -81,3 +81,9 @@ T: Yarhl.IO.DataWriter
 T: Yarhl.IO.TextReader
 T: Yarhl.IO.TextWriter
 T: Yarhl.FileSystem.Node
+
+R: Gendarme.Rules.Performance.AvoidUnneededFieldInitializationRule
+# Better be explicit in this case for clarity
+M: System.Void Yarhl.IO.DataStream::.ctor()
+M: System.Void Yarhl.IO.DataStream::.ctor(System.IO.Stream)
+M: System.Void Yarhl.IO.DataStream::.ctor(System.String,Yarhl.IO.FileOpenMode)


### PR DESCRIPTION
The Length setter was throwing an exception when creating substreams because of an invalid check with the offset of the parent stream. However, the actual fix is to avoid changing the size when the `DataStream` is created as a substream, since it would overwrite substreams after that one.