### PR TITLE
Implement relative path search

### DIFF
--- a/src/Yarhl.UnitTests/FileSystem/NavigatorTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NavigatorTests.cs
@@ -92,6 +92,19 @@ namespace Yarhl.UnitTests.FileSystem
         }
 
         [Test]
+        public void SearchRelativePath()
+        {
+            Node nodeSubChild = new Node("SubChild");
+            Node nodeChild = new Node("Child");
+            nodeChild.Add(nodeSubChild);
+            Node nodeParent = new Node("Parent");
+            nodeParent.Add(nodeChild);
+
+            Assert.AreSame(nodeSubChild, Navigator.SearchNode(nodeParent, "Child/SubChild"));
+            Assert.AreSame(nodeSubChild, Navigator.SearchNode(nodeChild, "SubChild"));
+        }
+
+        [Test]
         public void SearchNotFound()
         {
             Node nodeChild = new Node("Child");


### PR DESCRIPTION
### Description
`Navigator.SearchNode()` supported only searching through full paths (including the path of the node in the argument). This PR allows to use relative paths, that is, a path that doesn't start with `/` so it doesn't include the full path of the root node.

### Example
```cs
Navigator.SearchNode(nodeParent, "Child/SubChild")
```

Linked issue: #79 
