### PR TITLE
Check the return code from the converters when transforming the format of a node

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,9 +72,10 @@ steps:
     targetPath: artifacts/
   condition: eq(variables['Agent.OS'], 'Linux')
 
-- task: PublishPipelineArtifact@0
-  displayName: '[Linux] Publish doc artifacts'
-  inputs:
-    artifactName: 'Documentation'
-    targetPath: docs/_site/
-  condition: eq(variables['Agent.OS'], 'Linux')
+# Disable because of bugs in DocFX
+# - task: PublishPipelineArtifact@0
+#   displayName: '[Linux] Publish doc artifacts'
+#   inputs:
+#     artifactName: 'Documentation'
+#     targetPath: docs/_site/
+#   condition: eq(variables['Agent.OS'], 'Linux')

--- a/build.cake
+++ b/build.cake
@@ -403,7 +403,7 @@ Task("CI-Linux")
     .IsDependentOn("Run-Unit-Tests")
     .IsDependentOn("Run-Linter-Gendarme")
     .IsDependentOn("Run-AltCover")
-    .IsDependentOn("Build-Doc")
+    //.IsDependentOn("Build-Doc")  // Waiting for https://github.com/dotnet/docfx/issues/4857
     .IsDependentOn("Pack");
 
 Task("CI-MacOS")

--- a/build.cake
+++ b/build.cake
@@ -35,8 +35,8 @@
 #addin nuget:?package=Cake.Git&version=0.19.0
 
 // Documentation
-#addin nuget:?package=Cake.DocFx&version=0.12.0
-#tool nuget:?package=docfx.console&version=2.41.0
+#addin nuget:?package=Cake.DocFx&version=0.13.0
+#tool nuget:?package=docfx.console&version=2.44.0
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
@@ -289,16 +289,6 @@ Task("Build-Doc")
     .IsDependentOn("Build")
     .Does(() =>
 {
-    // Workaround for
-    // https://github.com/dotnet/docfx/issues/3389
-    NuGetInstall("SQLitePCLRaw.core", new NuGetInstallSettings {
-        ExcludeVersion  = true,
-        OutputDirectory = "./tools"
-    });
-    CopyFileToDirectory(
-        "tools/SQLitePCLRaw.core/lib/net45/SQLitePCLRaw.core.dll",
-        GetDirectories("tools/docfx.console.*").Single().Combine("tools"));
-
     DocFxMetadata("docs/docfx.json");
     DocFxBuild("docs/docfx.json");
 });

--- a/build.cake
+++ b/build.cake
@@ -35,8 +35,8 @@
 #addin nuget:?package=Cake.Git&version=0.19.0
 
 // Documentation
-#addin nuget:?package=Cake.DocFx&version=0.13.0
-#tool nuget:?package=docfx.console&version=2.44.0
+#addin nuget:?package=Cake.DocFx&version=0.12.0
+#tool nuget:?package=docfx.console&version=2.41.0
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
@@ -289,6 +289,17 @@ Task("Build-Doc")
     .IsDependentOn("Build")
     .Does(() =>
 {
+    // Workaround for
+    // https://github.com/dotnet/docfx/issues/3389
+    NuGetInstall("SQLitePCLRaw.core", new NuGetInstallSettings {
+        Version = "1.1.14",
+        ExcludeVersion  = true,
+        OutputDirectory = "./tools"
+    });
+    CopyFileToDirectory(
+        "tools/SQLitePCLRaw.core/lib/net45/SQLitePCLRaw.core.dll",
+        GetDirectories("tools/docfx.console.*").Single().Combine("tools"));
+
     DocFxMetadata("docs/docfx.json");
     DocFxBuild("docs/docfx.json");
 });

--- a/src/Yarhl.UnitTests/FileFormat/Converters.cs
+++ b/src/Yarhl.UnitTests/FileFormat/Converters.cs
@@ -148,6 +148,18 @@ namespace Yarhl.UnitTests.FileFormat
         }
     }
 
+    public class NoFormat
+    {
+    }
+
+    public class NullSource : IFormat
+    {
+    }
+
+    public class NullDestination : IFormat
+    {
+    }
+
     public class StringFormatTest2IntFormatTestConverter :
         IConverter<StringFormatTest, IntFormatTest>,
         IConverter<IntFormatTest, StringFormatTest>
@@ -160,6 +172,34 @@ namespace Yarhl.UnitTests.FileFormat
         public StringFormatTest Convert(IntFormatTest test)
         {
             return new StringFormatTest(test.Value.ToString());
+        }
+    }
+
+    public class StringFormatTest2NoFormat :
+        IConverter<StringFormatTest, NoFormat>,
+        IInitializer<int>
+    {
+        public void Initialize(int x)
+        {
+        }
+
+        public NoFormat Convert(StringFormatTest source)
+        {
+            return new NoFormat();
+        }
+    }
+
+    public class NullConverter :
+        IConverter<NullSource, NullDestination>,
+        IInitializer<int>
+    {
+        public void Initialize(int x)
+        {
+        }
+
+        public NullDestination Convert(NullSource source)
+        {
+            return null;
         }
     }
 

--- a/src/Yarhl.UnitTests/FileSystem/NodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeTests.cs
@@ -306,6 +306,29 @@ namespace Yarhl.UnitTests.FileSystem
         }
 
         [Test]
+        public void TransformToWithTypeThrowsIfConverterDoesNotReturnIFormat()
+        {
+            var dummy = new StringFormatTest("3");
+            Node node = new Node("mytest", dummy);
+
+            Assert.That(
+                () => node.TransformTo(typeof(NoFormat)),
+                Throws.InvalidOperationException);
+        }
+
+        [Test]
+        public void TransformToWithTypeDoesNotThrowIfReturnsNull()
+        {
+            var dummy = new NullSource();
+            Node node = new Node("mytest", dummy);
+
+            Assert.That(
+                () => node.TransformTo(typeof(NullDestination)),
+                Throws.Nothing);
+            Assert.That(node.Format, Is.Null);
+        }
+
+        [Test]
         public void TransformToGenericDisposeFormat()
         {
             var dummyFormat = new StringFormatTest("3");
@@ -349,6 +372,29 @@ namespace Yarhl.UnitTests.FileSystem
         }
 
         [Test]
+        public void TransformWithGenericThrowsIfConverterDoesNotReturnIFormat()
+        {
+            var dummy = new StringFormatTest("3");
+            Node node = new Node("mytest", dummy);
+
+            Assert.That(
+                () => node.TransformWith<StringFormatTest2NoFormat>(),
+                Throws.InvalidOperationException);
+        }
+
+        [Test]
+        public void TransformWithGenericDoesNotThrowIfReturnsNull()
+        {
+            var dummy = new NullSource();
+            Node node = new Node("mytest", dummy);
+
+            Assert.That(
+                () => node.TransformWith<NullConverter>(),
+                Throws.Nothing);
+            Assert.That(node.Format, Is.Null);
+        }
+
+        [Test]
         public void TransformWithInit()
         {
             var dummyFormat = new StringFormatTest("3");
@@ -369,6 +415,29 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.That(
                 node.TransformWith<PrivateConverter, int>(4),
                 Is.SameAs(node));
+        }
+
+        [Test]
+        public void TransformWithInitThrowsIfConverterDoesNotReturnIFormat()
+        {
+            var dummy = new StringFormatTest("3");
+            Node node = new Node("mytest", dummy);
+
+            Assert.That(
+                () => node.TransformWith<StringFormatTest2NoFormat, int>(2),
+                Throws.InvalidOperationException);
+        }
+
+        [Test]
+        public void TransformWithInitDoesNotThrowIfReturnsNull()
+        {
+            var dummy = new NullSource();
+            Node node = new Node("mytest", dummy);
+
+            Assert.That(
+                () => node.TransformWith<NullConverter, int>(2),
+                Throws.Nothing);
+            Assert.That(node.Format, Is.Null);
         }
 
         [Test]
@@ -417,6 +486,29 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.That(
                 () => node.TransformWith(myType),
                 Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void TransformWithTypeThrowsIfConverterDoesNotReturnIFormat()
+        {
+            var dummy = new StringFormatTest("3");
+            Node node = new Node("mytest", dummy);
+
+            Assert.That(
+                () => node.TransformWith(typeof(StringFormatTest2NoFormat)),
+                Throws.InvalidOperationException);
+        }
+
+        [Test]
+        public void TransformWithTypeDoesNotThrowIfReturnsNull()
+        {
+            var dummy = new NullSource();
+            Node node = new Node("mytest", dummy);
+
+            Assert.That(
+                () => node.TransformWith(typeof(NullConverter)),
+                Throws.Nothing);
+            Assert.That(node.Format, Is.Null);
         }
 
         [Test]

--- a/src/Yarhl/FileSystem/Node.cs
+++ b/src/Yarhl/FileSystem/Node.cs
@@ -163,7 +163,9 @@ namespace Yarhl.FileSystem
                     "Cannot transform a node without format");
             }
 
-            ChangeFormat((IFormat)ConvertFormat.To(dst, Format));
+            object result = ConvertFormat.To(dst, Format);
+            CastAndChangeFormat(result);
+
             return this;
         }
 
@@ -183,7 +185,9 @@ namespace Yarhl.FileSystem
                     "Cannot transform a node without format");
             }
 
-            ChangeFormat((IFormat)ConvertFormat.With<TConv>(Format));
+            object result = ConvertFormat.With<TConv>(Format);
+            CastAndChangeFormat(result);
+
             return this;
         }
 
@@ -206,8 +210,9 @@ namespace Yarhl.FileSystem
                     "Cannot transform a node without format");
             }
 
-            var dst = ConvertFormat.With<TConv, TParam>(param, Format);
-            ChangeFormat((IFormat)dst);
+            var result = ConvertFormat.With<TConv, TParam>(param, Format);
+            CastAndChangeFormat(result);
+
             return this;
         }
 
@@ -229,7 +234,9 @@ namespace Yarhl.FileSystem
                     "Cannot transform a node without format");
             }
 
-            ChangeFormat((IFormat)ConvertFormat.With(converterType, Format));
+            object result = ConvertFormat.With(converterType, Format);
+            CastAndChangeFormat(result);
+
             return this;
         }
 
@@ -278,6 +285,20 @@ namespace Yarhl.FileSystem
         {
             RemoveChildren();
             GetFormatAs<NodeContainerFormat>().MoveChildrenTo(this);
+        }
+
+        void CastAndChangeFormat(object newFormat)
+        {
+            if (newFormat == null) {
+                // Null may be an acceptable format, for now.
+                ChangeFormat(null);
+            } else if (newFormat is IFormat format) {
+                ChangeFormat(format);
+            } else {
+                throw new InvalidOperationException(
+                    "Result format does not implement the IFormat interface. " +
+                    "Cannot assign to the Format property.");
+            }
         }
     }
 }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.33.0" />
+    <package id="Cake" version="0.34.1" />
 </packages>


### PR DESCRIPTION
### Description
Introduce a check in the return object from the converter to make sure it implements the `IFormat` interface so we can cast it and assign to the `Format` property of the nodes. It allows to detect bugs easier (missing `IFormat` implementation of a format).

Also upgrade DocFX to remove old workaround.