### PR TITLE
Fix writing large files

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -219,6 +219,7 @@ public void TestWithAltCover(string projectPath, string assembly, string outputX
         InputDirectories = new[] { inputDir },
         OutputDirectories = new[] { outputDir },
         AssemblyFilter = new[] { "nunit.framework", "NUnit3" },
+        AttributeFilter = new[] { "ExcludeFromCodeCoverage" },
         TypeFilter = new[] { "Yarhl.AssemblyUtils" },
         XmlReport = outputXml,
         OpenCover = true

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -25,6 +25,7 @@
 namespace Yarhl.UnitTests.IO
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using NUnit.Framework;
     using Yarhl.FileFormat;
@@ -1217,8 +1218,9 @@ namespace Yarhl.UnitTests.IO
             File.Delete(tempFile);
         }
 
-        [Ignore("Generates 6 GB of files and takes a lot of time (~1 min)")]
         [Test]
+        [Ignore("Generates 6 GB of files and takes a lot of time (~1 min)")]
+        [ExcludeFromCodeCoverage]
         public void WriteToLargeFiles()
         {
             const long Size = 3L * 1024 * 1024 * 1024; // 3 GB

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1217,6 +1217,44 @@ namespace Yarhl.UnitTests.IO
             File.Delete(tempFile);
         }
 
+        [Ignore("Generates 6 GB of files and takes a lot of time (~1 min)")]
+        [Test]
+        public void WriteToLargeFiles()
+        {
+            const long Size = 3L * 1024 * 1024 * 1024; // 3 GB
+            string inputFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            string outputFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+            DataStream inputStream = null;
+            DataStream outputStream = null;
+            try {
+                inputStream = DataStreamFactory.FromFile(inputFile, FileOpenMode.ReadWrite);
+                byte[] buffer = new byte[70 * 1024]; // 70 KB (SOH)
+                for (int i = 0; i < buffer.Length; i++) {
+                    buffer[i] = (byte)(i % 256);
+                }
+
+                long written = 0;
+                while (written < Size) {
+                    int count = (Size - written) > buffer.Length
+                        ? buffer.Length
+                        : (int)(Size - written);
+                    inputStream.Write(buffer, 0, count);
+                    written += count;
+                }
+
+                inputStream.WriteTo(outputFile);
+
+                outputStream = DataStreamFactory.FromFile(outputFile, FileOpenMode.Read);
+                Assert.IsTrue(inputStream.Compare(outputStream));
+            } finally {
+                inputStream?.Dispose();
+                outputStream?.Dispose();
+                File.Delete(inputFile);
+                File.Delete(outputFile);
+            }
+        }
+
         [Test]
         public void WriteToFileCreatesParentFolder()
         {

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -334,7 +334,7 @@ namespace Yarhl.IO
 
             BaseStream.Position = AbsolutePosition;
             Position++;
-            return (byte)BaseStream.ReadByte();
+            return BaseStream.ReadByte();
         }
 
         /// <summary>
@@ -479,18 +479,10 @@ namespace Yarhl.IO
             const int BufferSize = 70 * 1024;
             byte[] buffer = new byte[Length > BufferSize ? BufferSize : Length];
 
-            long written = 0;
-            int bytesToRead = 0;
-            do {
-                if (written + buffer.Length > Length) {
-                    bytesToRead = (int)(Length - written);
-                } else {
-                    bytesToRead = buffer.Length;
-                }
-
-                written += Read(buffer, 0, bytesToRead);
-                stream.Write(buffer, 0, bytesToRead);
-            } while (written != Length);
+            while (!EndOfStream) {
+                int read = BlockRead(this, buffer);
+                stream.Write(buffer, 0, read);
+            }
 
             Seek(currPos, SeekMode.Start);
         }
@@ -524,15 +516,8 @@ namespace Yarhl.IO
 
             bool result = true;
             while (!EndOfStream && result) {
-                int loopLength;
-                if (Position + buffer1.Length > Length) {
-                    loopLength = (int)(Length - Position);
-                } else {
-                    loopLength = buffer1.Length;
-                }
-
-                Read(buffer1, 0, loopLength);
-                otherStream.Read(buffer2, 0, loopLength);
+                int loopLength = BlockRead(this, buffer1);
+                BlockRead(otherStream, buffer2);
 
                 for (int i = 0; i < loopLength && result; i++) {
                     if (buffer1[i] != buffer2[i]) {
@@ -568,6 +553,19 @@ namespace Yarhl.IO
                     Instances.Remove(BaseStream);
                 }
             }
+        }
+
+        private static int BlockRead(DataStream stream, byte[] buffer)
+        {
+            int read;
+            if (stream.Position + buffer.Length > stream.Length) {
+                read = (int)(stream.Length - stream.Position);
+            } else {
+                read = buffer.Length;
+            }
+
+            stream.Read(buffer, 0, read);
+            return read;
         }
 
         private void IncreaseStreamCounter()

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -479,7 +479,7 @@ namespace Yarhl.IO
             const int BufferSize = 70 * 1024;
             byte[] buffer = new byte[Length > BufferSize ? BufferSize : Length];
 
-            int written = 0;
+            long written = 0;
             int bytesToRead = 0;
             do {
                 if (written + buffer.Length > Length) {

--- a/src/Yarhl/IO/IStream.cs
+++ b/src/Yarhl/IO/IStream.cs
@@ -46,9 +46,9 @@ namespace Yarhl.IO
         /// Sets the length of the stream.
         /// </summary>
         /// <param name="length">The new length of the stream.</param>
-        /// <remarks>
+        /// <remarks><para>
         /// Some streams may not implement or support changing the length.
-        /// </remarks>
+        /// </para></remarks>
         void SetLength(long length);
 
         /// <summary>


### PR DESCRIPTION
### Description
Trying to write files larger than 2 GB was throwing an exception. The reason was a variable that was of type `int` instead of `long` so it was overflowing.

I have created a test but it's ignored since it generates 6 GB of files and takes around a minute. Passed locally.
