### PR TITLE
Register additional encoding providers

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>3.0.0-alpha08</Version>
+        <Version>3.0.0-alpha09</Version>
         <Product>SceneGate</Product>
 
         <Authors>SceneGate Team</Authors>

--- a/src/Yarhl.PerformanceTests/Yarhl.PerformanceTests.csproj
+++ b/src/Yarhl.PerformanceTests/Yarhl.PerformanceTests.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>Yarhl.PerformanceTests</AssemblyName>
     <Description>Performance tests for Yarhl.</Description>
+    <IsPackable>false</IsPackable>
 
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <RootNamespace>Yarhl.PerformanceTests</RootNamespace>
@@ -17,7 +18,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Yarhl.UnitTests/IO/TextReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/TextReaderTests.cs
@@ -68,12 +68,33 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void PropertyValuesWithConstructorEncodingName()
+        {
+            var reader = new TextReader(stream, "utf-16");
+            Assert.AreSame(stream, reader.Stream);
+            Assert.AreSame(Encoding.Unicode, reader.Encoding);
+            Assert.AreEqual(Environment.NewLine, reader.NewLine);
+            Assert.IsTrue(reader.AutoNewLine);
+        }
+
+        [Test]
+        public void CreateWithShiftJisEncoding()
+        {
+            // It will automatically register the encodings for .NET Core.
+            var reader = new TextReader(stream, "shift-jis");
+            Assert.That(reader.Encoding.CodePage, Is.EqualTo(932));
+        }
+
+        [Test]
         public void TestConstructorWithNullArguments()
         {
             Assert.Throws<ArgumentNullException>(() => new TextReader(null));
 
             Assert.Throws<ArgumentNullException>(() => new TextReader(null, Encoding.ASCII));
-            Assert.Throws<ArgumentNullException>(() => new TextReader(stream, null));
+            Assert.Throws<ArgumentNullException>(() => new TextReader(stream, (Encoding)null));
+
+            Assert.Throws<ArgumentNullException>(() => new TextReader(null, "ascii"));
+            Assert.Throws<ArgumentNullException>(() => new TextReader(stream, (string)null));
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/TextWriterTests.cs
+++ b/src/Yarhl.UnitTests/IO/TextWriterTests.cs
@@ -65,14 +65,34 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void ConstructorWithEncodingName()
+        {
+            var writer = new TextWriter(stream, "ascii");
+            Assert.AreSame(Encoding.ASCII, writer.Encoding);
+        }
+
+        [Test]
+        public void CreateWithShiftJisEncoding()
+        {
+            var writer = new TextWriter(stream, "shift-jis");
+            Assert.That(writer.Encoding.CodePage, Is.EqualTo(932));
+        }
+
+        [Test]
         public void WrongArgsInConstructorThrowsException()
         {
             Assert.Throws<ArgumentNullException>(
                 () => new TextWriter(null));
+
             Assert.Throws<ArgumentNullException>(
                 () => new TextWriter(null, Encoding.ASCII));
             Assert.Throws<ArgumentNullException>(
-                () => new TextWriter(stream, null));
+                () => new TextWriter(stream, (Encoding)null));
+
+            Assert.Throws<ArgumentNullException>(
+                () => new TextWriter(null, "ascii"));
+            Assert.Throws<ArgumentNullException>(
+                () => new TextWriter(stream, (string)null));
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
+++ b/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
@@ -28,6 +28,5 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/Yarhl/IO/DataReader.cs
+++ b/src/Yarhl/IO/DataReader.cs
@@ -35,6 +35,13 @@ namespace Yarhl.IO
     /// </summary>
     public class DataReader
     {
+        static DataReader()
+        {
+            // Make sure that the shift-jis encoding is initialized in
+            // .NET Core.
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Yarhl.IO.DataReader"/> class.
         /// </summary>

--- a/src/Yarhl/IO/DataWriter.cs
+++ b/src/Yarhl/IO/DataWriter.cs
@@ -34,6 +34,13 @@ namespace Yarhl.IO
     /// </summary>
     public class DataWriter
     {
+        static DataWriter()
+        {
+            // Make sure that the shift-jis encoding is initialized in
+            // .NET Core.
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Yarhl.IO.DataWriter"/> class.
         /// </summary>

--- a/src/Yarhl/IO/TextReader.cs
+++ b/src/Yarhl/IO/TextReader.cs
@@ -38,6 +38,13 @@ namespace Yarhl.IO
         readonly DataReader reader;
         string newLine;
 
+        static TextReader()
+        {
+            // Make sure that the shift-jis encoding is initialized in
+            // .NET Core.
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TextReader"/> class.
         /// </summary>

--- a/src/Yarhl/IO/TextReader.cs
+++ b/src/Yarhl/IO/TextReader.cs
@@ -60,6 +60,16 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to read from.</param>
         /// <param name="encoding">Encoding to use.</param>
+        public TextReader(DataStream stream, string encoding)
+            : this(stream, Encoding.GetEncoding(encoding))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextReader"/> class.
+        /// </summary>
+        /// <param name="stream">Stream to read from.</param>
+        /// <param name="encoding">Encoding to use.</param>
         public TextReader(DataStream stream, Encoding encoding)
         {
             Stream = stream ?? throw new ArgumentNullException(nameof(stream));

--- a/src/Yarhl/IO/TextWriter.cs
+++ b/src/Yarhl/IO/TextWriter.cs
@@ -36,6 +36,13 @@ namespace Yarhl.IO
     {
         readonly DataWriter writer;
 
+        static TextWriter()
+        {
+            // Make sure that the shift-jis encoding is initialized in
+            // .NET Core.
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TextWriter"/> class.
         /// </summary>

--- a/src/Yarhl/IO/TextWriter.cs
+++ b/src/Yarhl/IO/TextWriter.cs
@@ -56,6 +56,16 @@ namespace Yarhl.IO
         /// <summary>
         /// Initializes a new instance of the <see cref="TextWriter"/> class.
         /// </summary>
+        /// <param name="stream">Stream to read from.</param>
+        /// <param name="encoding">Encoding to use.</param>
+        public TextWriter(DataStream stream, string encoding)
+            : this(stream, Encoding.GetEncoding(encoding))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextWriter"/> class.
+        /// </summary>
         /// <param name="stream">Stream to write to.</param>
         /// <param name="encoding">Encoding to use.</param>
         public TextWriter(DataStream stream, Encoding encoding)

--- a/src/Yarhl/Yarhl.csproj
+++ b/src/Yarhl/Yarhl.csproj
@@ -32,6 +32,7 @@
     </PackageReference>
     <PackageReference Include="System.Composition" Version="1.2.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
     <PackageReference Include="Text.Analyzers" Version="2.6.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
### Description
This PR auto-registers additional encoding providers from the NuGet package `System.Text.Encoding.CodePages`. This is specially useful for .NET Core since it doesn't include the Shift-JIS encoding. The encodings are registered when the user uses for the first time any of these classes: `BinaryReader`, `BinaryWriter`, `TextReader` and `TextWriter`.

A new constructor with argument the name of the encoding has been added for `TextReader` and `TextWriter`. This fixes the use case of trying to get the Shift-JIS encoding for passing to the constructor, when it hasn't been yet registered since the static constructor has not been called. Also it's an esier to use constructor.

#### Other fixes

* Do not generate nugets for `Yarhl.PerformanTests` projects and fix duplicate `Main` in it.

### Example

```cs
var reader = new TextReader(stream, "shift-jis");
var writer = new TextWriter(stream, "shift-jis");
```