### PR TITLE
Implement remove nodes

### DIFF
--- a/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
@@ -209,6 +209,153 @@ namespace Yarhl.UnitTests.FileSystem
         }
 
         [Test]
+        public void RemoveChildByNode()
+        {
+            var node = new DummyNavigable("My parent");
+            var child1 = new DummyNavigable("Child1");
+            var child2 = new DummyNavigable("Child2");
+            node.Add(child1);
+            node.Add(child2);
+
+            Assert.That(node.Children.Count, Is.EqualTo(2));
+            Assert.That(node.Remove(child1), Is.True);
+
+            Assert.That(node.Children.Count, Is.EqualTo(1));
+            Assert.That(node.Children[0], Is.SameAs(child2));
+            Assert.That(child1.Parent, Is.Null);
+        }
+
+        [Test]
+        public void RemoveChildByNodeDoesNotDispose()
+        {
+            var node = new DummyNavigable("My parent");
+            var child1 = new DummyNavigable("Child1");
+            node.Add(child1);
+
+            Assert.That(node.Remove(child1), Is.True);
+
+            Assert.That(child1.Disposed, Is.False);
+        }
+
+        [Test]
+        public void RemoveChildByNodeReturnsFalseIfNoFound()
+        {
+            var node = new DummyNavigable("My parent");
+            var node2 = new DummyNavigable("My parent2");
+            var child1 = new DummyNavigable("Child1");
+            node2.Add(child1);
+            var child2 = new DummyNavigable("Child2");
+            node.Add(child2);
+
+            Assert.That(node.Children.Count, Is.EqualTo(1));
+            Assert.That(node.Children[0], Is.SameAs(child2));
+            Assert.That(node.Remove(child1), Is.False);
+
+            Assert.That(node.Children.Count, Is.EqualTo(1));
+            Assert.That(child1.Disposed, Is.False);
+            Assert.That(child1.Parent, Is.SameAs(node2));
+        }
+
+        [Test]
+        public void RemoveChildByNodeThrowsWhenNull()
+        {
+            var node = new DummyNavigable("My parent");
+            var child1 = new DummyNavigable("Child1");
+            node.Add(child1);
+
+            Assert.That(
+                () => node.Remove((DummyNavigable)null),
+                Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void RemoveChildByNodeThrowsWhenDisposed()
+        {
+            var node = new DummyNavigable("My parent");
+            var child1 = new DummyNavigable("Child1");
+            node.Add(child1);
+            node.Dispose();
+
+            Assert.That(
+                () => node.Remove(child1),
+                Throws.InstanceOf<ObjectDisposedException>());
+        }
+
+        [Test]
+        public void RemoveChildByName()
+        {
+            var node = new DummyNavigable("My parent");
+            var child1 = new DummyNavigable("Child1");
+            var child2 = new DummyNavigable("Child2");
+            node.Add(child1);
+            node.Add(child2);
+
+            Assert.That(node.Children.Count, Is.EqualTo(2));
+            Assert.That(node.Remove("Child1"), Is.True);
+
+            Assert.That(node.Children.Count, Is.EqualTo(1));
+            Assert.That(node.Children[0], Is.SameAs(child2));
+        }
+
+        [Test]
+        public void RemoveChildByNameDisposes()
+        {
+            var node = new DummyNavigable("My parent");
+            var child1 = new DummyNavigable("Child1");
+            node.Add(child1);
+
+            Assert.That(node.Remove("Child1"), Is.True);
+            Assert.That(child1.Disposed, Is.True);
+        }
+
+        [Test]
+        public void RemoveChildByNameReturnsFalseIfNoFound()
+        {
+            var node = new DummyNavigable("My parent");
+            var node2 = new DummyNavigable("My parent2");
+            var child1 = new DummyNavigable("Child1");
+            node2.Add(child1);
+            var child2 = new DummyNavigable("Child2");
+            node.Add(child2);
+
+            Assert.That(node.Children.Count, Is.EqualTo(1));
+            Assert.That(node.Children[0], Is.SameAs(child2));
+            Assert.That(node.Remove("Child1"), Is.False);
+
+            Assert.That(node.Children.Count, Is.EqualTo(1));
+            Assert.That(child1.Disposed, Is.False);
+            Assert.That(child1.Parent, Is.SameAs(node2));
+        }
+
+        [Test]
+        public void RemoveChildByNameThrowsWhenNull()
+        {
+            var node = new DummyNavigable("My parent");
+            var child1 = new DummyNavigable("Child1");
+            node.Add(child1);
+
+            Assert.That(
+                () => node.Remove((string)null),
+                Throws.ArgumentNullException);
+            Assert.That(
+                () => node.Remove(string.Empty),
+                Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void RemoveChildByNameThrowsWhenDisposed()
+        {
+            var node = new DummyNavigable("My parent");
+            var child1 = new DummyNavigable("Child1");
+            node.Add(child1);
+            node.Dispose();
+
+            Assert.That(
+                () => node.Remove("Child1"),
+                Throws.InstanceOf<ObjectDisposedException>());
+        }
+
+        [Test]
         public void RemoveChildren()
         {
             var children = new List<DummyNavigable>();

--- a/src/Yarhl/FileSystem/NavigableNode.cs
+++ b/src/Yarhl/FileSystem/NavigableNode.cs
@@ -154,7 +154,60 @@ namespace Yarhl.FileSystem
         }
 
         /// <summary>
-        /// Removes all the children from the node.
+        /// Remove a node.
+        /// </summary>
+        /// <param name="node">Node reference to remove.</param>
+        /// <remarks>
+        /// <para>This method does NOT dispose the removed node.</para>
+        /// </remarks>
+        /// <returns>Whether the node was found and removed successfully.</returns>
+        public bool Remove(T node)
+        {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(NavigableNode<T>));
+
+            if (node == null)
+                throw new ArgumentNullException(nameof(node));
+
+            bool result = children.Remove(node);
+            if (result) {
+                node.Parent = null;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Remove a node with the specified name.
+        /// </summary>
+        /// <param name="name">The name of the node to remove.</param>
+        /// <remarks>
+        /// <para>This method <strong>does</strong> dispose the removed node.
+        /// If you don't want to dispose it, search the node and call the
+        /// overload with the node argument.</para>
+        /// </remarks>
+        /// <returns>Whether the node was found and removed successfully.</returns>
+        public bool Remove(string name)
+        {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(NavigableNode<T>));
+
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentNullException(nameof(name));
+
+            int index = children.FindIndex(child => child.Name == name);
+            if (index == -1) {
+                return false;
+            }
+
+            children[index].Dispose();
+            children.RemoveAt(index);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Removes and dispose all the children from the node.
         /// </summary>
         public void RemoveChildren()
         {


### PR DESCRIPTION
### Description
Implement remove child nodes from a parent. It allows to remove by object reference and name. If the child is not a member of the parent, then it will return `false` as `List<T>.Remove` does.

In the case of the object reference, it won't dispose the node since the user still have the reference. In the case of the name, it will dispose the child since the user doesn't have it and it would be complex to retrieve later.

### Example
```cs
var parent = new Node("Parent");
var child1 = new Node("Child1");
var child2 = new Node("Child2");
var child3 = new Node("Child3");
node.Add(child1);
node.Add(child2);

node.Remove(child1);  // returns true and not disposed
node.Remove("Child2"); // returns true and disposed
node.Remove("Fake"); // returns false
node.Remove(child3); // returns false
```

Closes #89