### PR TITLE
New API for keeping the dispose ownership of Streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,8 @@ Mac OS X.
 
 | NuGet | [![Nuget](https://img.shields.io/nuget/v/Yarhl.svg)](https://www.nuget.org/packages/Yarhl) [![NuGet Alpha](https://img.shields.io/github/v/tag/SceneGate/Yarhl?color=yellow&include_prereleases&label=nuget)](https://github.com/SceneGate/Yarhl/packages) |
 | ----- | ------ |
-| **Build & Test** | [![Build Status](https://dev.azure.com/SceneGate/Yarhl/_apis/build/status/SceneGate.Yarhl?branchName=master)](https://dev.azure.com/SceneGate/Yarhl/_build/latest?definitionId=1&branchName=master) |
-| **Quality report** | [![Sonar Gate](https://sonarcloud.io/api/project_badges/measure?project=SceneGate_Yarhl&metric=alert_status)](https://sonarcloud.io/dashboard?id=SceneGate_Yarhl) [![Total alerts](https://img.shields.io/lgtm/alerts/g/SceneGate/Yarhl.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/SceneGate/Yarhl/alerts/) |
-| **Coverage** | [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=SceneGate_Yarhl&metric=coverage)](https://sonarcloud.io/dashboard?id=SceneGate_Yarhl) |
-| **Project Best Practices** | [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2919/badge)](https://bestpractices.coreinfrastructure.org/projects/2919) |
-| **Quality Details** | [![Maintainability](https://sonarcloud.io/api/project_badges/measure?project=SceneGate_Yarhl&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=SceneGate_Yarhl) [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=SceneGate_Yarhl&metric=bugs)](https://sonarcloud.io/dashboard?id=SceneGate_Yarhl) [![Code smells](https://sonarcloud.io/api/project_badges/measure?project=SceneGate_Yarhl&metric=code_smells)](https://sonarcloud.io/dashboard?id=SceneGate_Yarhl) [![Duplicated lines](https://sonarcloud.io/api/project_badges/measure?project=SceneGate_Yarhl&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=SceneGate_Yarhl) |
-| **Code Stats** | [![Lines of code](https://sonarcloud.io/api/project_badges/measure?project=SceneGate_Yarhl&metric=ncloc)](https://sonarcloud.io/dashboard?id=SceneGate_Yarhl) |
+| **Build & Test** | [![Build Status](https://dev.azure.com/SceneGate/Yarhl/_apis/build/status/SceneGate.Yarhl?branchName=master)](https://dev.azure.com/SceneGate/Yarhl/_build/latest?definitionId=1&branchName=master) ![Azure DevOps tests](https://img.shields.io/azure-devops/tests/SceneGate/Yarhl/1?compact_message) ![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/SceneGate/Yarhl/1) |
+| **Quality report** | [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2919/badge)](https://bestpractices.coreinfrastructure.org/projects/2919) [![Total alerts](https://img.shields.io/lgtm/alerts/g/SceneGate/Yarhl.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/SceneGate/Yarhl/alerts/) |
 
 ## Documentation
 

--- a/src/Yarhl.IntegrationTests/PluginDiscovery.cs
+++ b/src/Yarhl.IntegrationTests/PluginDiscovery.cs
@@ -28,7 +28,6 @@ namespace Yarhl.IntegrationTests
     using System.IO;
     using System.Linq;
     using NUnit.Framework;
-    using Yarhl;
 
     [TestFixture]
     public class PluginDiscovery

--- a/src/Yarhl.UnitTests/IO/BinaryFormatTests.cs
+++ b/src/Yarhl.UnitTests/IO/BinaryFormatTests.cs
@@ -25,7 +25,6 @@
 namespace Yarhl.UnitTests.IO
 {
     using System;
-    using System.IO;
     using NUnit.Framework;
     using Yarhl.IO;
     using Yarhl.IO.StreamFormat;

--- a/src/Yarhl.UnitTests/IO/DataReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataReaderTests.cs
@@ -323,6 +323,26 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void ReadSinglePositiveZero()
+        {
+            byte[] buffer = { 0x00, 0x00, 0x00, 0x00 };
+            stream.Write(buffer, 0, buffer.Length);
+            stream.Position = 0;
+            reader.Endianness = EndiannessMode.LittleEndian;
+            Assert.That(reader.ReadSingle(), Is.EqualTo(+0.0f));
+        }
+
+        [Test]
+        public void ReadSingleNegativeZero()
+        {
+            byte[] buffer = { 0x00, 0x00, 0x00, 0x80 };
+            stream.Write(buffer, 0, buffer.Length);
+            stream.Position = 0;
+            reader.Endianness = EndiannessMode.LittleEndian;
+            Assert.That(reader.ReadSingle(), Is.EqualTo(-0.0f));
+        }
+
+        [Test]
         public void ReadSingleInvalidEndianness()
         {
             byte[] buffer = { 0x40, 0x48, 0xF5, 0xC3 };

--- a/src/Yarhl.UnitTests/IO/DataWriterTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataWriterTests.cs
@@ -334,6 +334,38 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void WriteSingleNegativeZero()
+        {
+            DataStream stream = new DataStream();
+            DataWriter writer = new DataWriter(stream);
+
+            writer.Write(-0.0f);
+
+            stream.Position = 0;
+            Assert.That(stream.Length, Is.EqualTo(4));
+            Assert.That(stream.ReadByte, Is.EqualTo(0x00));
+            Assert.That(stream.ReadByte, Is.EqualTo(0x00));
+            Assert.That(stream.ReadByte, Is.EqualTo(0x00));
+            Assert.That(stream.ReadByte, Is.EqualTo(0x80));
+        }
+
+        [Test]
+        public void WriteSinglePositiveZero()
+        {
+            DataStream stream = new DataStream();
+            DataWriter writer = new DataWriter(stream);
+
+            writer.Write(+0.0f);
+
+            stream.Position = 0;
+            Assert.That(stream.Length, Is.EqualTo(4));
+            Assert.That(stream.ReadByte, Is.EqualTo(0x00));
+            Assert.That(stream.ReadByte, Is.EqualTo(0x00));
+            Assert.That(stream.ReadByte, Is.EqualTo(0x00));
+            Assert.That(stream.ReadByte, Is.EqualTo(0x00));
+        }
+
+        [Test]
         public void WriteDoubleLittle()
         {
             DataStream stream = new DataStream();

--- a/src/Yarhl/FileFormat/ConvertFormat.cs
+++ b/src/Yarhl/FileFormat/ConvertFormat.cs
@@ -28,11 +28,11 @@ namespace Yarhl.FileFormat
         /// Converts the format to the specified type.
         /// </summary>
         /// <returns>The new format.</returns>
-        /// <param name="source">Format to convert.</param>
+        /// <param name="src">Format to convert.</param>
         /// <typeparam name="TDst">The destination format type.</typeparam>
-        public static TDst To<TDst>(dynamic source)
+        public static TDst To<TDst>(dynamic src)
         {
-            return (TDst)To(typeof(TDst), source);
+            return (TDst)To(typeof(TDst), src);
         }
 
         /// <summary>

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -20,6 +20,7 @@
 namespace Yarhl.FileSystem
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using Yarhl.IO;
 
@@ -33,6 +34,10 @@ namespace Yarhl.FileSystem
         /// </summary>
         /// <returns>The new node.</returns>
         /// <param name="name">Node name.</param>
+        [SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "Ownserhip dispose transferred")]
         public static Node CreateContainer(string name)
         {
             return new Node(name, new NodeContainerFormat());
@@ -82,6 +87,10 @@ namespace Yarhl.FileSystem
         /// </summary>
         /// <param name="name">The name of the node.</param>
         /// <returns>The new node.</returns>
+        [SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "Ownserhip dispose transferred")]
         public static Node FromMemory(string name)
         {
             return new Node(name, new BinaryFormat());
@@ -97,6 +106,10 @@ namespace Yarhl.FileSystem
         /// </param>
         /// <param name="length">The length of the data in the node.</param>
         /// <returns>The new node.</returns>
+        [SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "Ownserhip dispose transferred")]
         public static Node FromSubstream(
             string name,
             DataStream source,
@@ -130,6 +143,10 @@ namespace Yarhl.FileSystem
         /// <returns>The node.</returns>
         /// <param name="filePath">File path.</param>
         /// <param name="nodeName">Node name.</param>
+        [SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "Ownserhip dispose transferred")]
         public static Node FromFile(string filePath, string nodeName)
         {
             // We need to catch if the node creation fails
@@ -175,6 +192,10 @@ namespace Yarhl.FileSystem
         /// <param name="subDirectories">
         /// If <see langword="true" /> it searchs recursively in subdirectories.
         /// </param>
+        [SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "Ownserhip dispose transferred")]
         public static Node FromDirectory(
             string dirPath,
             string filter,

--- a/src/Yarhl/IO/DataStreamFactory.cs
+++ b/src/Yarhl/IO/DataStreamFactory.cs
@@ -46,6 +46,14 @@ namespace Yarhl.IO
         /// Creates a new <see cref="DataStream"/> from a section of a
         /// <see cref="Stream"/>.
         /// </summary>
+        /// <remarks>
+        /// <p>The life-management of the stream is transferred to the
+        /// <see cref="DataStream"/>. This means that disposing the new
+        /// <see cref="DataStream"/> will potentially dispose the underlying
+        /// stream.</p>
+        /// <p>Check <see cref="FromStreamKeepingOwnership" /> if you don't
+        /// want this behavior.</p>
+        /// </remarks>
         /// <param name="stream">The stream to use as a base.</param>
         /// <param name="offset">Offset of the base stream.</param>
         /// <param name="length">Length of the new substream.</param>
@@ -60,7 +68,33 @@ namespace Yarhl.IO
                 throw new ArgumentOutOfRangeException(nameof(length));
 
             var baseStream = new StreamWrapper(stream);
-            return new DataStream(baseStream, offset, length);
+            return new DataStream(baseStream, offset, length, true);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="DataStream"/> from a section of a
+        /// <see cref="Stream"/>.
+        /// </summary>
+        /// <remarks>
+        /// <p>The dispose ownership is not transferred to the new
+        /// <see cref="DataStream" />. Instead, the caller is still responsible
+        /// to dispose according the stream argument.</p>
+        /// </remarks>
+        /// <param name="stream">The stream to use as a base.</param>
+        /// <param name="offset">Offset of the base stream.</param>
+        /// <param name="length">Length of the new substream.</param>
+        /// <returns>A new <see cref="DataStream"/>.</returns>
+        public static DataStream FromStreamKeepingOwnership(Stream stream, long offset, long length)
+        {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+            if (offset < 0 || offset > stream.Length)
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            if (length < 0 || offset + length > stream.Length)
+                throw new ArgumentOutOfRangeException(nameof(length));
+
+            var baseStream = new StreamWrapper(stream);
+            return new DataStream(baseStream, offset, length, false);
         }
 
         /// <summary>
@@ -91,7 +125,7 @@ namespace Yarhl.IO
                 throw new ArgumentOutOfRangeException(nameof(length));
 
             var baseStream = new StreamWrapper(new MemoryStream(data, 0, data.Length));
-            return new DataStream(baseStream, offset, length);
+            return new DataStream(baseStream, offset, length, true);
         }
 
         /// <summary>
@@ -129,7 +163,7 @@ namespace Yarhl.IO
                 throw new ArgumentOutOfRangeException(nameof(length));
 
             var baseStream = new LazyFileStream(path, mode);
-            return new DataStream(baseStream, offset, length);
+            return new DataStream(baseStream, offset, length, true);
         }
     }
 }

--- a/src/Yarhl/IO/IBinary.cs
+++ b/src/Yarhl/IO/IBinary.cs
@@ -16,7 +16,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace Yarhl.IO
 {
-    using System;
     using Yarhl.FileFormat;
 
     /// <summary>


### PR DESCRIPTION
### Description
`DataStream` has been improved to decided when it manages the life-cycle of the underlying `IStream`. The goal is to specify if we want to dispose also the underlying `Stream`. One new method has been added to the `DataStreamFactory`: `FromStreamKeepingOwnership(Stream, int, int)` to specify that new `DataStream` shouldn't dispose the `Stream` from the argument. `FromStream` will continue to transfer the ownership to the `DataStream`.

### Example
```csharp
// Case 1: baseStream1 ownership is transferred to the DataStream
Stream baseStream1 = new MemoryStream();
DataStream stream1 = DataStreamFactory.FromStream(baseStream1, 0, 0);
stream1.Dispose(); // <-- Dispose baseStream also

// Case 2: baseStream2 ownership is NOT transferred to the DataStream
Stream baseStream2 = new MemoryStream();
DataStream stream2 = DataStreamFactory.FromStreamKeepingOwnership(baseStream2, 0, 0);
stream2.Dispose(); // <-- It doesn't dispose baseStream2
baseStream2.Dispose(); // Make sure to call Dispose when using this method
```