### PR TITLE
Added API version to docs

### DIFF
--- a/docs/fusion/toc.yml
+++ b/docs/fusion/toc.yml
@@ -1,4 +1,4 @@
 - name: Conceptual
   href: ../articles/toc.yml
-- name: Reference
+- name: Reference v2
   href: ../api/toc.yml

--- a/docs/global_metadata.json
+++ b/docs/global_metadata.json
@@ -1,6 +1,6 @@
 {
-    "_appTitle": "SceneGate Yarhl",
-    "_appFooter": "Copyright (c) 2018 SceneGate Team",
+    "_appTitle": "SceneGate Yarhl 2.0.0.1",
+    "_appFooter": "Copyright (c) 2018 SceneGate Team | Yarhl 2.0.0.1",
     "_enableNewTab": true,
     "_gitContribute": {
         "apiSpecFolder": "docs/apidoc",

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,6 +1,6 @@
 - name: Home
   href: index.md
-- name: Documentation
+- name: Documentation v2
   href: fusion/
 - name: Repository
   href: https://github.com/SceneGate/Yarhl


### PR DESCRIPTION
### Description
Clarification of the API version of the docs. 
At least the big version number (v2) it's mandatory in my opinion.

=> Maybe change the 2.0.0.1 to just v2 too? (better maintenance).
=> I thought about automating it getting the version from the api itself but didn't found any easy solution.