### PR TITLE
Add extensibility to streams

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>3.0.0-alpha06</Version>
+        <Version>3.0.0-alpha07</Version>
         <Product>SceneGate</Product>
 
         <Authors>SceneGate Team</Authors>

--- a/src/Yarhl.UnitTests/IO/DataReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataReaderTests.cs
@@ -617,61 +617,39 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadPadding()
+        public void SkipPadding()
         {
             byte[] buffer = { 0xCA, 0xFE, 0x00, 0x00 };
             stream.Write(buffer, 0, buffer.Length);
 
             stream.Position = 0;
             reader.ReadUInt16();
-            reader.ReadPadding(4);
+            reader.SkipPadding(4);
 
             Assert.AreEqual(buffer.Length, stream.Position);
         }
 
         [Test]
-        public void ReadPaddingWhenNoNeed()
+        public void SkipPaddingWhenNoNeed()
         {
             byte[] buffer = { 0xCA, 0xFE, 0x00, 0x00 };
             stream.Write(buffer, 0, buffer.Length);
 
             stream.Position = 0;
             reader.ReadUInt32();
-            reader.ReadPadding(4);
+            reader.SkipPadding(4);
 
             Assert.AreEqual(buffer.Length, stream.Position);
         }
 
         [Test]
-        public void ReadPaddingAbsoluteMode()
+        public void SkipPaddingInvalidArguments()
         {
-            stream.WriteByte(0xAF);
-            stream.Write(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, 0, 7);
-            using (var stream2 = new DataStream(stream, 1, 7)) {
-                reader = new DataReader(stream2);
-
-                byte[] buffer = { 0xCA, 0xFE, 0x00, 0x00, 0xFF, 0xFF, 0xFF };
-                stream2.Write(buffer, 0, buffer.Length);
-
-                stream2.Position = 0;
-                reader.ReadUInt32();
-
-                reader.ReadPadding(4);
-                Assert.AreEqual(4, stream2.Position);
-
-                reader.ReadPadding(4, true);
-                Assert.AreEqual(7, stream2.Position);
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() => reader.SkipPadding(-2));
         }
 
         [Test]
-        public void ReadPaddingInvalidArguments()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => reader.ReadPadding(-2));
-        }
-
-        [Test]
-        public void ReadPaddingLessEqualOneDoesNothing()
+        public void SkipPaddingLessEqualOneDoesNothing()
         {
             byte[] buffer = { 0xCA, 0xFE, 0x00, 0x00 };
             stream.Write(buffer, 0, buffer.Length);
@@ -679,10 +657,10 @@ namespace Yarhl.UnitTests.IO
             stream.Position = 0;
             reader.ReadUInt32();
 
-            reader.ReadPadding(0);
+            reader.SkipPadding(0);
             Assert.AreEqual(buffer.Length, stream.Position);
 
-            reader.ReadPadding(1);
+            reader.SkipPadding(1);
             Assert.AreEqual(buffer.Length, stream.Position);
         }
     }

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -479,6 +479,24 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void CanPreallocateLengthForSubstream()
+        {
+            DataStream parent = new DataStream();
+            parent.BaseStream.SetLength(11);
+            parent.Length = 11;
+            parent.WriteByte(0xFF);
+            Assert.That(parent.Length, Is.EqualTo(11));
+
+            DataStream child = new DataStream(parent, 1, 10);
+            Assert.That(child.Length, Is.EqualTo(10));
+            Assert.That(parent.BaseStream.Length, Is.EqualTo(11));
+
+            for (int i = 0; i < 10; i++) {
+                Assert.That(child.ReadByte(), Is.EqualTo(0));
+            }
+        }
+
+        [Test]
         public void LengthAfterDisposeThrowException()
         {
             Stream baseStream = new MemoryStream();

--- a/src/Yarhl.UnitTests/IO/DataWriterTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataWriterTests.cs
@@ -959,37 +959,6 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void WritePaddingAbsoluteMode()
-        {
-            DataStream stream = new DataStream();
-            stream.WriteByte(0xAF);
-            stream.Write(new byte[] { 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA }, 0, 7);
-
-            DataStream stream2 = new DataStream(stream, 1, 7);
-            DataWriter writer = new DataWriter(stream2);
-
-            writer.Write(0xCAFEu);
-            writer.WritePadding(0xFF, 4);
-
-            byte[] expected = { 0xAF, 0xFE, 0xCA, 0x00, 0x00 };
-
-            stream.Position = 0;
-            byte[] actual = new byte[expected.Length];
-            stream.Read(actual, 0, expected.Length);
-            Assert.IsTrue(expected.SequenceEqual(actual));
-
-            writer.WritePadding(0xFF, 4, true);
-
-            byte[] expected2 = { 0xAF, 0xFE, 0xCA, 0x00, 0x00, 0xFF, 0xFF, 0xFF };
-            Assert.AreEqual(expected2.Length, stream.Length);
-
-            stream.Position = 0;
-            byte[] actual2 = new byte[expected2.Length];
-            stream.Read(actual2, 0, expected2.Length);
-            Assert.IsTrue(expected2.SequenceEqual(actual2));
-        }
-
-        [Test]
         public void WritePaddingInvalidArguments()
         {
             DataStream stream = new DataStream();

--- a/src/Yarhl/Gendarme.ignore
+++ b/src/Yarhl/Gendarme.ignore
@@ -44,6 +44,7 @@ M: System.Void Yarhl.PluginManager::Shutdown()
 
 R: Gendarme.Rules.Naming.UseCorrectSuffixRule
 # It doesn't inherit but internally use a Stream.
+T: Yarhl.IO.IStream
 T: Yarhl.IO.DataStream
 # Gendarme doesn't know about ReadOnlyCollection
 T: Yarhl.FileSystem.NavigableNodeCollection`1

--- a/src/Yarhl/IO/DataReader.cs
+++ b/src/Yarhl/IO/DataReader.cs
@@ -241,11 +241,12 @@ namespace Yarhl.IO
                 encoding = DefaultEncoding;
 
             long startPos = Stream.Position;
+            long streamLength = Stream.Length;
 
             // Reads the maximum number of bytes possible to get that number of chars
             int charLength = encoding.GetMaxByteCount(count);
-            if (charLength > Stream.Length - Stream.Position)
-                charLength = (int)(Stream.Length - Stream.Position);
+            if (charLength > streamLength - startPos)
+                charLength = (int)(streamLength - startPos);
 
             byte[] buffer = ReadBytes(charLength);
             char[] charArray = encoding.GetChars(buffer);

--- a/src/Yarhl/IO/DataReader.cs
+++ b/src/Yarhl/IO/DataReader.cs
@@ -43,7 +43,7 @@ namespace Yarhl.IO
         /// <para>By default the endianness is LittleEndian and
         /// the encoding is UTF-8.</para>
         /// </remarks>
-        public DataReader(DataStream stream)
+        public DataReader(IStream stream)
         {
             Stream = stream;
             Endianness = EndiannessMode.LittleEndian;
@@ -53,7 +53,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets the stream.
         /// </summary>
-        public DataStream Stream {
+        public IStream Stream {
             get;
             private set;
         }
@@ -359,24 +359,22 @@ namespace Yarhl.IO
         }
 
         /// <summary>
-        /// Reads bytes to padd the position in the stream.
+        /// Skip bytes to pad the position in the stream.
         /// </summary>
         /// <param name="padding">Padding value.</param>
-        /// <param name="absolutePadding">
-        /// If set to <see langword="true" /> absolute position in the stream.
-        /// </param>
-        public void ReadPadding(int padding, bool absolutePadding = false)
+        public void SkipPadding(int padding)
         {
             if (padding < 0)
                 throw new ArgumentOutOfRangeException(nameof(padding));
 
-            if (padding <= 1)
+            if (padding <= 1) {
                 return;
+            }
 
-            long position = absolutePadding ? Stream.AbsolutePosition : Stream.Position;
-            int times = (int)(padding - (position % padding));
-            if (times != padding)
-                ReadBytes(times);
+            long remainingBytes = Stream.Position.Pad(padding) - Stream.Position;
+            if (remainingBytes > 0) {
+                Stream.Seek(remainingBytes, SeekMode.Current);
+            }
         }
     }
 }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -212,7 +212,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets or sets the position from the start of this stream.
         /// </summary>
-        public virtual long Position {
+        public long Position {
             get {
                 return position;
             }
@@ -230,7 +230,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets or sets the length of this stream.
         /// </summary>
-        public virtual long Length {
+        public long Length {
             get {
                 return length;
             }
@@ -273,7 +273,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets a value indicating whether the position is at end of the stream.
         /// </summary>
-        public virtual bool EndOfStream {
+        public bool EndOfStream {
             get {
                 return Position >= Length;
             }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -273,7 +273,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets a value indicating whether the position is at end of the stream.
         /// </summary>
-        public bool EndOfStream {
+        public virtual bool EndOfStream {
             get {
                 return Position >= Length;
             }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -35,7 +35,7 @@ namespace Yarhl.IO
     /// <remarks>
     /// <para>Custom implementation of a Stream based on System.IO.Stream.</para>
     /// </remarks>
-    public class DataStream : IDisposable
+    public class DataStream : IStream, IDisposable
     {
         static readonly Dictionary<Stream, int> Instances = new Dictionary<Stream, int>();
         readonly Stack<long> positionStack = new Stack<long>();
@@ -212,7 +212,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets or sets the position from the start of this stream.
         /// </summary>
-        public long Position {
+        public virtual long Position {
             get {
                 return position;
             }
@@ -230,7 +230,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets or sets the length of this stream.
         /// </summary>
-        public long Length {
+        public virtual long Length {
             get {
                 return length;
             }
@@ -384,7 +384,7 @@ namespace Yarhl.IO
         /// Reads the next byte.
         /// </summary>
         /// <returns>The next byte.</returns>
-        public byte ReadByte()
+        public virtual byte ReadByte()
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(DataStream));
@@ -404,7 +404,7 @@ namespace Yarhl.IO
         /// <param name="buffer">Buffer to copy data.</param>
         /// <param name="index">Index to start copying in buffer.</param>
         /// <param name="count">Number of bytes to read.</param>
-        public int Read(byte[] buffer, int index, int count)
+        public virtual int Read(byte[] buffer, int index, int count)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(DataStream));
@@ -446,17 +446,19 @@ namespace Yarhl.IO
         /// <summary>
         /// Writes a byte.
         /// </summary>
-        /// <param name="val">Byte value.</param>
-        public void WriteByte(byte val)
+        /// <param name="data">Byte value.</param>
+        public virtual void WriteByte(byte data)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(DataStream));
 
             BaseStream.Position = AbsolutePosition;
-            BaseStream.WriteByte(val);
+            BaseStream.WriteByte(data);
 
-            if (Position == Length)
+            if (Position == Length) {
                 Length++;
+            }
+
             Position++;
         }
 
@@ -466,7 +468,7 @@ namespace Yarhl.IO
         /// <param name="buffer">Buffer to write.</param>
         /// <param name="index">Index in the buffer.</param>
         /// <param name="count">Bytes to write.</param>
-        public void Write(byte[] buffer, int index, int count)
+        public virtual void Write(byte[] buffer, int index, int count)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(DataStream));

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -212,7 +212,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets or sets the position from the start of this stream.
         /// </summary>
-        public long Position {
+        public virtual long Position {
             get {
                 return position;
             }
@@ -230,7 +230,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets or sets the length of this stream.
         /// </summary>
-        public long Length {
+        public virtual long Length {
             get {
                 return length;
             }
@@ -273,7 +273,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets a value indicating whether the position is at end of the stream.
         /// </summary>
-        public bool EndOfStream {
+        public virtual bool EndOfStream {
             get {
                 return Position >= Length;
             }

--- a/src/Yarhl/IO/DataWriter.cs
+++ b/src/Yarhl/IO/DataWriter.cs
@@ -42,7 +42,7 @@ namespace Yarhl.IO
         /// <para>By default the endianess is LittleEndian and
         /// the encoding is UTF-8.</para>
         /// </remarks>
-        public DataWriter(DataStream stream)
+        public DataWriter(IStream stream)
         {
             Stream = stream;
             Endianness = EndiannessMode.LittleEndian;
@@ -53,7 +53,7 @@ namespace Yarhl.IO
         /// Gets the stream.
         /// </summary>
         /// <value>The stream.</value>
-        public DataStream Stream {
+        public IStream Stream {
             get;
             private set;
         }
@@ -461,20 +461,16 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="val">Value to repeat.</param>
         /// <param name="padding">Padding value.</param>
-        /// <param name="absolutePadding">
-        /// If set to <see langword="true" /> pad using the absolute position
-        /// in the stream.
-        /// </param>
-        public void WritePadding(byte val, int padding, bool absolutePadding = false)
+        public void WritePadding(byte val, int padding)
         {
             if (padding < 0)
                 throw new ArgumentOutOfRangeException(nameof(padding));
 
-            if (padding <= 1)
+            if (padding <= 1) {
                 return;
+            }
 
-            long position = absolutePadding ? Stream.AbsolutePosition : Stream.Position;
-            WriteTimes(val, position.Pad(padding) - position);
+            WriteTimes(val, Stream.Position.Pad(padding) - Stream.Position);
         }
 
         void WriteNumber(ulong number, byte numBytes)

--- a/src/Yarhl/IO/IStream.cs
+++ b/src/Yarhl/IO/IStream.cs
@@ -1,0 +1,78 @@
+// Copyright (c) 2017 Benito Palacios Sánchez
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace Yarhl.IO
+{
+    /// <summary>
+    /// Generic data stream interface.
+    /// </summary>
+    public interface IStream
+    {
+        /// <summary>
+        /// Gets the position from the start of this stream.
+        /// </summary>
+        long Position { get; }
+
+        /// <summary>
+        /// Gets the length of this stream.
+        /// </summary>
+        long Length { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the position is at end of the stream.
+        /// </summary>
+        bool EndOfStream { get; }
+
+        /// <summary>
+        /// Move the position of the Stream.
+        /// </summary>
+        /// <param name="shift">Distance to move position.</param>
+        /// <param name="mode">Mode to move position.</param>
+        void Seek(long shift, SeekMode mode);
+
+        /// <summary>
+        /// Reads the next byte.
+        /// </summary>
+        /// <returns>The next byte.</returns>
+        byte ReadByte();
+
+        /// <summary>
+        /// Reads from the stream to the buffer.
+        /// </summary>
+        /// <returns>The number of bytes read.</returns>
+        /// <param name="buffer">Buffer to copy data.</param>
+        /// <param name="index">Index to start copying in buffer.</param>
+        /// <param name="count">Number of bytes to read.</param>
+        int Read(byte[] buffer, int index, int count);
+
+        /// <summary>
+        /// Writes a byte.
+        /// </summary>
+        /// <param name="data">Byte value.</param>
+        void WriteByte(byte data);
+
+        /// <summary>
+        /// Writes the a portion of the buffer to the stream.
+        /// </summary>
+        /// <param name="buffer">Buffer to write.</param>
+        /// <param name="index">Index in the buffer.</param>
+        /// <param name="count">Bytes to write.</param>
+        void Write(byte[] buffer, int index, int count);
+    }
+}

--- a/src/Yarhl/IO/TextReader.cs
+++ b/src/Yarhl/IO/TextReader.cs
@@ -145,30 +145,35 @@ namespace Yarhl.IO
                 throw new ArgumentNullException(nameof(token));
 
             // If starting is EOF, then return null
-            if (Stream.EndOfStream)
+            if (Stream.EndOfStream) {
                 return null;
+            }
 
             SkipPreamble();
 
-            const int BufferSize = 128;
-            byte[] buffer = new byte[BufferSize];
+            long startPos = Stream.Position;
+            long streamLength = Stream.Length;
 
             // Gather bytes from buffer to buffer into a list and try to
             // convert to find the token. This approach is faster since we
             // read blocks and it avoids issues with half-encoded chars.
-            long startPos = Stream.Position;
+            const int BufferSize = 128;
+            byte[] buffer = new byte[BufferSize];
+
             List<byte> textBuffer = new List<byte>();
             string text = string.Empty;
             int matchIndex = -1;
 
             while (matchIndex == -1) {
-                if (Stream.EndOfStream)
+                if (Stream.EndOfStream) {
                     break;
+                }
 
                 // Read buffer size if possible, otherwise remaining bytes
-                int size = Stream.Position + BufferSize <= Stream.Length ?
+                long currentPosition = Stream.Position;
+                int size = currentPosition + BufferSize <= streamLength ?
                     BufferSize :
-                    (int)(Stream.Length - Stream.Position);
+                    (int)(streamLength - currentPosition);
 
                 int read = Stream.Read(buffer, 0, size);
                 textBuffer.AddRange(buffer.Take(read));

--- a/src/Yarhl/IO/TextReader.cs
+++ b/src/Yarhl/IO/TextReader.cs
@@ -43,7 +43,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to read from.</param>
         /// <remarks><para>The default encoding is UTF-8.</para></remarks>
-        public TextReader(DataStream stream)
+        public TextReader(IStream stream)
             : this(stream, Encoding.UTF8)
         {
         }
@@ -53,7 +53,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to read from.</param>
         /// <param name="encoding">Encoding to use.</param>
-        public TextReader(DataStream stream, Encoding encoding)
+        public TextReader(IStream stream, Encoding encoding)
         {
             Stream = stream ?? throw new ArgumentNullException(nameof(stream));
             Encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
@@ -68,7 +68,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets the stream.
         /// </summary>
-        public DataStream Stream {
+        public IStream Stream {
             get;
             private set;
         }
@@ -180,7 +180,7 @@ namespace Yarhl.IO
             if (matchIndex != -1) {
                 // We skip the bytes of the token too
                 string fullResult = text.Substring(0, matchIndex + token.Length);
-                Stream.Position = startPos + Encoding.GetByteCount(fullResult);
+                Stream.Seek(startPos + Encoding.GetByteCount(fullResult), SeekMode.Start);
 
                 // Result without token
                 text = text.Substring(0, matchIndex);
@@ -227,9 +227,9 @@ namespace Yarhl.IO
         /// <returns>The next char.</returns>
         public char Peek()
         {
-            Stream.PushCurrentPosition();
+            long startPos = Stream.Position;
             char ch = Read();
-            Stream.PopPosition();
+            Stream.Seek(startPos, SeekMode.Start);
             return ch;
         }
 
@@ -240,9 +240,9 @@ namespace Yarhl.IO
         /// <param name="count">Number of chars to read.</param>
         public char[] Peek(int count)
         {
-            Stream.PushCurrentPosition();
+            long startPos = Stream.Position;
             char[] chars = Read(count);
-            Stream.PopPosition();
+            Stream.Seek(startPos, SeekMode.Start);
             return chars;
         }
 
@@ -253,9 +253,9 @@ namespace Yarhl.IO
         /// <param name="token">Token to find.</param>
         public string PeekToToken(string token)
         {
-            Stream.PushCurrentPosition();
+            long startPos = Stream.Position;
             string content = ReadToToken(token);
-            Stream.PopPosition();
+            Stream.Seek(startPos, SeekMode.Start);
             return content;
         }
 
@@ -265,9 +265,9 @@ namespace Yarhl.IO
         /// <returns>The next line.</returns>
         public string PeekLine()
         {
-            Stream.PushCurrentPosition();
+            long startPos = Stream.Position;
             string line = ReadLine();
-            Stream.PopPosition();
+            Stream.Seek(startPos, SeekMode.Start);
             return line;
         }
 
@@ -290,7 +290,7 @@ namespace Yarhl.IO
 
             // If it didn't fully match it wasn't a preamble, returns to 0
             if (!match) {
-                Stream.Position = 0;
+                Stream.Seek(0, SeekMode.Start);
             }
         }
     }

--- a/src/Yarhl/IO/TextWriter.cs
+++ b/src/Yarhl/IO/TextWriter.cs
@@ -41,7 +41,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to write to.</param>
         /// <remarks><para>The default encoding is UTF-8.</para></remarks>
-        public TextWriter(DataStream stream)
+        public TextWriter(IStream stream)
             : this(stream, Encoding.UTF8)
         {
         }
@@ -51,7 +51,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to write to.</param>
         /// <param name="encoding">Encoding to use.</param>
-        public TextWriter(DataStream stream, Encoding encoding)
+        public TextWriter(IStream stream, Encoding encoding)
         {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
@@ -70,7 +70,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets the stream.
         /// </summary>
-        public DataStream Stream {
+        public IStream Stream {
             get;
             private set;
         }


### PR DESCRIPTION
Implement extensibility points in streams.

### Description
A new interface `IStream` has been added. It defines the minimum requirements for any kind of streams. The original requirements comes from the fact that the C# class [`MemoryMappedFile`](https://docs.microsoft.com/en-us/dotnet/api/system.io.memorymappedfiles.memorymappedfile?view=netframework-4.8) does not implement `System.IO.Stream` so it cannot be wrapped over our `DataStream`. By having this new interface, common classes like `DataReader` and `DataWriter` will be able to work.

Also, I made the `virtual` the methods that `DataStream` implements from `IStream`, so they can be overriden. This is specially useful when additional logic needs to be added when reading / writing, without having to implement the full `IStream`. This requirements comes from the implementation of `LevelStream` for the RomFS (IVFC) format in Lemon.

As part of this changes, I renamed `ReadPadding` to `SkipPadding` since it wasn't returning anything. Also I removed the `absolutePosition` feature from them since it was not used, and it would make more complex the `IStream` interface. If needed, it can be easily achieved by writing / skipping the padding from the parent stream directly.