### PR TITLE
Improve DataStreams extensibility and add lazy FileStream and recyclable MemoryStream

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -23,20 +23,20 @@
 #tool nuget:?package=NUnit.ConsoleRunner&version=3.10.0
 
 // Gendarme: decompress zip
-#addin nuget:?package=Cake.Compression&loaddependencies=true&version=0.2.2
+#addin nuget:?package=Cake.Compression&loaddependencies=true&version=0.2.3
 
 // Test coverage
-#addin nuget:?package=altcover.api&version=5.2.667
-#tool nuget:?package=ReportGenerator&version=4.1.2
+#addin nuget:?package=altcover.api&version=6.0.700
+#tool nuget:?package=ReportGenerator&version=4.2.15
 
 // SonarQube quality checks
 #addin nuget:?package=Cake.Sonar&version=1.1.22
 #tool nuget:?package=MSBuild.SonarQube.Runner.Tool&version=4.6.0
-#addin nuget:?package=Cake.Git&version=0.19.0
+#addin nuget:?package=Cake.Git&version=0.21.0
 
 // Documentation
-#addin nuget:?package=Cake.DocFx&version=0.12.0
-#tool nuget:?package=docfx.console&version=2.41.0
+#addin nuget:?package=Cake.DocFx&version=0.13.0
+#tool nuget:?package=docfx.console&version=2.44.0
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
@@ -216,8 +216,8 @@ public void TestWithAltCover(string projectPath, string assembly, string outputX
     }
 
     var altcoverArgs = new AltCover.Parameters.Primitive.PrepareArgs {
-        InputDirectory = inputDir,
-        OutputDirectory = outputDir,
+        InputDirectories = new[] { inputDir },
+        OutputDirectories = new[] { outputDir },
         AssemblyFilter = new[] { "nunit.framework", "NUnit3" },
         TypeFilter = new[] { "Yarhl.AssemblyUtils" },
         XmlReport = outputXml,

--- a/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
@@ -30,6 +30,7 @@ namespace Yarhl.UnitTests.FileSystem
     using NUnit.Framework;
     using Yarhl.FileSystem;
     using Yarhl.IO;
+    using Yarhl.IO.StreamFormat;
 
     [TestFixture]
     public class NodeFactoryTests
@@ -66,7 +67,10 @@ namespace Yarhl.UnitTests.FileSystem
 
             Assert.IsFalse(File.Exists(tempFile));
             Assert.DoesNotThrow(() => tempNode = NodeFactory.FromFile(tempFile));
-            Assert.IsTrue(File.Exists(tempFile));
+
+            // It's lazy initialize, so we need to trigger an operation
+            Assert.IsFalse(File.Exists(tempFile));
+            tempNode.Stream.WriteByte(0xCA);
 
             tempNode.Dispose();
             File.Delete(tempFile);
@@ -459,7 +463,7 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.That(node.Name, Is.EqualTo("node"));
             Assert.That(node.Format, Is.TypeOf<BinaryFormat>());
             Assert.That(node.Stream, Is.Not.Null);
-            Assert.That(node.Stream.BaseStream, Is.TypeOf<MemoryStream>());
+            Assert.That(node.Stream.BaseStream, Is.TypeOf<RecyclableMemoryStream>());
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
@@ -1,0 +1,419 @@
+// Copyright (c) 2019 SceneGate Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace Yarhl.UnitTests.IO
+{
+    using System;
+    using System.IO;
+    using NUnit.Framework;
+    using Yarhl.IO;
+    using Yarhl.IO.StreamFormat;
+
+    [TestFixture]
+    public class DataStreamFactoryTests
+    {
+        [Test]
+        public void CreateFromStreamUseStream()
+        {
+            var stream = new MemoryStream();
+            var dataStream = DataStreamFactory.FromStream(stream);
+
+            Assert.That(dataStream.BaseStream, Is.AssignableFrom<StreamWrapper>());
+            Assert.That(
+                ((StreamWrapper)dataStream.BaseStream).BaseStream,
+                Is.SameAs(stream));
+
+            stream.Dispose();
+        }
+
+        [Test]
+        public void CreateFromStreamAllowsToExpand()
+        {
+            var stream = new MemoryStream();
+            var dataStream = DataStreamFactory.FromStream(stream);
+            Assert.That(() => stream.WriteByte(0xFE), Throws.Nothing);
+            stream.Dispose();
+        }
+
+        [Test]
+        public void CreateFromStreamThrowIfInvalidArgument()
+        {
+            Assert.That(
+                () => DataStreamFactory.FromStream(null),
+                Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void CreateFromSubStreamUseStream()
+        {
+            var stream = new MemoryStream();
+            stream.WriteByte(0xCA);
+            stream.WriteByte(0xFE);
+            stream.WriteByte(0xBE);
+            var dataStream = DataStreamFactory.FromStream(stream, 1, 2);
+
+            Assert.That(dataStream.BaseStream, Is.AssignableFrom<StreamWrapper>());
+            Assert.That(
+                ((StreamWrapper)dataStream.BaseStream).BaseStream,
+                Is.SameAs(stream));
+            Assert.That(dataStream.Position, Is.EqualTo(0));
+            Assert.That(dataStream.Offset, Is.EqualTo(1));
+            Assert.That(dataStream.Length, Is.EqualTo(2));
+
+            stream.Dispose();
+        }
+
+        [Test]
+        public void CreateFromSubStreamDoesNotAllowToExpand()
+        {
+            var stream = new MemoryStream();
+            stream.WriteByte(0xCA);
+            stream.WriteByte(0xFE);
+            stream.WriteByte(0xBE);
+            var dataStream = DataStreamFactory.FromStream(stream, 1, 2);
+
+            dataStream.Position = 2;
+            Assert.That(() => dataStream.WriteByte(0xAA), Throws.InvalidOperationException);
+        }
+
+        [Test]
+        public void CreateFromSubStreamThrowIfInvalidArgument()
+        {
+            var stream = new MemoryStream();
+            stream.WriteByte(0xCA);
+            stream.WriteByte(0xFE);
+
+            Assert.That(
+                () => DataStreamFactory.FromStream(null, 0, 0),
+                Throws.ArgumentNullException);
+            Assert.That(
+                () => DataStreamFactory.FromStream(stream, -1, 0),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => DataStreamFactory.FromStream(stream, 0, -1),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => DataStreamFactory.FromStream(stream, 3, 0),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => DataStreamFactory.FromStream(stream, 1, 2),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+
+            stream.Dispose();
+        }
+
+        [Test]
+        public void CreateFromMemoryUseMemoryStream()
+        {
+            var dataStream = DataStreamFactory.FromMemory();
+
+            Assert.That(dataStream.BaseStream, Is.AssignableFrom<RecyclableMemoryStream>());
+
+            dataStream.Dispose();
+        }
+
+        [Test]
+        public void CreateFromMemoryAllowToExpand()
+        {
+            var stream = DataStreamFactory.FromMemory();
+            Assert.That(() => stream.WriteByte(0xFE), Throws.Nothing);
+            stream.Dispose();
+        }
+
+        [Test]
+        public void CreateFromArrayReadsArray()
+        {
+            byte[] data = new byte[] { 0x01, 0x2, 0x3 };
+
+            var stream = DataStreamFactory.FromArray(data, 1, 2);
+            Assert.AreEqual(0, stream.Position);
+            Assert.AreEqual(1, stream.Offset);
+            Assert.AreEqual(2, stream.Length);
+            Assert.That(stream.ReadByte(), Is.EqualTo(2));
+            stream.Dispose();
+        }
+
+        [Test]
+        public void CreateFromArrayWritesToArray()
+        {
+            byte[] data = new byte[] { 0x01, 0x2, 0x3 };
+            var stream = DataStreamFactory.FromArray(data, 1, 2);
+
+            stream.WriteByte(0xFE);
+            Assert.That(data[1], Is.EqualTo(0xFE));
+            stream.Dispose();
+        }
+
+        [Test]
+        public void CreateFromArrayDoesNotAllowToExpand()
+        {
+            byte[] data = new byte[] { 0x01, 0x2, 0x3 };
+            var stream = DataStreamFactory.FromArray(data, 1, 2);
+
+            stream.Position = 2;
+            Assert.That(() => stream.WriteByte(0xFE), Throws.InvalidOperationException);
+            stream.Dispose();
+        }
+
+        [Test]
+        public void CreateFromArrayWithInvalidThrows()
+        {
+            byte[] data = new byte[] { 0x01 };
+
+            Assert.That(
+                () => DataStreamFactory.FromArray(null, 0, 0),
+                Throws.ArgumentNullException);
+            Assert.That(
+                () => DataStreamFactory.FromArray(data, -1, 0),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => DataStreamFactory.FromArray(data, 2, 0),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => DataStreamFactory.FromArray(data, 0, -1),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => DataStreamFactory.FromArray(data, 0, 2),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => DataStreamFactory.FromArray(data, 1, 1),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void CreateFromPathWritesFile()
+        {
+            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Assert.That(File.Exists(tempFile), Is.False);
+
+            int beforeCount = DataStream.ActiveStreams;
+            DataStream writeStream = null;
+            FileStream readStream = null;
+            try {
+                writeStream = DataStreamFactory.FromFile(tempFile, FileOpenMode.Write);
+                Assert.AreEqual(0x0, writeStream.Offset);
+                Assert.AreEqual(0x0, writeStream.Length);
+                Assert.AreEqual(0x0, writeStream.Position);
+                writeStream.WriteByte(0xCA);
+                writeStream.Dispose();
+                writeStream = null; // prevent two dispose
+
+                Assert.That(File.Exists(tempFile), Is.True);
+                readStream = new FileStream(tempFile, FileMode.Open);
+                Assert.AreEqual(0x1, readStream.Length);
+                Assert.AreEqual(0xCA, readStream.ReadByte());
+            } finally {
+                writeStream?.Dispose();
+                readStream?.Dispose();
+                File.Delete(tempFile);
+            }
+
+            Assert.AreEqual(beforeCount, DataStream.ActiveStreams);
+        }
+
+        [Test]
+        public void CreateFromPathAllowsToExpand()
+        {
+            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+            int beforeCount = DataStream.ActiveStreams;
+            DataStream writeStream = null;
+            try {
+                writeStream = DataStreamFactory.FromFile(tempFile, FileOpenMode.Write);
+                Assert.That(() => writeStream.WriteByte(0xCA), Throws.Nothing);
+            } finally {
+                writeStream?.Dispose();
+                File.Delete(tempFile);
+            }
+
+            Assert.AreEqual(beforeCount, DataStream.ActiveStreams);
+        }
+
+        [Test]
+        public void CreateFromPathReadsFile()
+        {
+            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Assert.That(File.Exists(tempFile), Is.False);
+
+            int beforeCount = DataStream.ActiveStreams;
+            FileStream writeStream = null;
+            DataStream readStream = null;
+            try {
+                writeStream = new FileStream(tempFile, FileMode.CreateNew);
+                Assert.AreEqual(0x0, writeStream.Length);
+                writeStream.WriteByte(0xCA);
+                writeStream.Dispose();
+                writeStream = null; // prevent two disposes
+
+                readStream = DataStreamFactory.FromFile(tempFile, FileOpenMode.Read);
+                Assert.IsNull(readStream.ParentDataStream);
+                Assert.AreEqual(0x0, readStream.Offset);
+                Assert.AreEqual(0x1, readStream.Length);
+                Assert.AreEqual(0x0, readStream.Position);
+                Assert.AreEqual(0xCA, readStream.ReadByte());
+            } finally {
+                writeStream?.Dispose();
+                readStream?.Dispose();
+                File.Delete(tempFile);
+            }
+
+            Assert.AreEqual(beforeCount, DataStream.ActiveStreams);
+        }
+
+        [Test]
+        public void CreateFromPathWithInvalidArgThrows()
+        {
+            Assert.That(
+                () => DataStreamFactory.FromFile(null, FileOpenMode.Append),
+                Throws.ArgumentNullException);
+            Assert.That(
+                () => DataStreamFactory.FromFile(string.Empty, FileOpenMode.Append),
+                Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void CreateFromSectionPathWritesFile()
+        {
+            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Assert.That(File.Exists(tempFile), Is.False);
+
+            int beforeCount = DataStream.ActiveStreams;
+            FileStream createStream = null;
+            DataStream writeStream = null;
+            FileStream readStream = null;
+            try {
+                createStream = new FileStream(tempFile, FileMode.CreateNew);
+                createStream.WriteByte(0xCA);
+                createStream.WriteByte(0xFE);
+                createStream.WriteByte(0xAA);
+                createStream.Dispose();
+                createStream = null; // prevent two disposes
+
+                writeStream = DataStreamFactory.FromFile(tempFile, FileOpenMode.Write, 1, 2);
+                Assert.AreEqual(0x1, writeStream.Offset);
+                Assert.AreEqual(0x2, writeStream.Length);
+                Assert.AreEqual(0x0, writeStream.Position);
+                writeStream.WriteByte(0xB4);
+                writeStream.Dispose();
+                writeStream = null; // prevent two dispose
+
+                readStream = new FileStream(tempFile, FileMode.Open);
+                readStream.Position = 1;
+                Assert.AreEqual(0xB4, readStream.ReadByte());
+            } finally {
+                createStream?.Dispose();
+                writeStream?.Dispose();
+                readStream?.Dispose();
+                File.Delete(tempFile);
+            }
+
+            Assert.AreEqual(beforeCount, DataStream.ActiveStreams);
+        }
+
+        [Test]
+        public void CreateFromSectionPathDoesNotAllowToExpand()
+        {
+            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+            int beforeCount = DataStream.ActiveStreams;
+            FileStream createStream = null;
+            DataStream writeStream = null;
+            try {
+                createStream = new FileStream(tempFile, FileMode.CreateNew);
+                createStream.WriteByte(0xCA);
+                createStream.WriteByte(0xFE);
+                createStream.WriteByte(0xAA);
+                createStream.Dispose();
+                createStream = null; // prevent two disposes
+
+                writeStream = DataStreamFactory.FromFile(tempFile, FileOpenMode.Write, 1, 2);
+                writeStream.Position = 2;
+                Assert.That(() => writeStream.WriteByte(0xB4), Throws.InvalidOperationException);
+            } finally {
+                createStream?.Dispose();
+                writeStream?.Dispose();
+                File.Delete(tempFile);
+            }
+
+            Assert.AreEqual(beforeCount, DataStream.ActiveStreams);
+        }
+
+        [Test]
+        public void CreateFromSectionPathReadsFile()
+        {
+            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Assert.That(File.Exists(tempFile), Is.False);
+
+            int beforeCount = DataStream.ActiveStreams;
+            FileStream writeStream = null;
+            DataStream readStream = null;
+            try {
+                writeStream = new FileStream(tempFile, FileMode.CreateNew);
+                writeStream.WriteByte(0xCA);
+                writeStream.WriteByte(0xFE);
+                writeStream.WriteByte(0xAA);
+                writeStream.Dispose();
+                writeStream = null; // prevent two disposes
+
+                readStream = DataStreamFactory.FromFile(tempFile, FileOpenMode.Read, 1, 2);
+                Assert.IsNull(readStream.ParentDataStream);
+                Assert.AreEqual(0x1, readStream.Offset);
+                Assert.AreEqual(0x2, readStream.Length);
+                Assert.AreEqual(0x0, readStream.Position);
+                Assert.AreEqual(0xFE, readStream.ReadByte());
+            } finally {
+                writeStream?.Dispose();
+                readStream?.Dispose();
+                File.Delete(tempFile);
+            }
+
+            Assert.AreEqual(beforeCount, DataStream.ActiveStreams);
+        }
+
+        [Test]
+        public void CreateFromSectionPathInvalidArgsThrows()
+        {
+            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+            try {
+                using (var stream = new FileStream(tempFile, FileMode.CreateNew)) {
+                    stream.WriteByte(0xCA);
+                    stream.WriteByte(0xFE);
+                }
+
+                Assert.Throws<ArgumentNullException>(() =>
+                    DataStreamFactory.FromFile(null, FileOpenMode.Append, 0, 0));
+                Assert.Throws<ArgumentNullException>(() =>
+                    DataStreamFactory.FromFile(string.Empty, FileOpenMode.Append, 0, 0));
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                    DataStreamFactory.FromFile(tempFile, FileOpenMode.Read, -1, 0));
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                    DataStreamFactory.FromFile(tempFile, FileOpenMode.Read, 3, 0));
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                    DataStreamFactory.FromFile(tempFile, FileOpenMode.Read, 0, -1));
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                    DataStreamFactory.FromFile(tempFile, FileOpenMode.Read, 0, 3));
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                    DataStreamFactory.FromFile(tempFile, FileOpenMode.Read, 1, 2));
+            } finally {
+                File.Delete(tempFile);
+            }
+        }
+    }
+}

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -29,17 +29,32 @@ namespace Yarhl.UnitTests.IO
     using NUnit.Framework;
     using Yarhl.FileFormat;
     using Yarhl.IO;
+    using Yarhl.IO.StreamFormat;
 
     [TestFixture]
     public class DataStreamTests
     {
+        IStream baseStream;
+
+        [SetUp]
+        public void SetUp()
+        {
+            baseStream = new RecyclableMemoryStream();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            baseStream?.Dispose();
+        }
+
         [Test]
         public void ConstructorFromStreamAndOffsetInitializes()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             int beforeCount = DataStream.ActiveStreams;
+
             DataStream stream = new DataStream(baseStream, 0x1, 0x1);
             Assert.AreSame(baseStream, stream.BaseStream);
             Assert.AreEqual(0x1, stream.Offset);
@@ -50,16 +65,8 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ConstructorThrowExceptionIfNullStream()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-                new DataStream((Stream)null, 0, 0));
-        }
-
-        [Test]
         public void ConstructorThrowExceptionIfNegativeOffset()
         {
-            Stream baseStream = new MemoryStream();
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 new DataStream(baseStream, -1, 4));
         }
@@ -67,7 +74,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ConstructorThrowExceptionIfOffsetBiggerThanLength()
         {
-            Stream baseStream = new MemoryStream();
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 new DataStream(baseStream, 1, 0));
         }
@@ -75,7 +81,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ConstructorThrowExceptionIfLengthLessThanZero()
         {
-            Stream baseStream = new MemoryStream();
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 new DataStream(baseStream, 0, -1));
         }
@@ -83,7 +88,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void DataStreamLengthLargerThanBaseLengthIsNotAllowed()
         {
-            Stream baseStream = new MemoryStream();
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 new DataStream(baseStream, 0, 100));
         }
@@ -91,7 +95,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ConstructorWithOnlyStreamInitializes()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             int beforeCount = DataStream.ActiveStreams;
@@ -108,7 +111,7 @@ namespace Yarhl.UnitTests.IO
         public void ConstructorStreamThrowsIfNull()
         {
             Assert.That(
-                () => new DataStream((Stream)null),
+                () => new DataStream((IStream)null),
                 Throws.ArgumentNullException);
         }
 
@@ -117,156 +120,18 @@ namespace Yarhl.UnitTests.IO
         {
             int beforeCount = DataStream.ActiveStreams;
             DataStream stream = new DataStream();
-            Assert.IsInstanceOf<MemoryStream>(stream.BaseStream);
-            Assert.IsTrue(stream.BaseStream.CanWrite);
-            Assert.IsTrue(stream.BaseStream.CanRead);
+            Assert.IsInstanceOf<RecyclableMemoryStream>(stream.BaseStream);
             Assert.AreEqual(0x0, stream.Offset);
             Assert.AreEqual(0x0, stream.Length);
             Assert.AreEqual(0x0, stream.Position);
             Assert.IsNull(stream.ParentDataStream);
             Assert.AreEqual(beforeCount + 1, DataStream.ActiveStreams);
-        }
-
-        [Test]
-        public void ConstructorFromArrayInitializes()
-        {
-            int beforeCount = DataStream.ActiveStreams;
-            byte[] data = new byte[] { 0x01, 0x02, 0x03 };
-            DataStream stream = new DataStream(data, 1, 2);
-            Assert.That(stream.BaseStream, Is.InstanceOf<MemoryStream>());
-            Assert.That(stream.BaseStream.CanWrite, Is.True);
-            Assert.That(stream.BaseStream.CanRead, Is.True);
-            Assert.That(stream.Offset, Is.EqualTo(1));
-            Assert.That(stream.Length, Is.EqualTo(2));
-            Assert.That(stream.Position, Is.EqualTo(0));
-            Assert.IsNull(stream.ParentDataStream);
-            Assert.AreEqual(beforeCount + 1, DataStream.ActiveStreams);
-        }
-
-        [Test]
-        public void ConstructorFromArrayWithInvalidThrows()
-        {
-            byte[] data = new byte[] { 0x01 };
-
-            Assert.Throws<ArgumentNullException>(() =>
-                new DataStream((byte[])null, 0, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new DataStream(data, -1, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new DataStream(data, 2, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new DataStream(data, 0, -1));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new DataStream(data, 0, 2));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new DataStream(data, 1, 1));
-        }
-
-        [Test]
-        public void FilePathConstructorOpenFile()
-        {
-            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-            try {
-                int beforeCount = DataStream.ActiveStreams;
-                DataStream writeStream = new DataStream(tempFile, FileOpenMode.Write);
-                Assert.IsInstanceOf<FileStream>(writeStream.BaseStream);
-                Assert.IsTrue(writeStream.BaseStream.CanWrite);
-                Assert.IsFalse(writeStream.BaseStream.CanRead);
-                Assert.AreEqual(0x0, writeStream.Offset);
-                Assert.AreEqual(0x0, writeStream.Length);
-                Assert.AreEqual(0x0, writeStream.Position);
-                Assert.AreEqual(beforeCount + 1, DataStream.ActiveStreams);
-                writeStream.WriteByte(0xCA);
-                writeStream.Dispose();
-
-                DataStream readStream = new DataStream(tempFile, FileOpenMode.Read);
-                Assert.IsInstanceOf<FileStream>(readStream.BaseStream);
-                Assert.IsFalse(readStream.BaseStream.CanWrite);
-                Assert.IsTrue(readStream.BaseStream.CanRead);
-                Assert.IsNull(readStream.ParentDataStream);
-                Assert.AreEqual(0x0, readStream.Offset);
-                Assert.AreEqual(0x1, readStream.Length);
-                Assert.AreEqual(0x0, readStream.Position);
-                Assert.AreEqual(0xCA, readStream.ReadByte());
-                readStream.Dispose();
-            } finally {
-                File.Delete(tempFile);
-            }
-        }
-
-        [Test]
-        public void FilePathConstructorWithInvalidThrows()
-        {
-            Assert.That(
-                () => new DataStream(null, FileOpenMode.Append),
-                Throws.ArgumentNullException);
-            Assert.That(
-                () => new DataStream(string.Empty, FileOpenMode.Append),
-                Throws.ArgumentNullException);
-        }
-
-        [Test]
-        public void FilePathConstructorWithOffset()
-        {
-            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-            DataStream readStream = null;
-            try {
-                using (var stream = new DataStream(tempFile, FileOpenMode.Write)) {
-                    stream.WriteByte(0xCA);
-                    stream.WriteByte(0xFE);
-                    stream.WriteByte(0xAF);
-                    stream.WriteByte(0xFA);
-                }
-
-                int beforeCount = DataStream.ActiveStreams;
-                readStream = new DataStream(tempFile, FileOpenMode.Read, 1, 2);
-                Assert.AreEqual(0x1, readStream.Offset);
-                Assert.AreEqual(0x2, readStream.Length);
-                Assert.AreEqual(0x0, readStream.Position);
-                Assert.AreEqual(0x1, readStream.AbsolutePosition);
-                Assert.AreEqual(0xFE, readStream.ReadByte());
-                Assert.AreEqual(beforeCount + 1, DataStream.ActiveStreams);
-            } finally {
-                readStream?.Dispose();
-                File.Delete(tempFile);
-            }
-        }
-
-        [Test]
-        public void FilePathConstructorWithOffsetAndInvalidThrows()
-        {
-            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-            try {
-                using (var stream = new DataStream(tempFile, FileOpenMode.Write)) {
-                    stream.WriteByte(0xCA);
-                }
-
-                Assert.Throws<ArgumentNullException>(() =>
-                    new DataStream(null, FileOpenMode.Append, 0, 0));
-                Assert.Throws<ArgumentNullException>(() =>
-                    new DataStream(string.Empty, FileOpenMode.Append, 0, 0));
-                Assert.Throws<ArgumentOutOfRangeException>(() =>
-                    new DataStream(tempFile, FileOpenMode.Read, -1, 0));
-                Assert.Throws<ArgumentOutOfRangeException>(() =>
-                    new DataStream(tempFile, FileOpenMode.Read, 2, 0));
-                Assert.Throws<ArgumentOutOfRangeException>(() =>
-                    new DataStream(tempFile, FileOpenMode.Read, 0, -1));
-                Assert.Throws<ArgumentOutOfRangeException>(() =>
-                    new DataStream(tempFile, FileOpenMode.Read, 0, 2));
-                Assert.Throws<ArgumentOutOfRangeException>(() =>
-                    new DataStream(tempFile, FileOpenMode.Read, 1, 1));
-            } finally {
-                File.Delete(tempFile);
-            }
+            stream.Dispose();
         }
 
         [Test]
         public void ConstructorFromDataStreamSetProperties()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             baseStream.WriteByte(0xBE);
@@ -287,21 +152,23 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ConstructorFromDataStreamInvalidThrows()
         {
-            DataStream baseStream = new DataStream();
-            baseStream.WriteByte(0x01);
+            DataStream stream = new DataStream();
+            stream.WriteByte(0x01);
 
             Assert.Throws<ArgumentNullException>(() =>
                 new DataStream((DataStream)null, 0, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new DataStream(baseStream, -1, 0));
+                new DataStream(stream, -1, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new DataStream(baseStream, 2, 0));
+                new DataStream(stream, 2, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new DataStream(baseStream, 0, -1));
+                new DataStream(stream, 0, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new DataStream(baseStream, 0, 2));
+                new DataStream(stream, 0, 2));
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new DataStream(baseStream, 1, 1));
+                new DataStream(stream, 1, 1));
+
+            stream.Dispose();
         }
 
         [Test]
@@ -315,7 +182,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void DisposeTwiceDoesNotAffectOtherStreams()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             baseStream.Position = 0;
@@ -343,7 +209,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void DiposingLastStreamDisposeBaseStream()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
 
@@ -351,18 +216,20 @@ namespace Yarhl.UnitTests.IO
             DataStream stream2 = new DataStream(baseStream);
 
             stream1.Dispose();
+            Assert.IsFalse(baseStream.Disposed);
             Assert.DoesNotThrow(() => baseStream.ReadByte());
 
             stream2.Dispose();
+            Assert.IsTrue(baseStream.Disposed);
             Assert.Throws<ObjectDisposedException>(() => baseStream.ReadByte());
         }
 
         [Test]
         public void DiposeCloseCorrectStream()
         {
-            Stream baseStream1 = new MemoryStream();
+            IStream baseStream1 = new RecyclableMemoryStream();
             baseStream1.WriteByte(0xCA);
-            Stream baseStream2 = new MemoryStream();
+            IStream baseStream2 = new RecyclableMemoryStream();
             baseStream2.WriteByte(0xCA);
 
             DataStream stream1 = new DataStream(baseStream1);
@@ -404,7 +271,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void SetPositionChangesProperty()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -417,7 +283,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void SetPositionAfterDisposeThrowsException()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -428,7 +293,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void SetNegativePositionThrowsException()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -438,7 +302,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void SetOutofRangePositionThrowsException()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -448,7 +311,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void SetLength()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream);
@@ -458,7 +320,7 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void CannotIncreaseLengthFromSubStream()
+        public void CannotExpandSubDataStream()
         {
             DataStream parentStream = new DataStream();
             parentStream.WriteByte(0x00);
@@ -471,18 +333,130 @@ namespace Yarhl.UnitTests.IO
                 Throws.InvalidOperationException);
 
             DataStream childStream2 = new DataStream(parentStream, 0, 2);
-            childStream2.WriteByte(0x02);
-            childStream2.WriteByte(0x02);
+            byte[] data = new byte[] { 0x02, 0x02, 0x02 };
             Assert.That(
-                () => childStream2.WriteByte(0x02),
+                () => childStream2.Write(data, 0, data.Length),
                 Throws.InvalidOperationException);
+
+            DataStream childStream3 = new DataStream(parentStream, 0, 1);
+            Assert.That(
+                () => childStream3.Length = 2,
+                Throws.InvalidOperationException);
+            Assert.That(
+                () => childStream3.Length = 0,
+                Throws.Nothing);
+            Assert.That(
+                () => childStream3.Length = 1,
+                Throws.InvalidOperationException);
+
+            childStream.Dispose();
+            childStream2.Dispose();
+            childStream3.Dispose();
+            parentStream.Dispose();
+        }
+
+        [Test]
+        public void CanExpandStream()
+        {
+            IStream parentStream = new RecyclableMemoryStream();
+
+            DataStream childStream = new DataStream(parentStream);
+            Assert.That(() => childStream.WriteByte(0x01), Throws.Nothing);
+
+            DataStream childStream2 = new DataStream(parentStream);
+            byte[] data = new byte[] { 0x02, 0x02 };
+            Assert.That(
+                () => childStream2.Write(data, 0, data.Length),
+                Throws.Nothing);
+
+            DataStream childStream3 = new DataStream(parentStream);
+            parentStream.Position = 2;
+            parentStream.WriteByte(0x03);
+            Assert.That(
+                () => childStream3.Length = 3,
+                Throws.Nothing);
+            Assert.That(
+                () => childStream3.Length = 0,
+                Throws.Nothing);
+            Assert.That(
+                () => childStream3.Length = 1,
+                Throws.Nothing);
+
+            childStream.Dispose();
+            childStream2.Dispose();
+            childStream3.Dispose();
+            parentStream.Dispose();
+        }
+
+        [Test]
+        public void CannotExpandSubStream()
+        {
+            IStream parentStream = new RecyclableMemoryStream();
+            parentStream.WriteByte(0x00);
+            parentStream.WriteByte(0x00);
+
+            DataStream childStream = new DataStream(parentStream, 1, 1);
+            childStream.WriteByte(0x01);
+            Assert.That(
+                () => childStream.WriteByte(0x01),
+                Throws.InvalidOperationException);
+
+            DataStream childStream2 = new DataStream(parentStream, 0, 2);
+            byte[] data = new byte[] { 0x02, 0x02, 0x02 };
+            Assert.That(
+                () => childStream2.Write(data, 0, data.Length),
+                Throws.InvalidOperationException);
+
+            DataStream childStream3 = new DataStream(parentStream, 0, 1);
+            Assert.That(
+                () => childStream3.Length = 2,
+                Throws.InvalidOperationException);
+            Assert.That(
+                () => childStream3.Length = 0,
+                Throws.Nothing);
+            Assert.That(
+                () => childStream3.Length = 1,
+                Throws.InvalidOperationException);
+
+            childStream.Dispose();
+            childStream2.Dispose();
+            childStream3.Dispose();
+            parentStream.Dispose();
+        }
+
+        [Test]
+        public void CanExpandMemoryStream()
+        {
+            DataStream childStream = new DataStream();
+            Assert.That(() => childStream.WriteByte(0x01), Throws.Nothing);
+
+            DataStream childStream2 = new DataStream();
+            byte[] data = new byte[] { 0x02, 0x02 };
+            Assert.That(
+                () => childStream2.Write(data, 0, data.Length),
+                Throws.Nothing);
+
+            DataStream childStream3 = new DataStream();
+            childStream3.BaseStream.WriteByte(0x03);
+            Assert.That(
+                () => childStream3.Length = 1,
+                Throws.Nothing);
+            Assert.That(
+                () => childStream3.Length = 0,
+                Throws.Nothing);
+            Assert.That(
+                () => childStream3.Length = 1,
+                Throws.Nothing);
+
+            childStream.Dispose();
+            childStream2.Dispose();
+            childStream3.Dispose();
         }
 
         [Test]
         public void CanPreallocateLengthForSubstream()
         {
             DataStream parent = new DataStream();
-            parent.BaseStream.SetLength(11);
             parent.Length = 11;
             parent.WriteByte(0xFF);
             Assert.That(parent.Length, Is.EqualTo(11));
@@ -494,12 +468,13 @@ namespace Yarhl.UnitTests.IO
             for (int i = 0; i < 10; i++) {
                 Assert.That(child.ReadByte(), Is.EqualTo(0));
             }
+
+            parent.Dispose();
         }
 
         [Test]
         public void LengthAfterDisposeThrowException()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             DataStream stream = new DataStream(baseStream, 0, 1);
             stream.Dispose();
@@ -509,17 +484,14 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void OutOfRangeLengthThrowException()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             DataStream stream = new DataStream(baseStream, 0, 0);
             Assert.Throws<ArgumentOutOfRangeException>(() => stream.Length = -2);
-            Assert.Throws<ArgumentOutOfRangeException>(() => stream.Length = 2);
         }
 
         [Test]
         public void DecreaseLengthAdjustPosition()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream);
@@ -532,7 +504,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void EndOfStreamIsSet()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -544,7 +515,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void GetValidAbsolutePosition()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 1, 1);
@@ -556,7 +526,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void SeekFromOrigin()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -567,7 +536,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void SeekFromCurrent()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -580,7 +548,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void SeekFromEnd()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -597,6 +564,7 @@ namespace Yarhl.UnitTests.IO
             stream.Seek(0);
             Assert.That(stream.Position, Is.EqualTo(0));
             Assert.That(stream.AbsolutePosition, Is.EqualTo(0));
+            stream.Dispose();
         }
 
         [Test]
@@ -607,12 +575,12 @@ namespace Yarhl.UnitTests.IO
             Assert.That(
                 () => stream.Seek(0, (SeekMode)0x100),
                 Throws.TypeOf<ArgumentOutOfRangeException>());
+            stream.Dispose();
         }
 
         [Test]
         public void SeekWhenDisposedThrowsException()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -624,7 +592,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void SeekToNegativeThrowsException()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -637,7 +604,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void SeekToOutOfRangeThrowsException()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -655,6 +621,7 @@ namespace Yarhl.UnitTests.IO
             Assert.AreEqual(2, stream.Position);
             stream.PushToPosition(-1, SeekMode.Current);
             Assert.AreEqual(1, stream.Position);
+            stream.Dispose();
         }
 
         [Test]
@@ -666,6 +633,7 @@ namespace Yarhl.UnitTests.IO
             stream.PushToPosition(0);
             Assert.That(stream.Position, Is.EqualTo(0));
             Assert.That(stream.AbsolutePosition, Is.EqualTo(0));
+            stream.Dispose();
         }
 
         [Test]
@@ -688,6 +656,7 @@ namespace Yarhl.UnitTests.IO
             Assert.AreEqual(2, stream.Position);
             stream.PushCurrentPosition();
             Assert.AreEqual(2, stream.Position);
+            stream.Dispose();
         }
 
         [Test]
@@ -720,6 +689,7 @@ namespace Yarhl.UnitTests.IO
             Assert.AreEqual(1, stream.Position);
             stream.PopPosition();
             Assert.AreEqual(2, stream.Position);
+            stream.Dispose();
         }
 
         [Test]
@@ -729,6 +699,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0xA);
             stream.WriteByte(0xB);
             Assert.Throws<InvalidOperationException>(stream.PopPosition);
+            stream.Dispose();
         }
 
         [Test]
@@ -754,6 +725,7 @@ namespace Yarhl.UnitTests.IO
                 () => Assert.That(stream.ReadByte(), Is.EqualTo(0xBA)),
                 -2,
                 SeekMode.Current);
+            stream.Dispose();
         }
 
         [Test]
@@ -769,6 +741,7 @@ namespace Yarhl.UnitTests.IO
                 1,
                 SeekMode.Start);
             Assert.That(stream.Position, Is.EqualTo(4));
+            stream.Dispose();
         }
 
         [Test]
@@ -782,6 +755,7 @@ namespace Yarhl.UnitTests.IO
             stream.RunInPosition(
                 () => Assert.That(stream.ReadByte(), Is.EqualTo(0xFE)),
                 1);
+            stream.Dispose();
         }
 
         [Test]
@@ -790,12 +764,12 @@ namespace Yarhl.UnitTests.IO
             DataStream stream = new DataStream();
             stream.WriteByte(0xCA);
             Assert.That(() => stream.RunInPosition(null, 0), Throws.ArgumentNullException);
+            stream.Dispose();
         }
 
         [Test]
         public void ReadsByte()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -808,7 +782,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadByteAfterDisposeThrowException()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -819,7 +792,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadByteWhenEOSThrowsException()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -831,7 +803,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadSetBaseStreamPosition()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -842,7 +813,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadsBuffer()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -861,7 +831,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadBufferfterDisposeThrowException()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -873,7 +842,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadBufferWhenEOSThrowsException()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -886,7 +854,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadBufferSetBaseStreamPosition()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -899,7 +866,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadBufferZeroBytes()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -911,7 +877,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadBufferButNullThrowException()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -922,7 +887,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadBufferOutOfRange()
         {
-            Stream baseStream = new MemoryStream();
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2);
@@ -938,6 +902,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0xAF);
             stream.Position = 0x00;
             Assert.AreEqual(0xAF, stream.ReadFormat<byte>());
+            stream.Dispose();
         }
 
         [Test]
@@ -955,7 +920,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WritesAByteAndIncreasePosition()
         {
-            MemoryStream baseStream = new MemoryStream(2);
             DataStream stream = new DataStream(baseStream);
             stream.WriteByte(0xCA);
             Assert.AreEqual(1, stream.Position);
@@ -972,6 +936,7 @@ namespace Yarhl.UnitTests.IO
             Assert.AreEqual(1, stream.Position);
             stream.Position = 0;
             Assert.AreEqual(0xCA, stream.ReadByte());
+            stream.Dispose();
         }
 
         [Test]
@@ -985,7 +950,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteByteSetBaseStreamPosition()
         {
-            MemoryStream baseStream = new MemoryStream(2);
             DataStream stream = new DataStream(baseStream);
             baseStream.Position = 1;
             stream.WriteByte(0xCA);
@@ -996,7 +960,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteBufferAndIncreasePosition()
         {
-            MemoryStream baseStream = new MemoryStream(2);
             DataStream stream = new DataStream(baseStream);
             byte[] buffer = { 0x00, 0xCA };
             stream.Write(buffer, 1, 1);
@@ -1008,7 +971,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteBufferAndIncreaseLength()
         {
-            MemoryStream baseStream = new MemoryStream();
             baseStream.WriteByte(0xFF);
             DataStream stream = new DataStream(baseStream);
             Assert.AreEqual(1, stream.Length);
@@ -1032,6 +994,7 @@ namespace Yarhl.UnitTests.IO
             stream.Position = 0;
             Assert.AreEqual(0xCA, stream.ReadByte());
             Assert.AreEqual(0xFE, stream.ReadByte());
+            stream.Dispose();
         }
 
         [Test]
@@ -1046,7 +1009,6 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteBufferSetBaseStreamPosition()
         {
-            MemoryStream baseStream = new MemoryStream();
             baseStream.WriteByte(0xFF);
             DataStream stream = new DataStream(baseStream);
             Assert.AreEqual(1, baseStream.Position);
@@ -1061,6 +1023,7 @@ namespace Yarhl.UnitTests.IO
         {
             DataStream stream = new DataStream();
             Assert.Throws<ArgumentNullException>(() => stream.Write(null, 0, 1));
+            stream.Dispose();
         }
 
         [Test]
@@ -1070,6 +1033,7 @@ namespace Yarhl.UnitTests.IO
             byte[] buffer = { 0xCA };
             Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(buffer, 10, 1));
             Assert.Throws<ArgumentOutOfRangeException>(() => stream.Write(buffer, 0, 10));
+            stream.Dispose();
         }
 
         [Test]
@@ -1086,6 +1050,7 @@ namespace Yarhl.UnitTests.IO
             stream.Write(buffer, 0, 0);
             Assert.AreEqual(0, stream.Position);
             Assert.AreEqual(0, stream.Length);
+            stream.Dispose();
         }
 
         [Test]
@@ -1103,18 +1068,21 @@ namespace Yarhl.UnitTests.IO
             Assert.AreEqual(0xFE, stream2.ReadByte());
             Assert.AreEqual(0x00, stream2.ReadByte());
             Assert.AreEqual(0xFF, stream2.ReadByte());
+            stream1.Dispose();
+            stream2.Dispose();
         }
 
         [Test]
         public void WriteToNullStream()
         {
-            DataStream stream1 = new DataStream();
-            stream1.WriteByte(0xCA);
-            stream1.WriteByte(0xFE);
-            stream1.WriteByte(0x00);
-            stream1.WriteByte(0xFF);
+            DataStream stream = new DataStream();
+            stream.WriteByte(0xCA);
+            stream.WriteByte(0xFE);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0xFF);
             Assert.Throws<ArgumentNullException>(
-                () => stream1.WriteTo((DataStream)null));
+                () => stream.WriteTo((DataStream)null));
+            stream.Dispose();
         }
 
         [Test]
@@ -1128,6 +1096,7 @@ namespace Yarhl.UnitTests.IO
             DataStream stream2 = new DataStream();
             stream2.Dispose();
             Assert.Throws<ObjectDisposedException>(() => stream1.WriteTo(stream2));
+            stream1.Dispose();
         }
 
         [Test]
@@ -1141,6 +1110,7 @@ namespace Yarhl.UnitTests.IO
             DataStream stream2 = new DataStream();
             stream1.Dispose();
             Assert.Throws<ObjectDisposedException>(() => stream1.WriteTo(stream2));
+            stream2.Dispose();
         }
 
         [Test]
@@ -1155,6 +1125,8 @@ namespace Yarhl.UnitTests.IO
             stream2.WriteByte(0xBE);
             stream1.WriteTo(stream2);
             Assert.AreEqual(4, stream1.Position);
+            stream1.Dispose();
+            stream2.Dispose();
         }
 
         [Test]
@@ -1174,6 +1146,8 @@ namespace Yarhl.UnitTests.IO
             Assert.AreEqual(0xFE, stream2.ReadByte());
             Assert.AreEqual(0x00, stream2.ReadByte());
             Assert.AreEqual(0xFF, stream2.ReadByte());
+            stream1.Dispose();
+            stream2.Dispose();
         }
 
         [Test]
@@ -1193,6 +1167,8 @@ namespace Yarhl.UnitTests.IO
             Assert.AreEqual(0xFE, stream2.ReadByte());
             Assert.AreEqual(0x00, stream2.ReadByte());
             Assert.AreEqual(0xFF, stream2.ReadByte());
+            stream1.Dispose();
+            stream2.Dispose();
         }
 
         [Test]
@@ -1205,6 +1181,9 @@ namespace Yarhl.UnitTests.IO
             DataStream stream2 = new DataStream();
             stream1.WriteTo(stream2);
             Assert.IsTrue(stream1.Compare(stream2));
+
+            stream1.Dispose();
+            stream2.Dispose();
         }
 
         [Test]
@@ -1227,6 +1206,9 @@ namespace Yarhl.UnitTests.IO
             Assert.AreEqual(0xFE, stream2.ReadByte());
             Assert.AreEqual(0x00, stream2.ReadByte());
             Assert.AreEqual(0xFF, stream2.ReadByte());
+
+            stream1.Dispose();
+            stream2.Dispose();
         }
 
         [Test]
@@ -1241,7 +1223,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0xFF);
             stream.WriteTo(tempFile);
 
-            DataStream fileStream = new DataStream(tempFile, FileOpenMode.Read);
+            DataStream fileStream = DataStreamFactory.FromFile(tempFile, FileOpenMode.Read);
             Assert.IsTrue(stream.Compare(fileStream));
 
             fileStream.Dispose();
@@ -1261,7 +1243,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0xFE);
             stream.WriteTo(tempFile);
 
-            DataStream fileStream = new DataStream(tempFile, FileOpenMode.Read);
+            DataStream fileStream = DataStreamFactory.FromFile(tempFile, FileOpenMode.Read);
             Assert.That(() => stream.Compare(fileStream), Is.True);
 
             fileStream.Dispose();
@@ -1282,7 +1264,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0xFE);
             stream.WriteTo(tempFile);
 
-            DataStream fileStream = new DataStream(tempFile, FileOpenMode.Read);
+            DataStream fileStream = DataStreamFactory.FromFile(tempFile, FileOpenMode.Read);
             Assert.That(() => stream.Compare(fileStream), Is.True);
 
             fileStream.Dispose();
@@ -1303,6 +1285,7 @@ namespace Yarhl.UnitTests.IO
             Assert.Throws<ArgumentNullException>(
                 () => stream1.WriteTo((string)null));
             Assert.Throws<ArgumentNullException>(() => stream1.WriteTo(string.Empty));
+            stream1.Dispose();
         }
 
         [Test]
@@ -1332,6 +1315,9 @@ namespace Yarhl.UnitTests.IO
             stream2.WriteByte(0xFF);
             Assert.IsTrue(stream1.Compare(stream2));
             Assert.IsTrue(stream2.Compare(stream1));
+
+            stream1.Dispose();
+            stream2.Dispose();
         }
 
         [Test]
@@ -1349,6 +1335,9 @@ namespace Yarhl.UnitTests.IO
             stream2.WriteByte(0xFF);
             Assert.IsFalse(stream1.Compare(stream2));
             Assert.IsFalse(stream2.Compare(stream1));
+
+            stream1.Dispose();
+            stream2.Dispose();
         }
 
         [Test]
@@ -1365,6 +1354,9 @@ namespace Yarhl.UnitTests.IO
             stream2.WriteByte(0x00);
             Assert.IsFalse(stream1.Compare(stream2));
             Assert.IsFalse(stream2.Compare(stream1));
+
+            stream1.Dispose();
+            stream2.Dispose();
         }
 
         [Test]
@@ -1376,6 +1368,7 @@ namespace Yarhl.UnitTests.IO
             stream1.WriteByte(0x00);
             stream1.WriteByte(0xFF);
             Assert.Throws<ArgumentNullException>(() => stream1.Compare(null));
+            stream1.Dispose();
         }
 
         [Test]
@@ -1393,6 +1386,7 @@ namespace Yarhl.UnitTests.IO
             stream1.WriteByte(0xFF);
             stream2.Dispose();
             Assert.Throws<ObjectDisposedException>(() => stream1.Compare(stream2));
+            stream1.Dispose();
         }
 
         [Test]
@@ -1410,6 +1404,7 @@ namespace Yarhl.UnitTests.IO
             stream1.WriteByte(0xFF);
             stream1.Dispose();
             Assert.Throws<ObjectDisposedException>(() => stream1.Compare(stream2));
+            stream2.Dispose();
         }
 
         [Test]
@@ -1427,6 +1422,8 @@ namespace Yarhl.UnitTests.IO
             stream2.WriteByte(0xFF);
             stream1.Position = 1;
             Assert.IsTrue(stream1.Compare(stream2));
+            stream1.Dispose();
+            stream2.Dispose();
         }
 
         [Test]
@@ -1447,6 +1444,9 @@ namespace Yarhl.UnitTests.IO
             Assert.IsTrue(stream1.Compare(stream2));
             Assert.AreEqual(1, stream1.Position);
             Assert.AreEqual(2, stream2.Position);
+
+            stream1.Dispose();
+            stream2.Dispose();
         }
 
         [Test]
@@ -1465,6 +1465,9 @@ namespace Yarhl.UnitTests.IO
             stream1.BaseStream.Position = 1;
             stream2.BaseStream.Position = 2;
             Assert.IsTrue(stream1.Compare(stream2));
+
+            stream1.Dispose();
+            stream2.Dispose();
         }
 
         public class DummyBinaryConverter : IConverter<BinaryFormat, byte>

--- a/src/Yarhl.UnitTests/IO/StreamFormat/LazyFileStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/StreamFormat/LazyFileStreamTests.cs
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 namespace Yarhl.UnitTests.IO.StreamFormat
 {
+    using System;
     using System.IO;
     using NUnit.Framework;
     using Yarhl.IO;
@@ -138,6 +139,30 @@ namespace Yarhl.UnitTests.IO.StreamFormat
                 Assert.That(fs.ReadByte(), Is.EqualTo(0x42));
                 Assert.That(fs.ReadByte(), Is.EqualTo(0xBB));
             }
+        }
+
+        [Test]
+        public void PublicMethodThrowAfterDispose()
+        {
+            var stream = new LazyFileStream(tempFile, FileOpenMode.ReadWrite);
+            stream.Dispose();
+
+            byte[] buffer = new byte[1];
+            Assert.That(
+                () => stream.SetLength(10),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => stream.WriteByte(0x00),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => stream.Write(buffer, 0, 1),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => stream.ReadByte(),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => stream.Read(buffer, 0, 1),
+                Throws.InstanceOf<ObjectDisposedException>());
         }
     }
 }

--- a/src/Yarhl.UnitTests/IO/StreamFormat/LazyFileStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/StreamFormat/LazyFileStreamTests.cs
@@ -1,0 +1,143 @@
+// Copyright (c) 2019 SceneGate Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace Yarhl.UnitTests.IO.StreamFormat
+{
+    using System.IO;
+    using NUnit.Framework;
+    using Yarhl.IO;
+    using Yarhl.IO.StreamFormat;
+
+    [TestFixture]
+    public class LazyFileStreamTests
+    {
+        string tempFile;
+
+        [SetUp]
+        public void SetUp()
+        {
+            tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Assert.That(File.Exists(tempFile), Is.False);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            File.Delete(tempFile);
+        }
+
+        [Test]
+        public void ConstructorDoesNotOpenStream()
+        {
+            var stream = new LazyFileStream(tempFile, FileOpenMode.ReadWrite);
+            Assert.That(stream.BaseStream, Is.Null);
+        }
+
+        [Test]
+        public void ConstructorSetFileLengthOrZero()
+        {
+            var stream = new LazyFileStream(tempFile, FileOpenMode.ReadWrite);
+            Assert.That(stream.Length, Is.EqualTo(0));
+            Assert.That(stream.BaseStream, Is.Null);
+            Assert.That(File.Exists(tempFile), Is.False);
+
+            using (var fs = new FileStream(tempFile, FileMode.CreateNew)) {
+                fs.WriteByte(0xAA);
+            }
+
+            using (stream = new LazyFileStream(tempFile, FileOpenMode.ReadWrite)) {
+                Assert.That(stream.Length, Is.EqualTo(1));
+                Assert.That(stream.BaseStream, Is.Null);
+            }
+        }
+
+        [Test]
+        public void SetLengthOpensFile()
+        {
+            using (var stream = new LazyFileStream(tempFile, FileOpenMode.ReadWrite)) {
+                stream.SetLength(1);
+                Assert.That(stream.BaseStream, Is.Not.Null);
+                Assert.That(File.Exists(tempFile), Is.True);
+                Assert.That(stream.Length, Is.EqualTo(1));
+                Assert.That(stream.BaseStream.Length, Is.EqualTo(1));
+            }
+        }
+
+        [Test]
+        public void LengthSyncWithStream()
+        {
+            using (var stream = new LazyFileStream(tempFile, FileOpenMode.ReadWrite)) {
+                stream.SetLength(1);
+                Assert.That(stream.Length, Is.EqualTo(1));
+                stream.BaseStream.Position = 1;
+                stream.BaseStream.WriteByte(0xAA);
+                Assert.That(stream.Length, Is.EqualTo(2));
+            }
+        }
+
+        [Test]
+        public void ReadOpensFile()
+        {
+            using (var fs = new FileStream(tempFile, FileMode.CreateNew)) {
+                fs.WriteByte(0x42);
+                fs.WriteByte(0xAA);
+            }
+
+            using (var stream = new LazyFileStream(tempFile, FileOpenMode.Read)) {
+                Assert.That(stream.BaseStream, Is.Null);
+                Assert.That(stream.ReadByte(), Is.EqualTo(0x42));
+                Assert.That(stream.BaseStream, Is.Not.Null);
+            }
+
+            using (var stream = new LazyFileStream(tempFile, FileOpenMode.Read)) {
+                Assert.That(stream.BaseStream, Is.Null);
+                byte[] buffer = new byte[2];
+                stream.Read(buffer, 0, buffer.Length);
+                Assert.That(buffer[1], Is.EqualTo(0xAA));
+                Assert.That(stream.BaseStream, Is.Not.Null);
+            }
+        }
+
+        [Test]
+        public void WriteOpensFile()
+        {
+            using (var stream = new LazyFileStream(tempFile, FileOpenMode.Write)) {
+                Assert.That(stream.BaseStream, Is.Null);
+                stream.WriteByte(0x42);
+                Assert.That(stream.BaseStream, Is.Not.Null);
+            }
+
+            using (var fs = new FileStream(tempFile, FileMode.Open)) {
+                Assert.That(fs.ReadByte(), Is.EqualTo(0x42));
+            }
+
+            using (var stream = new LazyFileStream(tempFile, FileOpenMode.Append)) {
+                stream.Position = 1;
+                Assert.That(stream.BaseStream, Is.Null);
+                stream.Write(new byte[] { 0xAA, 0xBB }, 1, 1);
+                Assert.That(stream.BaseStream, Is.Not.Null);
+            }
+
+            using (var fs = new FileStream(tempFile, FileMode.Open)) {
+                Assert.That(fs.ReadByte(), Is.EqualTo(0x42));
+                Assert.That(fs.ReadByte(), Is.EqualTo(0xBB));
+            }
+        }
+    }
+}

--- a/src/Yarhl.UnitTests/IO/StreamFormat/RecyclableMemoryStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/StreamFormat/RecyclableMemoryStreamTests.cs
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 namespace Yarhl.UnitTests.IO.StreamFormat
 {
+    using System;
     using NUnit.Framework;
     using Yarhl.IO.StreamFormat;
 
@@ -79,6 +80,30 @@ namespace Yarhl.UnitTests.IO.StreamFormat
 
             Assert.That(stream.Length, Is.EqualTo(1));
             Assert.That(stream.Position, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void PublicMethodThrowAfterDispose()
+        {
+            var stream = new RecyclableMemoryStream();
+            stream.Dispose();
+
+            byte[] buffer = new byte[1];
+            Assert.That(
+                () => stream.SetLength(10),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => stream.WriteByte(0x00),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => stream.Write(buffer, 0, 1),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => stream.ReadByte(),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => stream.Read(buffer, 0, 1),
+                Throws.InstanceOf<ObjectDisposedException>());
         }
     }
 }

--- a/src/Yarhl.UnitTests/IO/StreamFormat/RecyclableMemoryStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/StreamFormat/RecyclableMemoryStreamTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) 2019 SceneGate Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace Yarhl.UnitTests.IO.StreamFormat
+{
+    using NUnit.Framework;
+    using Yarhl.IO.StreamFormat;
+
+    [TestFixture]
+    public class RecyclableMemoryStreamTests
+    {
+        [Test]
+        public void ConstructorCreatesAMemoryStream()
+        {
+            var stream = new RecyclableMemoryStream();
+            Assert.That(
+                stream.BaseStream,
+                Is.TypeOf<Microsoft.IO.RecyclableMemoryStream>());
+            stream.Dispose();
+        }
+
+        [Test]
+        public void CanIncreaseLength()
+        {
+            var stream = new RecyclableMemoryStream();
+            Assert.That(() => stream.SetLength(4), Throws.Nothing);
+            Assert.That(stream.Length, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void UpdatedLongBufferIsClean()
+        {
+            var stream = new RecyclableMemoryStream();
+            stream.WriteByte(0x42);
+            stream.SetLength(11);
+            Assert.That(stream.Length, Is.EqualTo(11));
+
+            stream.Position = 0;
+            Assert.That(stream.ReadByte(), Is.EqualTo(0x42));
+            for (int i = 0; i < 10; i++) {
+                Assert.That(stream.ReadByte(), Is.EqualTo(0));
+            }
+
+            stream.SetLength(80 * 1024);
+            stream.Position = 1;
+            for (int i = 1; i < stream.Length; i++) {
+                Assert.That(stream.ReadByte(), Is.EqualTo(0));
+            }
+
+            stream.Dispose();
+        }
+
+        [Test]
+        public void CanDecreaseLength()
+        {
+            var stream = new RecyclableMemoryStream();
+            stream.WriteByte(0xCA);
+            stream.WriteByte(0xFE);
+            Assert.That(stream.Length, Is.EqualTo(2));
+            Assert.That(stream.Position, Is.EqualTo(2));
+
+            stream.SetLength(1);
+
+            Assert.That(stream.Length, Is.EqualTo(1));
+            Assert.That(stream.Position, Is.EqualTo(1));
+        }
+    }
+}

--- a/src/Yarhl.UnitTests/IO/StreamFormat/StreamWrapperTests.cs
+++ b/src/Yarhl.UnitTests/IO/StreamFormat/StreamWrapperTests.cs
@@ -183,5 +183,30 @@ namespace Yarhl.UnitTests.IO.StreamFormat
             stream.Position = 1;
             Assert.That(stream.ReadByte(), Is.EqualTo(0x14));
         }
+
+        [Test]
+        public void PublicMethodThrowAfterDispose()
+        {
+            var stream = new MemoryStream();
+            var wrapper = new StreamWrapper(stream);
+            wrapper.Dispose();
+
+            byte[] buffer = new byte[1];
+            Assert.That(
+                () => wrapper.SetLength(10),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => wrapper.WriteByte(0x00),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => wrapper.Write(buffer, 0, 1),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => wrapper.ReadByte(),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => wrapper.Read(buffer, 0, 1),
+                Throws.InstanceOf<ObjectDisposedException>());
+        }
     }
 }

--- a/src/Yarhl.UnitTests/IO/StreamFormat/StreamWrapperTests.cs
+++ b/src/Yarhl.UnitTests/IO/StreamFormat/StreamWrapperTests.cs
@@ -1,0 +1,187 @@
+// Copyright (c) 2019 SceneGate Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace Yarhl.UnitTests.IO.StreamFormat
+{
+    using System;
+    using System.IO;
+    using NUnit.Framework;
+    using Yarhl.IO.StreamFormat;
+
+    [TestFixture]
+    public class StreamWrapperTests
+    {
+        [Test]
+        public void ConstructorSetProperties()
+        {
+            var stream = new MemoryStream();
+            var wrapper = new StreamWrapper(stream);
+            Assert.That(wrapper.BaseStream, Is.SameAs(stream));
+        }
+
+        [Test]
+        public void LengthGetterIsSyncWithStream()
+        {
+            var stream = new MemoryStream();
+            stream.WriteByte(0x11);
+            var wrapper = new StreamWrapper(stream);
+            Assert.That(wrapper.Length, Is.EqualTo(1));
+
+            stream.WriteByte(0xAA);
+            Assert.That(wrapper.Length, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void DiposeCloseStream()
+        {
+            var stream = new MemoryStream();
+            stream.WriteByte(0xAA);
+            var wrapper = new StreamWrapper(stream);
+
+            wrapper.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => stream.ReadByte());
+        }
+
+        [Test]
+        public void DisposeTwiceDoesNotThrowException()
+        {
+            var stream = new MemoryStream();
+            var wrapper = new StreamWrapper(stream);
+
+            wrapper.Dispose();
+            Assert.DoesNotThrow(wrapper.Dispose);
+        }
+
+        [Test]
+        public void DisposeChangesDisposed()
+        {
+            var stream = new MemoryStream();
+            var wrapper = new StreamWrapper(stream);
+            Assert.IsFalse(wrapper.Disposed);
+            wrapper.Dispose();
+            Assert.IsTrue(wrapper.Disposed);
+        }
+
+        [Test]
+        public void SetLengthChangesStreamLength()
+        {
+            var stream = new MemoryStream();
+            var wrapper = new StreamWrapper(stream);
+            Assert.That(wrapper.Length, Is.EqualTo(0));
+            Assert.That(stream.Length, Is.EqualTo(0));
+
+            wrapper.SetLength(10);
+
+            Assert.That(wrapper.Length, Is.EqualTo(10));
+            Assert.That(stream.Length, Is.EqualTo(10));
+        }
+
+        [Test]
+        public void ReadByteReadsAndAdvance()
+        {
+            var stream = new MemoryStream();
+            var wrapper = new StreamWrapper(stream);
+            stream.WriteByte(0x11);
+            stream.WriteByte(0x12);
+            stream.WriteByte(0x13);
+            Assert.That(wrapper.Position, Is.EqualTo(0));
+
+            Assert.That(wrapper.ReadByte(), Is.EqualTo(0x11));
+            Assert.That(wrapper.Position, Is.EqualTo(1));
+
+            wrapper.Position = 2;
+            Assert.That(wrapper.ReadByte(), Is.EqualTo(0x13));
+            Assert.That(wrapper.Position, Is.EqualTo(0x03));
+        }
+
+        [Test]
+        public void ReadArrayReadsAndAdvance()
+        {
+            var stream = new MemoryStream();
+            var wrapper = new StreamWrapper(stream);
+            stream.WriteByte(0x11);
+            stream.WriteByte(0x12);
+            stream.WriteByte(0x13);
+            stream.WriteByte(0x14);
+            Assert.That(wrapper.Position, Is.EqualTo(0));
+
+            byte[] buffer = new byte[10];
+            buffer[2] = 0xCA;
+            wrapper.Read(buffer, 0, 2);
+            Assert.That(buffer[0], Is.EqualTo(0x11));
+            Assert.That(buffer[1], Is.EqualTo(0x12));
+            Assert.That(buffer[2], Is.EqualTo(0xCA));
+            Assert.That(wrapper.Position, Is.EqualTo(2));
+
+            wrapper.Position = 3;
+            wrapper.Read(buffer, 9, 1);
+            Assert.That(buffer[9], Is.EqualTo(0x14));
+            Assert.That(buffer[0], Is.EqualTo(0x11));
+            Assert.That(wrapper.Position, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void WriteByteWritesAndAdvance()
+        {
+            var stream = new MemoryStream();
+            var wrapper = new StreamWrapper(stream);
+
+            wrapper.WriteByte(0x11);
+            Assert.That(wrapper.Position, Is.EqualTo(1));
+            stream.Position = 0;
+            Assert.That(stream.ReadByte(), Is.EqualTo(0x11));
+
+            wrapper.WriteByte(0x12);
+            Assert.That(wrapper.Position, Is.EqualTo(2));
+            stream.Position = 1;
+            Assert.That(stream.ReadByte(), Is.EqualTo(0x12));
+
+            wrapper.Position = 0;
+            wrapper.WriteByte(0x13);
+            Assert.That(wrapper.Position, Is.EqualTo(1));
+            stream.Position = 0;
+            Assert.That(stream.ReadByte(), Is.EqualTo(0x13));
+        }
+
+        [Test]
+        public void WriteArrayWritesAndAdvance()
+        {
+            var stream = new MemoryStream();
+            var wrapper = new StreamWrapper(stream);
+
+            byte[] buffer = new byte[] { 0x11, 0x12, 0x13, 0xFF, 0x14 };
+            wrapper.Write(buffer, 0, 2);
+            Assert.That(wrapper.Position, Is.EqualTo(2));
+            Assert.That(wrapper.Length, Is.EqualTo(2));
+            Assert.That(stream.Length, Is.EqualTo(2));
+            stream.Position = 0;
+            Assert.That(stream.ReadByte(), Is.EqualTo(0x11));
+            Assert.That(stream.ReadByte(), Is.EqualTo(0x12));
+
+            wrapper.Position = 1;
+            wrapper.Write(buffer, 4, 1);
+            Assert.That(wrapper.Position, Is.EqualTo(2));
+            Assert.That(wrapper.Length, Is.EqualTo(2));
+            Assert.That(stream.Length, Is.EqualTo(2));
+            stream.Position = 1;
+            Assert.That(stream.ReadByte(), Is.EqualTo(0x14));
+        }
+    }
+}

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -134,7 +134,8 @@ namespace Yarhl.FileSystem
         {
             // We need to catch if the node creation fails
             // for instance for null names, to dispose the stream.
-            var format = new BinaryFormat(filePath);
+            FileOpenMode mode = FileOpenMode.ReadWrite;
+            var format = new BinaryFormat(DataStreamFactory.FromFile(filePath, mode));
             Node node;
             try {
                 node = new Node(nodeName, format);

--- a/src/Yarhl/Gendarme.ignore
+++ b/src/Yarhl/Gendarme.ignore
@@ -26,6 +26,7 @@ R: Gendarme.Rules.Correctness.EnsureLocalDisposalRule
 M: Yarhl.FileSystem.Node Yarhl.FileSystem.NodeFactory::FromFile(System.String,System.String)
 M: Yarhl.FileSystem.Node Yarhl.FileSystem.NodeFactory::FromDirectory(System.String,System.String,System.String,System.Boolean)
 M: Yarhl.FileSystem.Node Yarhl.FileSystem.NodeFactory::FromSubstream(System.String,Yarhl.IO.DataStream,System.Int64,System.Int64)
+T: Yarhl.IO.DataStreamFactory
 # In the DataStream we are sure we will dispose the streams created in the ctor.
 M: System.Void Yarhl.IO.DataStream::.ctor()
 M: System.Void Yarhl.IO.DataStream::.ctor(System.String,Yarhl.IO.FileOpenMode)
@@ -43,9 +44,11 @@ R: Gendarme.Rules.Concurrency.ReviewLockUsedOnlyForOperationsOnVariablesRule
 M: System.Void Yarhl.PluginManager::Shutdown()
 
 R: Gendarme.Rules.Naming.UseCorrectSuffixRule
-# It doesn't inherit but internally use a Stream.
+# It is our implementation of Stream.
 T: Yarhl.IO.IStream
 T: Yarhl.IO.DataStream
+T: Yarhl.IO.StreamFormat.LazyFileStream
+T: Yarhl.IO.StreamFormat.RecyclableMemoryStream
 # Gendarme doesn't know about ReadOnlyCollection
 T: Yarhl.FileSystem.NavigableNodeCollection`1
 
@@ -59,10 +62,12 @@ T: Yarhl.IO.DataStream
 T: Yarhl.IO.DataWriter
 T: Yarhl.IO.TextReader
 T: Yarhl.IO.TextWriter
+T: Yarhl.IO.StreamFormat.LazyFileStream
 
 R: Gendarme.Rules.Maintainability.VariableNamesShouldNotMatchFieldNamesRule
 # I allow this to happen only for constructors
 T: Yarhl.IO.DataStream
+T: Yarhl.IO.StreamFormat.LazyFileStream
 
 R: Gendarme.Rules.Globalization.PreferIFormatProviderOverrideRule
 # It looks like a bug in Gendarme, we are adding a char to a string
@@ -86,5 +91,5 @@ T: Yarhl.FileSystem.Node
 R: Gendarme.Rules.Performance.AvoidUnneededFieldInitializationRule
 # Better be explicit in this case for clarity
 M: System.Void Yarhl.IO.DataStream::.ctor()
-M: System.Void Yarhl.IO.DataStream::.ctor(System.IO.Stream)
-M: System.Void Yarhl.IO.DataStream::.ctor(System.String,Yarhl.IO.FileOpenMode)
+M: System.Void Yarhl.IO.DataStream::.ctor(Yarhl.IO.IStream,System.Int64,System.Int64)
+M: System.Void Yarhl.IO.DataStream::.ctor(Yarhl.IO.DataStream,System.Int64,System.Int64)

--- a/src/Yarhl/IO/BinaryFormat.cs
+++ b/src/Yarhl/IO/BinaryFormat.cs
@@ -42,6 +42,21 @@ namespace Yarhl.IO
         /// <para>This format creates a substream from the provided stream.</para>
         /// </remarks>
         /// <param name="stream">Binary stream.</param>
+        public BinaryFormat(DataStream stream)
+        {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+
+            Stream = stream;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BinaryFormat"/> class.
+        /// </summary>
+        /// <remarks>
+        /// <para>This format creates a substream from the provided stream.</para>
+        /// </remarks>
+        /// <param name="stream">Binary stream.</param>
         /// <param name="offset">Offset from the DataStream start.</param>
         /// <param name="length">Length of the substream.</param>
         public BinaryFormat(DataStream stream, long offset, long length)
@@ -54,51 +69,6 @@ namespace Yarhl.IO
                 throw new ArgumentOutOfRangeException(nameof(length));
 
             Stream = new DataStream(stream, offset, length);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BinaryFormat"/> class.
-        /// </summary>
-        /// <remarks>
-        /// <para>This format creates a substream from the provided stream.</para>
-        /// </remarks>
-        /// <param name="stream">Binary stream.</param>
-        public BinaryFormat(DataStream stream)
-        {
-            if (stream == null)
-                throw new ArgumentNullException(nameof(stream));
-
-            Stream = new DataStream(stream, 0, stream.Length);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BinaryFormat" /> class.
-        /// </summary>
-        /// <param name="data">Stream data buffer.</param>
-        /// <param name="offset">Offset of the data in the buffer.</param>
-        /// <param name="length">Length of the data.</param>
-        public BinaryFormat(byte[] data, int offset, int length)
-        {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (offset < 0 || offset > data.Length)
-                throw new ArgumentOutOfRangeException(nameof(offset));
-            if (length < 0 || offset + length > data.Length)
-                throw new ArgumentOutOfRangeException(nameof(length));
-
-            Stream = new DataStream(data, offset, length);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BinaryFormat"/> class.
-        /// </summary>
-        /// <param name="filePath">The file path.</param>
-        public BinaryFormat(string filePath)
-        {
-            if (string.IsNullOrEmpty(filePath))
-                throw new ArgumentNullException(nameof(filePath));
-
-            Stream = new DataStream(filePath, FileOpenMode.ReadWrite);
         }
 
         /// <summary>

--- a/src/Yarhl/IO/DataReader.cs
+++ b/src/Yarhl/IO/DataReader.cs
@@ -43,7 +43,7 @@ namespace Yarhl.IO
         /// <para>By default the endianness is LittleEndian and
         /// the encoding is UTF-8.</para>
         /// </remarks>
-        public DataReader(IStream stream)
+        public DataReader(DataStream stream)
         {
             Stream = stream;
             Endianness = EndiannessMode.LittleEndian;
@@ -53,7 +53,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets the stream.
         /// </summary>
-        public IStream Stream {
+        public DataStream Stream {
             get;
             private set;
         }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -28,6 +28,7 @@ namespace Yarhl.IO
     using System.Collections.Generic;
     using System.IO;
     using Yarhl.FileFormat;
+    using Yarhl.IO.StreamFormat;
 
     /// <summary>
     /// Data stream.
@@ -35,52 +36,52 @@ namespace Yarhl.IO
     /// <remarks>
     /// <para>Custom implementation of a Stream based on System.IO.Stream.</para>
     /// </remarks>
-    public class DataStream : IStream, IDisposable
+    public class DataStream : IDisposable
     {
-        static readonly Dictionary<Stream, int> Instances = new Dictionary<Stream, int>();
+        static readonly Dictionary<IStream, int> Instances = new Dictionary<IStream, int>();
         readonly Stack<long> positionStack = new Stack<long>();
-        readonly bool isSubstream;
+        readonly bool canExpand;
         long position;
         long length;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DataStream"/> class.
-        /// A new stream is created in the memory.
+        /// A new stream is created in memory.
         /// </summary>
         public DataStream()
         {
-            BaseStream = new MemoryStream();
-            isSubstream = false;
+            BaseStream = new RecyclableMemoryStream();
+            canExpand = true;
             Offset = 0;
             this.length = 0;
 
-            IncreaseStreamCounter(BaseStream);
+            IncreaseStreamCounter();
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DataStream"/> class.
+        /// Initializes a new instance of the <see cref="DataStream" /> class.
         /// </summary>
         /// <param name="stream">Base stream.</param>
-        public DataStream(Stream stream)
+        public DataStream(IStream stream)
         {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
 
             BaseStream = stream;
-            isSubstream = false;
+            canExpand = true;
             Offset = 0;
             this.length = stream.Length;
 
-            IncreaseStreamCounter(stream);
+            IncreaseStreamCounter();
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DataStream"/> class.
+        /// Initializes a new instance of the <see cref="DataStream" /> class.
         /// </summary>
         /// <param name="stream">Base stream.</param>
         /// <param name="offset">Offset from the base stream.</param>
-        /// <param name="length">Length of this DataStream.</param>
-        public DataStream(Stream stream, long offset, long length)
+        /// <param name="length">Length of this substream.</param>
+        public DataStream(IStream stream, long offset, long length)
         {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
@@ -90,78 +91,11 @@ namespace Yarhl.IO
                 throw new ArgumentOutOfRangeException(nameof(length));
 
             BaseStream = stream;
-            isSubstream = true;
+            canExpand = false;
             Offset = offset;
             this.length = length;
 
-            IncreaseStreamCounter(stream);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DataStream" /> class.
-        /// </summary>
-        /// <param name="data">Stream data buffer.</param>
-        /// <param name="offset">Offset of the data in the buffer.</param>
-        /// <param name="length">Length of the data.</param>
-        public DataStream(byte[] data, int offset, int length)
-        {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (offset < 0 || offset > data.Length)
-                throw new ArgumentOutOfRangeException(nameof(offset));
-            if (length < 0 || offset + length > data.Length)
-                throw new ArgumentOutOfRangeException(nameof(length));
-
-            BaseStream = new MemoryStream(data, 0, data.Length);
-            isSubstream = true;
-            Offset = offset;
-            this.length = length;
-
-            IncreaseStreamCounter(BaseStream);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DataStream"/> class.
-        /// </summary>
-        /// <param name="filePath">File path.</param>
-        /// <param name="mode">File open mode.</param>
-        public DataStream(string filePath, FileOpenMode mode)
-        {
-            if (string.IsNullOrEmpty(filePath))
-                throw new ArgumentNullException(nameof(filePath));
-
-            BaseStream = new FileStream(filePath, mode.ToFileMode(), mode.ToFileAccess());
-            isSubstream = false;
-            Offset = 0;
-            this.length = BaseStream.Length;
-
-            IncreaseStreamCounter(BaseStream);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DataStream"/> class.
-        /// </summary>
-        /// <param name="filePath">File path.</param>
-        /// <param name="mode">File open mode.</param>
-        /// <param name="offset">Offset from the start of the file.</param>
-        /// <param name="length">Length of this DataStream.</param>
-        public DataStream(string filePath, FileOpenMode mode, long offset, long length)
-        {
-            if (string.IsNullOrEmpty(filePath))
-                throw new ArgumentNullException(nameof(filePath));
-
-            long fileSize = new FileInfo(filePath).Length;
-            if (offset < 0 || offset > fileSize)
-                throw new ArgumentOutOfRangeException(nameof(offset));
-            if (length < 0 || offset + length > fileSize)
-                throw new ArgumentOutOfRangeException(nameof(length));
-
-            BaseStream = new FileStream(filePath, mode.ToFileMode(), mode.ToFileAccess());
-            isSubstream = true;
-            Offset = offset;
-            this.length = length;
-
-            IncreaseStreamCounter(BaseStream);
+            IncreaseStreamCounter();
         }
 
         /// <summary>
@@ -169,7 +103,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Base stream.</param>
         /// <param name="offset">Offset from the DataStream start.</param>
-        /// <param name="length">Length of this DataStream.</param>
+        /// <param name="length">Length of this substream.</param>
         public DataStream(DataStream stream, long offset, long length)
         {
             if (stream == null)
@@ -181,11 +115,11 @@ namespace Yarhl.IO
 
             ParentDataStream = stream;
             BaseStream = stream.BaseStream;
-            isSubstream = true;
+            canExpand = false;
             Offset = stream.Offset + offset;
             this.length = length;
 
-            IncreaseStreamCounter(BaseStream);
+            IncreaseStreamCounter();
         }
 
         /// <summary>
@@ -238,13 +172,18 @@ namespace Yarhl.IO
             set {
                 if (Disposed)
                     throw new ObjectDisposedException(nameof(DataStream));
-                if (value < 0 || Offset + value > BaseStream.Length)
+                if (value < 0)
                     throw new ArgumentOutOfRangeException(nameof(value));
 
-                if (isSubstream) {
-                    throw new InvalidOperationException(
-                        "Offset is not 0. " +
-                        "Cannot change the size of sub-streams.");
+                if (value > length) {
+                    if (!canExpand) {
+                        throw new InvalidOperationException(
+                            "Cannot change the size of sub-streams.");
+                    } else if (value > BaseStream.Length) {
+                        // If we can expand, it's not a substream so forget
+                        // about offset (always 0). Increase base stream too.
+                        BaseStream.SetLength(value);
+                    }
                 }
 
                 length = value;
@@ -255,7 +194,8 @@ namespace Yarhl.IO
         }
 
         /// <summary>
-        /// Gets the parent DataStream.
+        /// Gets the parent DataStream only if this stream was initialized from
+        /// a DataStream.
         /// </summary>
         public DataStream ParentDataStream {
             get;
@@ -265,7 +205,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets the base stream.
         /// </summary>
-        public Stream BaseStream {
+        public IStream BaseStream {
             get;
             private set;
         }
@@ -384,7 +324,7 @@ namespace Yarhl.IO
         /// Reads the next byte.
         /// </summary>
         /// <returns>The next byte.</returns>
-        public virtual byte ReadByte()
+        public byte ReadByte()
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(DataStream));
@@ -404,7 +344,7 @@ namespace Yarhl.IO
         /// <param name="buffer">Buffer to copy data.</param>
         /// <param name="index">Index to start copying in buffer.</param>
         /// <param name="count">Number of bytes to read.</param>
-        public virtual int Read(byte[] buffer, int index, int count)
+        public int Read(byte[] buffer, int index, int count)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(DataStream));
@@ -447,10 +387,13 @@ namespace Yarhl.IO
         /// Writes a byte.
         /// </summary>
         /// <param name="data">Byte value.</param>
-        public virtual void WriteByte(byte data)
+        public void WriteByte(byte data)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(DataStream));
+
+            if (Position == Length && !canExpand)
+                throw new InvalidOperationException("Cannot expand stream");
 
             BaseStream.Position = AbsolutePosition;
             BaseStream.WriteByte(data);
@@ -468,7 +411,7 @@ namespace Yarhl.IO
         /// <param name="buffer">Buffer to write.</param>
         /// <param name="index">Index in the buffer.</param>
         /// <param name="count">Bytes to write.</param>
-        public virtual void Write(byte[] buffer, int index, int count)
+        public void Write(byte[] buffer, int index, int count)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(DataStream));
@@ -480,6 +423,9 @@ namespace Yarhl.IO
                 throw new ArgumentNullException(nameof(buffer));
             if (index + count > buffer.Length)
                 throw new ArgumentOutOfRangeException(nameof(index));
+
+            if (Position + count > Length && !canExpand)
+                throw new InvalidOperationException("Cannot expand stream");
 
             BaseStream.Position = AbsolutePosition;
             BaseStream.Write(buffer, index, count);
@@ -504,11 +450,13 @@ namespace Yarhl.IO
             // Parent dir can be empty if we just specified the file name.
             // In that case, the folder (cwd) already exists.
             string parentDir = Path.GetDirectoryName(fileOut);
-            if (!string.IsNullOrEmpty(parentDir))
+            if (!string.IsNullOrEmpty(parentDir)) {
                 Directory.CreateDirectory(parentDir);
+            }
 
-            using (var stream = new DataStream(fileOut, FileOpenMode.Write))
+            using (var stream = DataStreamFactory.FromFile(fileOut, FileOpenMode.Write)) {
                 WriteTo(stream);
+            }
         }
 
         /// <summary>
@@ -528,7 +476,7 @@ namespace Yarhl.IO
             long currPos = Position;
             Seek(0, SeekMode.Start);
 
-            const int BufferSize = 5 * 1024;
+            const int BufferSize = 70 * 1024;
             byte[] buffer = new byte[BufferSize];
 
             int written = 0;
@@ -615,12 +563,13 @@ namespace Yarhl.IO
             }
         }
 
-        private static void IncreaseStreamCounter(Stream stream)
+        private void IncreaseStreamCounter()
         {
-            if (!Instances.ContainsKey(stream))
-                Instances.Add(stream, 1);
-            else
-                Instances[stream] += 1;
+            if (!Instances.ContainsKey(BaseStream)) {
+                Instances.Add(BaseStream, 1);
+            } else {
+                Instances[BaseStream] += 1;
+            }
         }
     }
 }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -477,15 +477,16 @@ namespace Yarhl.IO
             Seek(0, SeekMode.Start);
 
             const int BufferSize = 70 * 1024;
-            byte[] buffer = new byte[BufferSize];
+            byte[] buffer = new byte[Length > BufferSize ? BufferSize : Length];
 
             int written = 0;
             int bytesToRead = 0;
             do {
-                if (written + BufferSize > Length)
+                if (written + buffer.Length > Length) {
                     bytesToRead = (int)(Length - written);
-                else
-                    bytesToRead = BufferSize;
+                } else {
+                    bytesToRead = buffer.Length;
+                }
 
                 written += Read(buffer, 0, bytesToRead);
                 stream.Write(buffer, 0, bytesToRead);
@@ -518,16 +519,22 @@ namespace Yarhl.IO
             otherStream.Seek(0, SeekMode.Start);
 
             const int BufferSize = 70 * 1024;
-            byte[] buffer1 = new byte[BufferSize];
-            byte[] buffer2 = new byte[BufferSize];
+            byte[] buffer1 = new byte[Length > BufferSize ? BufferSize : Length];
+            byte[] buffer2 = new byte[buffer1.Length];
 
             bool result = true;
             while (!EndOfStream && result) {
-                int length = (int)(Position + BufferSize > Length ? Length - Position : BufferSize);
-                Read(buffer1, 0, length);
-                otherStream.Read(buffer2, 0, length);
+                int loopLength;
+                if (Position + buffer1.Length > Length) {
+                    loopLength = (int)(Length - Position);
+                } else {
+                    loopLength = buffer1.Length;
+                }
 
-                for (int i = 0; i < length && result; i++) {
+                Read(buffer1, 0, loopLength);
+                otherStream.Read(buffer2, 0, loopLength);
+
+                for (int i = 0; i < loopLength && result; i++) {
                     if (buffer1[i] != buffer2[i]) {
                         result = false;
                     }

--- a/src/Yarhl/IO/DataStreamFactory.cs
+++ b/src/Yarhl/IO/DataStreamFactory.cs
@@ -1,0 +1,135 @@
+// Copyright (c) 2019 SceneGate Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace Yarhl.IO
+{
+    using System;
+    using System.IO;
+    using Yarhl.IO.StreamFormat;
+
+    /// <summary>
+    /// Factory of DataStream.
+    /// </summary>
+    public static class DataStreamFactory
+    {
+        /// <summary>
+        /// Creates a new <see cref="DataStream"/> from a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The stream to use as a base.</param>
+        /// <returns>A new <see cref="DataStream"/>.</returns>
+        public static DataStream FromStream(Stream stream)
+        {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+
+            var baseStream = new StreamWrapper(stream);
+            return new DataStream(baseStream);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="DataStream"/> from a section of a
+        /// <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The stream to use as a base.</param>
+        /// <param name="offset">Offset of the base stream.</param>
+        /// <param name="length">Length of the new substream.</param>
+        /// <returns>A new <see cref="DataStream"/>.</returns>
+        public static DataStream FromStream(Stream stream, long offset, long length)
+        {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+            if (offset < 0 || offset > stream.Length)
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            if (length < 0 || offset + length > stream.Length)
+                throw new ArgumentOutOfRangeException(nameof(length));
+
+            var baseStream = new StreamWrapper(stream);
+            return new DataStream(baseStream, offset, length);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="DataStream"/> in memory.
+        /// </summary>
+        /// <returns>A new <see cref="DataStream"/>.</returns>
+        public static DataStream FromMemory()
+        {
+            var baseStream = new RecyclableMemoryStream();
+            return new DataStream(baseStream);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="DataStream"/> from an array of data.
+        /// </summary>
+        /// <param name="data">The array of data to use in the stream.</param>
+        /// <param name="offset">Offset in the array of data.</param>
+        /// <param name="length">Length of the new stream.</param>
+        /// <returns>A new <see cref="DataStream"/>.</returns>
+        public static DataStream FromArray(byte[] data, int offset, int length)
+        {
+            if (data == null)
+                throw new ArgumentNullException(nameof(data));
+
+            if (offset < 0 || offset > data.Length)
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            if (length < 0 || offset + length > data.Length)
+                throw new ArgumentOutOfRangeException(nameof(length));
+
+            var baseStream = new StreamWrapper(new MemoryStream(data, 0, data.Length));
+            return new DataStream(baseStream, offset, length);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="DataStream"/> from a file.
+        /// </summary>
+        /// <param name="path">The path of the file.</param>
+        /// <param name="mode">The mode to open the file.</param>
+        /// <returns>A new <see cref="DataStream"/>.</returns>
+        public static DataStream FromFile(string path, FileOpenMode mode)
+        {
+            if (string.IsNullOrEmpty(path))
+                throw new ArgumentNullException(nameof(path));
+
+            var baseStream = new LazyFileStream(path, mode);
+            return new DataStream(baseStream);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="DataStream"/> from a section of a file.
+        /// </summary>
+        /// <param name="path">The path of the file.</param>
+        /// <param name="mode">The mode to open the file.</param>
+        /// <param name="offset">Offset from the start of the file.</param>
+        /// <param name="length">Length of the new stream.</param>
+        /// <returns>A new <see cref="DataStream"/>.</returns>
+        public static DataStream FromFile(string path, FileOpenMode mode, long offset, long length)
+        {
+            if (string.IsNullOrEmpty(path))
+                throw new ArgumentNullException(nameof(path));
+
+            long fileSize = new FileInfo(path).Length;
+            if (offset < 0 || offset > fileSize)
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            if (length < 0 || offset + length > fileSize)
+                throw new ArgumentOutOfRangeException(nameof(length));
+
+            var baseStream = new LazyFileStream(path, mode);
+            return new DataStream(baseStream, offset, length);
+        }
+    }
+}

--- a/src/Yarhl/IO/DataWriter.cs
+++ b/src/Yarhl/IO/DataWriter.cs
@@ -42,7 +42,7 @@ namespace Yarhl.IO
         /// <para>By default the endianess is LittleEndian and
         /// the encoding is UTF-8.</para>
         /// </remarks>
-        public DataWriter(IStream stream)
+        public DataWriter(DataStream stream)
         {
             Stream = stream;
             Endianness = EndiannessMode.LittleEndian;
@@ -53,7 +53,7 @@ namespace Yarhl.IO
         /// Gets the stream.
         /// </summary>
         /// <value>The stream.</value>
-        public IStream Stream {
+        public DataStream Stream {
             get;
             private set;
         }

--- a/src/Yarhl/IO/IStream.cs
+++ b/src/Yarhl/IO/IStream.cs
@@ -46,6 +46,9 @@ namespace Yarhl.IO
         /// Sets the length of the stream.
         /// </summary>
         /// <param name="length">The new length of the stream.</param>
+        /// <remarks>
+        /// Some streams may not implement or support changing the length.
+        /// </remarks>
         void SetLength(long length);
 
         /// <summary>

--- a/src/Yarhl/IO/IStream.cs
+++ b/src/Yarhl/IO/IStream.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Benito Palacios Sánchez
+// Copyright (c) 2019 SceneGate Team
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,15 +19,17 @@
 // THE SOFTWARE.
 namespace Yarhl.IO
 {
+    using System;
+
     /// <summary>
     /// Generic data stream interface.
     /// </summary>
-    public interface IStream
+    public interface IStream : IDisposable
     {
         /// <summary>
-        /// Gets the position from the start of this stream.
+        /// Gets or sets the position from the start of this stream.
         /// </summary>
-        long Position { get; }
+        long Position { get; set; }
 
         /// <summary>
         /// Gets the length of this stream.
@@ -35,16 +37,16 @@ namespace Yarhl.IO
         long Length { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the position is at end of the stream.
+        /// Gets a value indicating whether this <see cref="IStream" />
+        /// has been dispsosed.
         /// </summary>
-        bool EndOfStream { get; }
+        bool Disposed { get; }
 
         /// <summary>
-        /// Move the position of the Stream.
+        /// Sets the length of the stream.
         /// </summary>
-        /// <param name="shift">Distance to move position.</param>
-        /// <param name="mode">Mode to move position.</param>
-        void Seek(long shift, SeekMode mode);
+        /// <param name="length">The new length of the stream.</param>
+        void SetLength(long length);
 
         /// <summary>
         /// Reads the next byte.

--- a/src/Yarhl/IO/StreamFormat/LazyFileStream.cs
+++ b/src/Yarhl/IO/StreamFormat/LazyFileStream.cs
@@ -21,7 +21,10 @@ namespace Yarhl.IO.StreamFormat
 {
     using System.IO;
 
-    internal sealed class LazyFileStream : StreamWrapper
+    /// <summary>
+    /// Open file for reading or writing on the first operation (lazily).
+    /// </summary>
+    sealed class LazyFileStream : StreamWrapper
     {
         readonly string path;
         readonly FileOpenMode mode;
@@ -29,6 +32,11 @@ namespace Yarhl.IO.StreamFormat
 
         bool isInitialized;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LazyFileStream"/> class.
+        /// </summary>
+        /// <param name="path">Path to the file.</param>
+        /// <param name="mode">Mode to open the file.</param>
         public LazyFileStream(string path, FileOpenMode mode)
         {
             this.path = path;
@@ -40,8 +48,15 @@ namespace Yarhl.IO.StreamFormat
             initialLength = info.Exists ? info.Length : 0;
         }
 
+        /// <summary>
+        /// Gets the length of this stream.
+        /// </summary>
         public override long Length => BaseStream?.Length ?? initialLength;
 
+        /// <summary>
+        /// Sets the length of the stream.
+        /// </summary>
+        /// <param name="length">The new length of the stream.</param>
         public override void SetLength(long length)
         {
             if (!isInitialized) {
@@ -51,6 +66,13 @@ namespace Yarhl.IO.StreamFormat
             base.SetLength(length);
         }
 
+        /// <summary>
+        /// Reads from the stream to the buffer.
+        /// </summary>
+        /// <returns>The number of bytes read.</returns>
+        /// <param name="buffer">Buffer to copy data.</param>
+        /// <param name="index">Index to start copying in buffer.</param>
+        /// <param name="count">Number of bytes to read.</param>
         public override int Read(byte[] buffer, int index, int count)
         {
             if (!isInitialized) {
@@ -60,6 +82,10 @@ namespace Yarhl.IO.StreamFormat
             return base.Read(buffer, index, count);
         }
 
+        /// <summary>
+        /// Reads the next byte.
+        /// </summary>
+        /// <returns>The next byte.</returns>
         public override byte ReadByte()
         {
             if (!isInitialized) {
@@ -69,6 +95,12 @@ namespace Yarhl.IO.StreamFormat
             return base.ReadByte();
         }
 
+        /// <summary>
+        /// Writes the a portion of the buffer to the stream.
+        /// </summary>
+        /// <param name="buffer">Buffer to write.</param>
+        /// <param name="index">Index in the buffer.</param>
+        /// <param name="count">Bytes to write.</param>
         public override void Write(byte[] buffer, int index, int count)
         {
             if (!isInitialized) {
@@ -78,6 +110,10 @@ namespace Yarhl.IO.StreamFormat
             base.Write(buffer, index, count);
         }
 
+        /// <summary>
+        /// Writes a byte.
+        /// </summary>
+        /// <param name="data">Byte value.</param>
         public override void WriteByte(byte data)
         {
             if (!isInitialized) {

--- a/src/Yarhl/IO/StreamFormat/LazyFileStream.cs
+++ b/src/Yarhl/IO/StreamFormat/LazyFileStream.cs
@@ -1,0 +1,96 @@
+// Copyright (c) 2019 SceneGate Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace Yarhl.IO.StreamFormat
+{
+    using System.IO;
+
+    internal sealed class LazyFileStream : StreamWrapper
+    {
+        readonly string path;
+        readonly FileOpenMode mode;
+        readonly long initialLength;
+
+        bool isInitialized;
+
+        public LazyFileStream(string path, FileOpenMode mode)
+        {
+            this.path = path;
+            this.mode = mode;
+
+            // Before the stream is initialized, we can get the
+            // length so we can report it wihthout opening the file.
+            var info = new FileInfo(path);
+            initialLength = info.Exists ? info.Length : 0;
+        }
+
+        public override long Length => BaseStream?.Length ?? initialLength;
+
+        public override void SetLength(long length)
+        {
+            if (!isInitialized) {
+                Initialize();
+            }
+
+            base.SetLength(length);
+        }
+
+        public override int Read(byte[] buffer, int index, int count)
+        {
+            if (!isInitialized) {
+                Initialize();
+            }
+
+            return base.Read(buffer, index, count);
+        }
+
+        public override byte ReadByte()
+        {
+            if (!isInitialized) {
+                Initialize();
+            }
+
+            return base.ReadByte();
+        }
+
+        public override void Write(byte[] buffer, int index, int count)
+        {
+            if (!isInitialized) {
+                Initialize();
+            }
+
+            base.Write(buffer, index, count);
+        }
+
+        public override void WriteByte(byte data)
+        {
+            if (!isInitialized) {
+                Initialize();
+            }
+
+            base.WriteByte(data);
+        }
+
+        void Initialize()
+        {
+            isInitialized = true;
+            BaseStream = new FileStream(path, mode.ToFileMode(), mode.ToFileAccess());
+        }
+    }
+}

--- a/src/Yarhl/IO/StreamFormat/LazyFileStream.cs
+++ b/src/Yarhl/IO/StreamFormat/LazyFileStream.cs
@@ -24,7 +24,7 @@ namespace Yarhl.IO.StreamFormat
     /// <summary>
     /// Open file for reading or writing on the first operation (lazily).
     /// </summary>
-    sealed class LazyFileStream : StreamWrapper
+    public sealed class LazyFileStream : StreamWrapper
     {
         readonly string path;
         readonly FileOpenMode mode;

--- a/src/Yarhl/IO/StreamFormat/LazyFileStream.cs
+++ b/src/Yarhl/IO/StreamFormat/LazyFileStream.cs
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 namespace Yarhl.IO.StreamFormat
 {
+    using System;
     using System.IO;
 
     /// <summary>
@@ -59,6 +60,9 @@ namespace Yarhl.IO.StreamFormat
         /// <param name="length">The new length of the stream.</param>
         public override void SetLength(long length)
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(LazyFileStream));
+
             if (!isInitialized) {
                 Initialize();
             }
@@ -75,6 +79,9 @@ namespace Yarhl.IO.StreamFormat
         /// <param name="count">Number of bytes to read.</param>
         public override int Read(byte[] buffer, int index, int count)
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(LazyFileStream));
+
             if (!isInitialized) {
                 Initialize();
             }
@@ -88,6 +95,9 @@ namespace Yarhl.IO.StreamFormat
         /// <returns>The next byte.</returns>
         public override byte ReadByte()
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(LazyFileStream));
+
             if (!isInitialized) {
                 Initialize();
             }
@@ -103,6 +113,9 @@ namespace Yarhl.IO.StreamFormat
         /// <param name="count">Bytes to write.</param>
         public override void Write(byte[] buffer, int index, int count)
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(LazyFileStream));
+
             if (!isInitialized) {
                 Initialize();
             }
@@ -116,6 +129,9 @@ namespace Yarhl.IO.StreamFormat
         /// <param name="data">Byte value.</param>
         public override void WriteByte(byte data)
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(LazyFileStream));
+
             if (!isInitialized) {
                 Initialize();
             }

--- a/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
+++ b/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
@@ -21,21 +21,34 @@ namespace Yarhl.IO.StreamFormat
 {
     using Microsoft.IO;
 
-    internal sealed class RecyclableMemoryStream : StreamWrapper
+    /// <summary>
+    /// In-memory stream with a pool of buffers.
+    /// </summary>
+    sealed class RecyclableMemoryStream : StreamWrapper
     {
         static readonly RecyclableMemoryStreamManager Manager = CreateManager();
 
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="RecyclableMemoryStream"/> class.
+        /// </summary>
         public RecyclableMemoryStream()
             : base(Manager.GetStream())
         {
         }
 
+        /// <summary>
+        /// Sets the length of the stream.
+        /// </summary>
+        /// <param name="length">The new length of the stream.</param>
         public override void SetLength(long length)
         {
             long oldLength = Length;
             int additionalLength = (int)(length - oldLength);
             base.SetLength(length);
 
+            // Since we are reusing buffers from a pool, it's not guarantee
+            // that requesting more space will return a clean buffer.
             if (additionalLength > 0) {
                 long oldPos = Position;
                 Position = oldLength;

--- a/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
+++ b/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
@@ -45,7 +45,7 @@ namespace Yarhl.IO.StreamFormat
         public override void SetLength(long length)
         {
             if (Disposed)
-                throw new ObjectDisposedException(nameof(LazyFileStream));
+                throw new ObjectDisposedException(nameof(RecyclableMemoryStream));
 
             long oldLength = Length;
             int additionalLength = (int)(length - oldLength);

--- a/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
+++ b/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 namespace Yarhl.IO.StreamFormat
 {
+    using System;
     using Microsoft.IO;
 
     /// <summary>
@@ -43,6 +44,9 @@ namespace Yarhl.IO.StreamFormat
         /// <param name="length">The new length of the stream.</param>
         public override void SetLength(long length)
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(LazyFileStream));
+
             long oldLength = Length;
             int additionalLength = (int)(length - oldLength);
             base.SetLength(length);
@@ -53,8 +57,8 @@ namespace Yarhl.IO.StreamFormat
                 ClearBuffer(oldLength, additionalLength);
             }
 
-            if (Position > Length) {
-                Position = Length;
+            if (Position > length) {
+                Position = length;
             }
         }
 

--- a/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
+++ b/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2019 SceneGate Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace Yarhl.IO.StreamFormat
+{
+    using Microsoft.IO;
+
+    internal sealed class RecyclableMemoryStream : StreamWrapper
+    {
+        static readonly RecyclableMemoryStreamManager Manager = CreateManager();
+
+        public RecyclableMemoryStream()
+            : base(Manager.GetStream())
+        {
+        }
+
+        public override void SetLength(long length)
+        {
+            long oldLength = Length;
+            int additionalLength = (int)(length - oldLength);
+            base.SetLength(length);
+
+            if (additionalLength > 0) {
+                long oldPos = Position;
+                Position = oldLength;
+
+                // TODO: Write in blocks
+                byte[] clearData = new byte[additionalLength];
+                Write(clearData, 0, additionalLength);
+
+                Position = oldPos;
+            }
+        }
+
+        static RecyclableMemoryStreamManager CreateManager()
+        {
+            return new RecyclableMemoryStreamManager();
+        }
+    }
+}

--- a/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
+++ b/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
@@ -24,7 +24,7 @@ namespace Yarhl.IO.StreamFormat
     /// <summary>
     /// In-memory stream with a pool of buffers.
     /// </summary>
-    sealed class RecyclableMemoryStream : StreamWrapper
+    public sealed class RecyclableMemoryStream : StreamWrapper
     {
         static readonly RecyclableMemoryStreamManager Manager = CreateManager();
 

--- a/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
+++ b/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
@@ -25,7 +25,7 @@ namespace Yarhl.IO.StreamFormat
     /// <summary>
     /// Wrapper over .NET streams.
     /// </summary>
-    class StreamWrapper : IStream
+    public class StreamWrapper : IStream
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="StreamWrapper" /> class.

--- a/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
+++ b/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
@@ -79,6 +79,9 @@ namespace Yarhl.IO.StreamFormat
         /// <param name="length">The new length of the stream.</param>
         public virtual void SetLength(long length)
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(LazyFileStream));
+
             BaseStream.SetLength(length);
         }
 
@@ -91,6 +94,9 @@ namespace Yarhl.IO.StreamFormat
         /// <param name="count">Number of bytes to read.</param>
         public virtual int Read(byte[] buffer, int index, int count)
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(LazyFileStream));
+
             BaseStream.Position = Position;
             Position += count;
             return BaseStream.Read(buffer, index, count);
@@ -102,6 +108,9 @@ namespace Yarhl.IO.StreamFormat
         /// <returns>The next byte.</returns>
         public virtual byte ReadByte()
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(LazyFileStream));
+
             BaseStream.Position = Position;
             Position++;
             return (byte)BaseStream.ReadByte();
@@ -115,6 +124,9 @@ namespace Yarhl.IO.StreamFormat
         /// <param name="count">Bytes to write.</param>
         public virtual void Write(byte[] buffer, int index, int count)
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(LazyFileStream));
+
             BaseStream.Position = Position;
             BaseStream.Write(buffer, index, count);
             Position += count;
@@ -126,6 +138,9 @@ namespace Yarhl.IO.StreamFormat
         /// <param name="data">Byte value.</param>
         public virtual void WriteByte(byte data)
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(LazyFileStream));
+
             BaseStream.Position = Position;
             BaseStream.WriteByte(data);
             Position++;

--- a/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
+++ b/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
@@ -80,7 +80,7 @@ namespace Yarhl.IO.StreamFormat
         public virtual void SetLength(long length)
         {
             if (Disposed)
-                throw new ObjectDisposedException(nameof(LazyFileStream));
+                throw new ObjectDisposedException(nameof(StreamWrapper));
 
             BaseStream.SetLength(length);
         }
@@ -95,7 +95,7 @@ namespace Yarhl.IO.StreamFormat
         public virtual int Read(byte[] buffer, int index, int count)
         {
             if (Disposed)
-                throw new ObjectDisposedException(nameof(LazyFileStream));
+                throw new ObjectDisposedException(nameof(StreamWrapper));
 
             BaseStream.Position = Position;
             Position += count;
@@ -109,7 +109,7 @@ namespace Yarhl.IO.StreamFormat
         public virtual byte ReadByte()
         {
             if (Disposed)
-                throw new ObjectDisposedException(nameof(LazyFileStream));
+                throw new ObjectDisposedException(nameof(StreamWrapper));
 
             BaseStream.Position = Position;
             Position++;
@@ -125,7 +125,7 @@ namespace Yarhl.IO.StreamFormat
         public virtual void Write(byte[] buffer, int index, int count)
         {
             if (Disposed)
-                throw new ObjectDisposedException(nameof(LazyFileStream));
+                throw new ObjectDisposedException(nameof(StreamWrapper));
 
             BaseStream.Position = Position;
             BaseStream.Write(buffer, index, count);
@@ -139,7 +139,7 @@ namespace Yarhl.IO.StreamFormat
         public virtual void WriteByte(byte data)
         {
             if (Disposed)
-                throw new ObjectDisposedException(nameof(LazyFileStream));
+                throw new ObjectDisposedException(nameof(StreamWrapper));
 
             BaseStream.Position = Position;
             BaseStream.WriteByte(data);

--- a/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
+++ b/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
@@ -1,0 +1,104 @@
+// Copyright (c) 2019 SceneGate Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace Yarhl.IO.StreamFormat
+{
+    using System;
+    using System.IO;
+
+    internal class StreamWrapper : IStream
+    {
+        public StreamWrapper(Stream stream)
+        {
+            BaseStream = stream;
+        }
+
+        protected StreamWrapper()
+        {
+        }
+
+        public Stream BaseStream {
+            get;
+            protected set;
+        }
+
+        public long Position {
+            get;
+            set;
+        }
+
+        public virtual long Length => BaseStream.Length;
+
+        public bool Disposed {
+            get;
+            private set;
+        }
+
+        public virtual void SetLength(long length)
+        {
+            BaseStream.SetLength(length);
+        }
+
+        public virtual int Read(byte[] buffer, int index, int count)
+        {
+            BaseStream.Position = Position;
+            Position += count;
+            return BaseStream.Read(buffer, index, count);
+        }
+
+        public virtual byte ReadByte()
+        {
+            BaseStream.Position = Position;
+            Position++;
+            return (byte)BaseStream.ReadByte();
+        }
+
+        public virtual void Write(byte[] buffer, int index, int count)
+        {
+            BaseStream.Position = Position;
+            BaseStream.Write(buffer, index, count);
+            Position += count;
+        }
+
+        public virtual void WriteByte(byte data)
+        {
+            BaseStream.Position = Position;
+            BaseStream.WriteByte(data);
+            Position++;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool freeManaged)
+        {
+            if (Disposed) {
+                return;
+            }
+
+            Disposed = true;
+            if (freeManaged) {
+                BaseStream?.Dispose();
+            }
+        }
+    }
+}

--- a/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
+++ b/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
@@ -22,39 +22,73 @@ namespace Yarhl.IO.StreamFormat
     using System;
     using System.IO;
 
-    internal class StreamWrapper : IStream
+    /// <summary>
+    /// Wrapper over .NET streams.
+    /// </summary>
+    class StreamWrapper : IStream
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamWrapper" /> class.
+        /// </summary>
+        /// <param name="stream">The stream to wrap.</param>
         public StreamWrapper(Stream stream)
         {
             BaseStream = stream;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamWrapper" /> class.
+        /// </summary>
         protected StreamWrapper()
         {
         }
 
+        /// <summary>
+        /// Gets or sets the base stream.
+        /// </summary>
         public Stream BaseStream {
             get;
             protected set;
         }
 
+        /// <summary>
+        /// Gets or sets the position from the start of this stream.
+        /// </summary>
         public long Position {
             get;
             set;
         }
 
+        /// <summary>
+        /// Gets the length of this stream.
+        /// </summary>
         public virtual long Length => BaseStream.Length;
 
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="IStream" />
+        /// has been dispsosed.
+        /// </summary>
         public bool Disposed {
             get;
             private set;
         }
 
+        /// <summary>
+        /// Sets the length of the stream.
+        /// </summary>
+        /// <param name="length">The new length of the stream.</param>
         public virtual void SetLength(long length)
         {
             BaseStream.SetLength(length);
         }
 
+        /// <summary>
+        /// Reads from the stream to the buffer.
+        /// </summary>
+        /// <returns>The number of bytes read.</returns>
+        /// <param name="buffer">Buffer to copy data.</param>
+        /// <param name="index">Index to start copying in buffer.</param>
+        /// <param name="count">Number of bytes to read.</param>
         public virtual int Read(byte[] buffer, int index, int count)
         {
             BaseStream.Position = Position;
@@ -62,6 +96,10 @@ namespace Yarhl.IO.StreamFormat
             return BaseStream.Read(buffer, index, count);
         }
 
+        /// <summary>
+        /// Reads the next byte.
+        /// </summary>
+        /// <returns>The next byte.</returns>
         public virtual byte ReadByte()
         {
             BaseStream.Position = Position;
@@ -69,6 +107,12 @@ namespace Yarhl.IO.StreamFormat
             return (byte)BaseStream.ReadByte();
         }
 
+        /// <summary>
+        /// Writes the a portion of the buffer to the stream.
+        /// </summary>
+        /// <param name="buffer">Buffer to write.</param>
+        /// <param name="index">Index in the buffer.</param>
+        /// <param name="count">Bytes to write.</param>
         public virtual void Write(byte[] buffer, int index, int count)
         {
             BaseStream.Position = Position;
@@ -76,6 +120,10 @@ namespace Yarhl.IO.StreamFormat
             Position += count;
         }
 
+        /// <summary>
+        /// Writes a byte.
+        /// </summary>
+        /// <param name="data">Byte value.</param>
         public virtual void WriteByte(byte data)
         {
             BaseStream.Position = Position;
@@ -83,12 +131,21 @@ namespace Yarhl.IO.StreamFormat
             Position++;
         }
 
+        /// <summary>
+        /// Releases all resource used by the <see cref="StreamWrapper"/> object.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Releases all resource used by the <see cref="StreamWrapper"/>
+        /// object.
+        /// </summary>
+        /// <param name="freeManaged">If set to
+        /// <see langword="true" /> free managed resources also.</param>
         protected virtual void Dispose(bool freeManaged)
         {
             if (Disposed) {

--- a/src/Yarhl/IO/TextReader.cs
+++ b/src/Yarhl/IO/TextReader.cs
@@ -43,7 +43,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to read from.</param>
         /// <remarks><para>The default encoding is UTF-8.</para></remarks>
-        public TextReader(IStream stream)
+        public TextReader(DataStream stream)
             : this(stream, Encoding.UTF8)
         {
         }
@@ -53,7 +53,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to read from.</param>
         /// <param name="encoding">Encoding to use.</param>
-        public TextReader(IStream stream, Encoding encoding)
+        public TextReader(DataStream stream, Encoding encoding)
         {
             Stream = stream ?? throw new ArgumentNullException(nameof(stream));
             Encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
@@ -68,7 +68,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets the stream.
         /// </summary>
-        public IStream Stream {
+        public DataStream Stream {
             get;
             private set;
         }

--- a/src/Yarhl/IO/TextWriter.cs
+++ b/src/Yarhl/IO/TextWriter.cs
@@ -41,7 +41,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to write to.</param>
         /// <remarks><para>The default encoding is UTF-8.</para></remarks>
-        public TextWriter(IStream stream)
+        public TextWriter(DataStream stream)
             : this(stream, Encoding.UTF8)
         {
         }
@@ -51,7 +51,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to write to.</param>
         /// <param name="encoding">Encoding to use.</param>
-        public TextWriter(IStream stream, Encoding encoding)
+        public TextWriter(DataStream stream, Encoding encoding)
         {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
@@ -70,7 +70,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets the stream.
         /// </summary>
-        public IStream Stream {
+        public DataStream Stream {
             get;
             private set;
         }

--- a/src/Yarhl/Yarhl.csproj
+++ b/src/Yarhl/Yarhl.csproj
@@ -21,6 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
### Description
Improve extensibility of `DataStream` by creating a custom wrapper with the interface `IStream`. In this way, we can always use all the features of `DataStream` and it will handle a `IStream` instead of old `Stream`. This fixes problems like having many unrelated constructors to create different `Stream` types, allow to implement easily lazy `FileSteram` or a easy replacement for `MemoryStream`.

It adds a factory to move out most of the constructors from `DataStream`, so it's easier to extend.

### Example
The new `DataStream` factory allows to create:
* Memory streams: using a recyclable buffer pool, so it's more memory-friendly.
* Lazy file streams: the file is only opened on the first read/write operation. So we avoid the common problem trying to conver a full folder and subfolder to nodes.
* Regular .NET `Stream` wrapper.
* Array stream: using the common `MemoryStream` class so changes affect the underlying array.

```cs
public static class DataStreamFactory
{
    public static DataStream FromArray(byte[] data, int offset, int length);
    public static DataStream FromFile(string path, FileOpenMode mode);
    public static DataStream FromFile(string path, FileOpenMode mode, long offset, long length);
    public static DataStream FromMemory();
    public static DataStream FromStream(Stream stream);
    public static DataStream FromStream(Stream stream, long offset, long length);
}
```

The new classes `LazyFileStream`, `RecyclableMemoryStream` and `StreamWrapper` are not expected to be used by the developers. Only in special-advanced cases where the `IStream` needs to be implemented or when the `IStream` needs to be wrapped or created. The factory will create the actual implementations.

`DataStream` should be created from `DataStreamFactory` or with the default constructor as an alias to `DataStreamFactory.FromMemory()`.

Another _breaking_ change is that now `BinaryFormat` does not create an internal `DataStream` so it will dispose the stream passed in the constructor. This improves how it needs to be created (no need of the single using line).

### Other small changes
* Update Cake dependencies
* Fix detection when an array can be expanded or not
* Reduce the read buffers when the stream length is smaller than 70KB.