### PR TITLE
Check that child node doesn't add parent

### DIFF
--- a/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
@@ -109,6 +109,20 @@ namespace Yarhl.UnitTests.FileSystem
         }
 
         [Test]
+        public void AddParentThrowException()
+        {
+            var grandparent = new DummyNavigable("Grandparent");
+            var parent = new DummyNavigable("Parent");
+            var child = new DummyNavigable("Child");
+            grandparent.Add(parent);
+            parent.Add(child);
+
+            Assert.That(() => child.Add(parent), Throws.ArgumentException);
+            Assert.That(() => child.Add(grandparent), Throws.ArgumentException);
+            Assert.That(() => parent.Add(grandparent), Throws.ArgumentException);
+        }
+
+        [Test]
         public void ChildrenGetsByName()
         {
             var node = new DummyNavigable("MyChild");

--- a/src/Yarhl/FileSystem/NavigableNode.cs
+++ b/src/Yarhl/FileSystem/NavigableNode.cs
@@ -124,6 +124,9 @@ namespace Yarhl.FileSystem
             if (node == null)
                 throw new ArgumentNullException(nameof(node));
 
+            if (Path.StartsWith(node.Path))
+                throw new ArgumentException("Cannot add parent as child", nameof(node));
+
             // Update the parent of the child
             node.Parent = (T)this;
 


### PR DESCRIPTION
### Description
Adding a check to ensure that a node it is not adding any of its parent node as child. This could have cause infinite loops and weird behaviours (like trying to get the `Path`).

### Example
```cs
// The following code is not valid anymore
var parent = new DummyNavigable("Parent");
var child = new DummyNavigable("Child");
parent.Add(child);

child.Add(parent);  // this throw an ArgumentException
```
