### PR TITLE
Do not dispose when changing to the same format instance

### DIFF
--- a/src/Yarhl.UnitTests/FileSystem/NodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeTests.cs
@@ -183,6 +183,18 @@ namespace Yarhl.UnitTests.FileSystem
         }
 
         [Test]
+        public void ChangeFormatDoesNothingForSameFormat()
+        {
+            var dummyFormat1 = new StringFormatTest("3");
+            var dummyFormat2 = dummyFormat1;
+            Node node = new Node("mytest", dummyFormat1);
+            node.ChangeFormat(dummyFormat2);
+            Assert.AreEqual(dummyFormat2, node.Format);
+            Assert.IsFalse(dummyFormat1.Disposed);
+            Assert.IsFalse(dummyFormat2.Disposed);
+        }
+
+        [Test]
         public void ChangeFormatWithoutDisposingPreviousFormat()
         {
             var dummyFormat1 = new StringFormatTest("3");

--- a/src/Yarhl/FileSystem/Node.cs
+++ b/src/Yarhl/FileSystem/Node.cs
@@ -97,6 +97,8 @@ namespace Yarhl.FileSystem
         /// remove the children of the node.
         /// If the new format is a container, this method will add the format
         /// children to the node.</para>
+        /// <para>If the new format is the same reference as the current format
+        /// the method is a no-op.</para>
         /// </remarks>
         /// <param name="newFormat">The new format to assign.</param>
         /// <param name="disposePreviousFormat">
@@ -107,6 +109,10 @@ namespace Yarhl.FileSystem
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(Node));
+
+            if (newFormat == Format) {
+                return;
+            }
 
             // If it was a container, clean children
             if (IsContainer) {


### PR DESCRIPTION
### Description
If the user tries to change the format of a node to the current format instance, the method `ChangeFormat` should be a no-op.

This allows to implement converters which output is actually the same instance. Like importing over the source rather than converting into a new class.