### PR TITLE
Fix ConvertFormat.With and TransformWith on base types

### DIFF
--- a/src/Yarhl.UnitTests/FileFormat/ConvertFormatTests.cs
+++ b/src/Yarhl.UnitTests/FileFormat/ConvertFormatTests.cs
@@ -162,6 +162,8 @@ namespace Yarhl.UnitTests.FileFormat
             Base val = new Base { X = 3 };
             Assert.Throws<InvalidOperationException>(
                 () => ConvertFormat.To<ushort>(val));
+            Assert.Throws<InvalidOperationException>(
+                () => ConvertFormat.With<ConvertDerived>(val));
         }
 
         [Test]
@@ -192,6 +194,21 @@ namespace Yarhl.UnitTests.FileFormat
             int conv = 0;
             Assert.DoesNotThrow(() => conv = ConvertFormat.To<int>(format));
             Assert.AreEqual(15, conv);
+
+            Assert.DoesNotThrow(() => conv = (int)ConvertFormat.With<ConvertBase>(format));
+            Assert.AreEqual(15, conv);
+        }
+
+        [Test]
+        public void ConvertFromImplementationWithInterfaceConverter()
+        {
+            var format = new InterfaceImpl { Z = 14 };
+            int conv = 0;
+            Assert.DoesNotThrow(() => conv = (int)ConvertFormat.With<ConverterInterface>(format));
+            Assert.AreEqual(14, conv);
+
+            Assert.DoesNotThrow(() => conv = ConvertFormat.To<int>(format));
+            Assert.AreEqual(14, conv);
         }
 
         [Test]
@@ -415,6 +432,20 @@ namespace Yarhl.UnitTests.FileFormat
             public byte Convert(StringFormatTest format)
             {
                 return (byte)(System.Convert.ToByte(format.Value) + Offset);
+            }
+        }
+
+        public class InterfaceImpl : IInterface
+        {
+            public int Z { get; set; }
+        }
+
+        public class ConverterInterface :
+            IConverter<IInterface, int>
+        {
+            public int Convert(IInterface source)
+            {
+                return source.Z;
             }
         }
 

--- a/src/Yarhl.UnitTests/FileFormat/Converters.cs
+++ b/src/Yarhl.UnitTests/FileFormat/Converters.cs
@@ -23,6 +23,11 @@ namespace Yarhl.UnitTests.FileFormat
   // to create a file per test converter.
   #pragma warning disable SA1402, SA1649
 
+    public interface IInterface
+    {
+        int Z { get; }
+    }
+
     public class SingleOuterConverterExample : IConverter<string, uint>
     {
         public uint Convert(string source)

--- a/src/Yarhl/FileFormat/ConvertFormat.cs
+++ b/src/Yarhl/FileFormat/ConvertFormat.cs
@@ -148,7 +148,7 @@ namespace Yarhl.FileFormat
             bool canConvert = converterInterfaces.Any(i =>
                 i.IsGenericType &&
                 i.GenericTypeArguments.Length == 2 &&
-                i.GenericTypeArguments[0] == src.GetType());
+                i.GenericTypeArguments[0].IsAssignableFrom(src.GetType()));
 
             if (!canConvert) {
                 throw new InvalidOperationException(


### PR DESCRIPTION
### Description
When using methods to transform or convert with a specific converter but the type to convert is a derived type, the library was throwing an exception. The problem was on the check of the converter interfaces, it should do an assignable from instead of exact type matching.

For instance, it was not possible to use a converter expecting as a source `IBinary` and then passing a `BinaryFormat` type variable.