### PR TITLE
Improve performance of stream compare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ tools/*
 docs/_site/
 docs/api/
 doc-branch/
+
+# Benchmarks
+BenchmarkDotNet.Artifacts/

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,3 +1,197 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
 [*.cs]
-indent_style = space
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
 indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = false
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false:silent
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_property = false:silent
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+
+# Expression-level preferences
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+
+# Field preferences
+dotnet_style_readonly_field = true:suggestion
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = false:silent
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = true:silent
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:suggestion
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Code-block preferences
+csharp_prefer_braces = true:silent
+csharp_prefer_simple_using_statement = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+
+# 'using' directive preferences
+csharp_using_directive_placement = inside_namespace:silent
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = false
+csharp_new_line_before_else = false
+csharp_new_line_before_finally = false
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = methods,types
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case

--- a/src/StyleCopTests.ruleset
+++ b/src/StyleCopTests.ruleset
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Rules for Yarhl.IntegrationTests" ToolsVersion="12.0">
-  <Include Path="..\StyleCop.ruleset" Action="Default" />
+<RuleSet Name="Rules for Yarhl tests" ToolsVersion="12.0">
+  <Include Path="StyleCop.ruleset" Action="Default" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <!-- Disable documentation in unit tests. -->
     <Rule Id="SA0001" Action="None" />
+    <Rule Id="SA1600" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/Yarhl.PerformanceTests/DataStreamCompare.cs
+++ b/src/Yarhl.PerformanceTests/DataStreamCompare.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2019 Benito Palacios Sánchez
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace Yarhl.PerformanceTests
+{
+    using BenchmarkDotNet.Attributes;
+    using Yarhl.IO;
+
+    public class DataStreamCompare
+    {
+        DataStream stream1;
+        DataStream stream2;
+
+        [Params(32, 1024, 5 * 1024, 80 * 1024, 1024 * 1024)]
+        public long Length { get; set; }
+
+        [GlobalSetup]
+        public void SetUp()
+        {
+            stream1 = new DataStream();
+            for (int i = 0; i < Length; i++) {
+                stream1.WriteByte((byte)(i % 256));
+            }
+
+            stream2 = new DataStream();
+            stream1.WriteTo(stream2);
+        }
+
+        [GlobalCleanup]
+        public void CleanUp()
+        {
+            stream1?.Dispose();
+            stream2?.Dispose();
+        }
+
+        [Benchmark]
+        public void Compare()
+        {
+            stream1.Compare(stream2);
+        }
+    }
+}

--- a/src/Yarhl.PerformanceTests/Program.cs
+++ b/src/Yarhl.PerformanceTests/Program.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) 2019 Benito Palacios Sánchez
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace Yarhl.PerformanceTests
+{
+    using BenchmarkDotNet.Running;
+
+    static class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length > 0 && args[0] == "auto") {
+                RunAuto();
+            } else {
+                RunManual();
+            }
+        }
+
+        static void RunAuto()
+        {
+            BenchmarkRunner.Run<DataStreamCompare>();
+        }
+
+        static void RunManual()
+        {
+            const int Iterations = 1_000;
+
+            var test1 = new DataStreamCompare();
+            test1.Length = 1024 * 1024;
+            test1.SetUp();
+
+            for (int i = 0; i < Iterations; i++) {
+                test1.Compare();
+            }
+
+            test1.CleanUp();
+        }
+    }
+}

--- a/src/Yarhl.PerformanceTests/Yarhl.PerformanceTests.csproj
+++ b/src/Yarhl.PerformanceTests/Yarhl.PerformanceTests.csproj
@@ -1,13 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <AssemblyName>Yarhl.IntegrationTests</AssemblyName>
-    <Description>Plugin integration tests for Yarhl.</Description>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>Yarhl.PerformanceTests</AssemblyName>
+    <Description>Performance tests for Yarhl.</Description>
 
-    <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
-    <RootNamespace>Yarhl.IntegrationTests</RootNamespace>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <RootNamespace>Yarhl.PerformanceTests</RootNamespace>
     <CodeAnalysisRuleSet>..\StyleCopTests.ruleset</CodeAnalysisRuleSet>
     <!-- Mark the project as being a test project -->
     <SonarQubeTestProject>true</SonarQubeTestProject>
@@ -16,13 +16,11 @@
     <ProjectReference Include="..\Yarhl\Yarhl.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nunit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Yarhl.UnitTests/StyleCop.ruleset
+++ b/src/Yarhl.UnitTests/StyleCop.ruleset
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Rules for Yarhl.UnitTests" ToolsVersion="12.0">
-  <Include Path="..\StyleCop.ruleset" Action="Default" />
-  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-    <!-- Disable documentation in unit tests. -->
-    <Rule Id="SA0001" Action="None" />
-    <Rule Id="SA1600" Action="None" />
-  </Rules>
-</RuleSet>

--- a/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
+++ b/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
@@ -8,7 +8,7 @@
 
     <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
     <RootNamespace>Yarhl.UnitTests</RootNamespace>
-    <CodeAnalysisRuleSet>StyleCop.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\StyleCopTests.ruleset</CodeAnalysisRuleSet>
     <!-- Mark the project as being a test project -->
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>

--- a/src/Yarhl.sln
+++ b/src/Yarhl.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yarhl.UnitTests", "Yarhl.Un
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yarhl.IntegrationTests", "Yarhl.IntegrationTests\Yarhl.IntegrationTests.csproj", "{B32EE98E-01F2-4B98-8160-7567C5AE1A8D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yarhl.PerformanceTests", "Yarhl.PerformanceTests\Yarhl.PerformanceTests.csproj", "{ADF44DD6-B355-45FB-A50A-06CBCE2EFF6E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,5 +74,17 @@ Global
 		{B32EE98E-01F2-4B98-8160-7567C5AE1A8D}.Release|x64.Build.0 = Release|Any CPU
 		{B32EE98E-01F2-4B98-8160-7567C5AE1A8D}.Release|x86.ActiveCfg = Release|Any CPU
 		{B32EE98E-01F2-4B98-8160-7567C5AE1A8D}.Release|x86.Build.0 = Release|Any CPU
+		{ADF44DD6-B355-45FB-A50A-06CBCE2EFF6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADF44DD6-B355-45FB-A50A-06CBCE2EFF6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADF44DD6-B355-45FB-A50A-06CBCE2EFF6E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ADF44DD6-B355-45FB-A50A-06CBCE2EFF6E}.Debug|x64.Build.0 = Debug|Any CPU
+		{ADF44DD6-B355-45FB-A50A-06CBCE2EFF6E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ADF44DD6-B355-45FB-A50A-06CBCE2EFF6E}.Debug|x86.Build.0 = Debug|Any CPU
+		{ADF44DD6-B355-45FB-A50A-06CBCE2EFF6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADF44DD6-B355-45FB-A50A-06CBCE2EFF6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADF44DD6-B355-45FB-A50A-06CBCE2EFF6E}.Release|x64.ActiveCfg = Release|Any CPU
+		{ADF44DD6-B355-45FB-A50A-06CBCE2EFF6E}.Release|x64.Build.0 = Release|Any CPU
+		{ADF44DD6-B355-45FB-A50A-06CBCE2EFF6E}.Release|x86.ActiveCfg = Release|Any CPU
+		{ADF44DD6-B355-45FB-A50A-06CBCE2EFF6E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -560,18 +560,30 @@ namespace Yarhl.IO
             if (otherStream.Disposed)
                 throw new ObjectDisposedException(nameof(otherStream));
 
-            if (Length != otherStream.Length)
+            if (Length != otherStream.Length) {
                 return false;
+            }
 
             long startPosition = Position;
             long otherStreamStartPosition = otherStream.position;
             Seek(0, SeekMode.Start);
             otherStream.Seek(0, SeekMode.Start);
 
+            const int BufferSize = 70 * 1024;
+            byte[] buffer1 = new byte[BufferSize];
+            byte[] buffer2 = new byte[BufferSize];
+
             bool result = true;
             while (!EndOfStream && result) {
-                if (ReadByte() != otherStream.ReadByte())
-                    result = false;
+                int length = (int)(Position + BufferSize > Length ? Length - Position : BufferSize);
+                Read(buffer1, 0, length);
+                otherStream.Read(buffer2, 0, length);
+
+                for (int i = 0; i < length && result; i++) {
+                    if (buffer1[i] != buffer2[i]) {
+                        result = false;
+                    }
+                }
             }
 
             Seek(startPosition, SeekMode.Start);


### PR DESCRIPTION
### Description
Comparing large streams was not feasible since the `Compare` method was taking too long. Instead of reading byte by byte now we read by blocks. I have added also a benchmark project so we can start writing more benchmark and compare between releases.

For the use case of 10 MB, before it was taking `16,357 us` and now it takes `850 us`.

As part of the pull request I have added also a configuration file with code style settings that VS can use.

### Performan results

#### Before
|  Method |  Length |            Mean |         Error |        StdDev |
|-------- |-------- |----------------:|--------------:|--------------:|
| Compare |      32 |        523.5 ns |      1.325 ns |      1.174 ns |
| Compare |    1024 |     16,013.9 ns |     26.025 ns |     23.071 ns |
| Compare |    5120 |     81,648.6 ns |    106.389 ns |     94.311 ns |
| Compare |   81920 |  1,372,969.3 ns |  2,081.951 ns |  1,625.450 ns |
| Compare | 1048576 | 16,357,543.1 ns | 23,864.284 ns | 22,322.666 ns |

#### Trying to replace look with `Enumerable.SequenceEqual`

|  Method |  Length |       Mean |      Error |     StdDev |
|-------- |-------- |-----------:|-----------:|-----------:|
| Compare |      32 |   626.2 us |  1.5622 us |  1.4613 us |
| Compare |    1024 |   624.9 us |  0.4670 us |  0.4369 us |
| Compare |    5120 |   626.9 us |  2.9577 us |  2.6219 us |
| Compare |   81920 | 1,256.7 us |  3.2089 us |  2.8446 us |
| Compare | 1048576 | 9,403.7 us | 21.5151 us | 19.0726 us |

#### Final implementation

|  Method |  Length |       Mean |     Error |    StdDev |
|-------- |-------- |-----------:|----------:|----------:|
| Compare |      32 |   4.936 us | 0.0239 us | 0.0200 us |
| Compare |    1024 |   5.990 us | 0.0224 us | 0.0210 us |
| Compare |    5120 |   9.170 us | 0.0163 us | 0.0136 us |
| Compare |   81920 |  70.103 us | 0.1514 us | 0.1342 us |
| Compare | 1048576 | 850.875 us | 0.8558 us | 0.8005 us |

Now we can event tests large streams of 512 MB (was taking too long before to write a test).

|  Method |    Length |           Mean |         Error |        StdDev |         Median |
|-------- |---------- |---------------:|--------------:|--------------:|---------------:|
| Compare | 536870912 | 454,487.979 us | 1,555.8960 us | 1,379.2613 us | 454,634.450 us |

**Note**: This tests are comparing in-memory streams which is way faster than comparing a stream from the disk. In that case, the performance hit is on the read operation over the disk.