### PR TITLE
Improve Replacer methods name

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>3.0.0-alpha05</Version>
+        <Version>3.0.0-alpha06</Version>
         <Product>SceneGate</Product>
 
         <Authors>SceneGate Team</Authors>

--- a/src/Yarhl.Media/Text/Replacer.cs
+++ b/src/Yarhl.Media/Text/Replacer.cs
@@ -89,25 +89,40 @@ namespace Yarhl.Media.Text
         }
 
         /// <summary>
-        /// Transform a text replacing the strings from the map.
+        /// Transform a text replacing the chars from source to destination.
         /// </summary>
         /// <param name="text">The text to transform.</param>
-        /// <param name="originalText">
-        /// True to replace strings from the Original field of the map with the
-        /// Modified version. False to apply the reverse.
-        /// </param>
         /// <remarks>
         /// <para>When multiple original fields in the map have same start, the
         /// later map entry will have preference.</para>
         /// </remarks>
         /// <returns>The transformed text.</returns>
-        public string Transform(string text, bool originalText)
+        public string TransformForward(string text)
+        {
+            return Transform(text, true);
+        }
+
+        /// <summary>
+        /// Transform a text with replacing chars from destination to source.
+        /// </summary>
+        /// <param name="text">The text to transform.</param>
+        /// <remarks>
+        /// <para>When multiple original fields in the map have same start, the
+        /// later map entry will have preference.</para>
+        /// </remarks>
+        /// <returns>The transformed text.</returns>
+        public string TransformBackward(string text)
+        {
+            return Transform(text, false);
+        }
+
+        string Transform(string text, bool isOriginalText)
         {
             if (text == null)
                 throw new ArgumentNullException(nameof(text));
 
             // Get a list of matches by order of the map
-            IDictionary<int, int> matches = MatchMap(text, originalText);
+            IDictionary<int, int> matches = MatchMap(text, isOriginalText);
 
             // From the list of matches, rebuild the string
             StringBuilder builder = new StringBuilder();
@@ -117,8 +132,8 @@ namespace Yarhl.Media.Text
                     builder.Append(text[textIdx++]);
                 } else {
                     ReplacerEntry entry = map[matches[textIdx]];
-                    string original = originalText ? entry.Original : entry.Modified;
-                    string modified = originalText ? entry.Modified : entry.Original;
+                    string original = isOriginalText ? entry.Original : entry.Modified;
+                    string modified = isOriginalText ? entry.Modified : entry.Original;
 
                     // Append the modified in the new string and skip the original
                     builder.Append(modified);

--- a/src/Yarhl.UnitTests/Media/Text/ReplacerTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/ReplacerTests.cs
@@ -124,8 +124,8 @@ namespace Yarhl.UnitTests.Media.Text
             replacer.Add("a", "z");
             replacer.Add("b", "y");
 
-            Assert.That(replacer.Transform("ababtr", true), Is.EqualTo("zyzytr"));
-            Assert.That(replacer.Transform("zyzytr", false), Is.EqualTo("ababtr"));
+            Assert.That(replacer.TransformForward("ababtr"), Is.EqualTo("zyzytr"));
+            Assert.That(replacer.TransformBackward("zyzytr"), Is.EqualTo("ababtr"));
         }
 
         [Test]
@@ -135,8 +135,8 @@ namespace Yarhl.UnitTests.Media.Text
             replacer.Add("<br/>", "\n");
             replacer.Add("z", ".");
 
-            Assert.That(replacer.Transform("zz<br/>zz", true), Is.EqualTo("..\n.."));
-            Assert.That(replacer.Transform("..\n..", false), Is.EqualTo("zz<br/>zz"));
+            Assert.That(replacer.TransformForward("zz<br/>zz"), Is.EqualTo("..\n.."));
+            Assert.That(replacer.TransformBackward("..\n.."), Is.EqualTo("zz<br/>zz"));
         }
 
         [Test]
@@ -146,15 +146,15 @@ namespace Yarhl.UnitTests.Media.Text
             replacer.Add("a", "z");
             replacer.Add("ab", "y");
 
-            Assert.That(replacer.Transform("aabaa", true), Is.EqualTo("zyzz"));
-            Assert.That(replacer.Transform("zyzz", false), Is.EqualTo("aabaa"));
+            Assert.That(replacer.TransformForward("aabaa"), Is.EqualTo("zyzz"));
+            Assert.That(replacer.TransformBackward("zyzz"), Is.EqualTo("aabaa"));
 
             replacer = new Replacer();
             replacer.Add("ab", "y");
             replacer.Add("a", "z");
 
-            Assert.That(replacer.Transform("aabaa", true), Is.EqualTo("zzbzz"));
-            Assert.That(replacer.Transform("zzbzz", false), Is.EqualTo("aabaa"));
+            Assert.That(replacer.TransformForward("aabaa"), Is.EqualTo("zzbzz"));
+            Assert.That(replacer.TransformBackward("zzbzz"), Is.EqualTo("aabaa"));
         }
 
         [Test]
@@ -164,20 +164,20 @@ namespace Yarhl.UnitTests.Media.Text
             replacer.Add("a", "b");
             replacer.Add("b", "c");
 
-            Assert.That(replacer.Transform("aabaa", true), Is.EqualTo("bbcbb"));
-            Assert.That(replacer.Transform("bbcbb", false), Is.EqualTo("aabaa"));
+            Assert.That(replacer.TransformForward("aabaa"), Is.EqualTo("bbcbb"));
+            Assert.That(replacer.TransformBackward("bbcbb"), Is.EqualTo("aabaa"));
 
             replacer.Add("b", "a");
 
-            Assert.That(replacer.Transform("aabaa", true), Is.EqualTo("bbabb"));
-            Assert.That(replacer.Transform("bbabb", false), Is.EqualTo("aabaa"));
+            Assert.That(replacer.TransformForward("aabaa"), Is.EqualTo("bbabb"));
+            Assert.That(replacer.TransformBackward("bbabb"), Is.EqualTo("aabaa"));
         }
 
         [Test]
         public void TransformWithoutMapReturnsOriginal()
         {
             Replacer replacer = new Replacer();
-            Assert.That(replacer.Transform("abc", true), Is.EqualTo("abc"));
+            Assert.That(replacer.TransformForward("abc"), Is.EqualTo("abc"));
         }
 
         [Test]
@@ -186,7 +186,7 @@ namespace Yarhl.UnitTests.Media.Text
             Replacer replacer = new Replacer();
             replacer.Add("a", "b");
 
-            Assert.That(replacer.Transform(string.Empty, true), Is.EqualTo(string.Empty));
+            Assert.That(replacer.TransformForward(string.Empty), Is.EqualTo(string.Empty));
         }
 
         [Test]
@@ -195,7 +195,7 @@ namespace Yarhl.UnitTests.Media.Text
             Replacer replacer = new Replacer();
             replacer.Add("a", "b");
 
-            Assert.That(() => replacer.Transform(null, true), Throws.ArgumentNullException);
+            Assert.That(() => replacer.TransformForward(null), Throws.ArgumentNullException);
         }
     }
 }


### PR DESCRIPTION
### Description
The `Transform` method of the `Replacer` class was a bit confusing because it expected a boolean and it wasn't clear what `true` or `false` was doing. I renamed the methods.

### Example
```cs
// Before
Assert.That(replacer.Transform("aabaa", true), Is.EqualTo("bbabb"));
Assert.That(replacer.Transform("bbabb", false), Is.EqualTo("aabaa"));

// Now
Assert.That(replacer.TransformForward("aabaa"), Is.EqualTo("bbabb"));
Assert.That(replacer.TransformBackward("bbabb"), Is.EqualTo("aabaa"));
```