### PR TITLE
Split the PO converter into two classes

### DIFF
--- a/src/Yarhl.Media/Text/Binary2Po.cs
+++ b/src/Yarhl.Media/Text/Binary2Po.cs
@@ -1,0 +1,244 @@
+// Copyright (c) 2017 Benito Palacios Sánchez
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace Yarhl.Media.Text
+{
+    using System;
+    using System.Text;
+    using Yarhl.FileFormat;
+    using Yarhl.IO;
+
+    /// <summary>
+    /// Binary to Po converter.
+    /// </summary>
+    public class Binary2Po : IConverter<IBinary, Po>
+    {
+        /// <summary>
+        /// Convert the specified Binary stream into a PO object.
+        /// </summary>
+        /// <returns>The converted PO object.</returns>
+        /// <param name="source">Source binary stream.</param>
+        public Po Convert(IBinary source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            TextReader reader = new TextReader(source.Stream);
+            Po po = new Po();
+
+            // Read the header if any
+            PoEntry entry = ReadEntry(reader);
+            if (entry == null)
+                return po;
+
+            if (entry.Original.Length == 0)
+                po.Header = Entry2Header(entry);
+            else
+                po.Add(entry);
+
+            // Read other entries
+            while ((entry = ReadEntry(reader)) != null) {
+                po.Add(entry);
+            }
+
+            return po;
+        }
+
+                static PoEntry ReadEntry(TextReader reader)
+        {
+            // Skip all the blank lines before the block of text
+            string line = string.Empty;
+            while (reader.PeekLine()?.Trim().Length == 0)
+                reader.ReadLine();
+
+            // If nothing to read, EOF
+            if (reader.Stream.EndOfStream)
+                return null;
+
+            PoEntry entry = new PoEntry();
+            while (!reader.Stream.EndOfStream) {
+                // Get the next line
+                line = reader.ReadLine();
+
+                // If it's blank, then this block finished
+                if (string.IsNullOrWhiteSpace(line))
+                    break;
+
+                ParseLine(reader, entry, line);
+            }
+
+            return entry;
+        }
+
+        static void ParseLine(TextReader reader, PoEntry entry, string line)
+        {
+            string[] fields = line.Split(new[] { ' ' }, 2);
+            if (fields.Length != 2)
+                throw new FormatException("Invalid line format: " + line);
+
+            switch (fields[0]) {
+                case "#":
+                    entry.TranslatorComment = ReadMultiLineComment(
+                        reader,
+                        fields[1].TrimStart(),
+                        "# ");
+                    break;
+                case "#.":
+                    entry.ExtractedComments = ReadMultiLineComment(
+                        reader,
+                        fields[1],
+                        "#.");
+                    break;
+                case "#:":
+                    entry.Reference = fields[1];
+                    break;
+                case "#,":
+                    entry.Flags = fields[1];
+                    break;
+
+                case "#|":
+                    string[] subfields = fields[1].Split(new[] { ' ' }, 2);
+                    if (subfields[0] == "msgctxt")
+                        entry.PreviousContext = subfields[1];
+                    else if (subfields[0] == "msgid")
+                        entry.PreviousOriginal = subfields[1];
+                    else
+                        throw new FormatException("Unknown previous field: " + line);
+                    break;
+
+                case "msgctxt":
+                    entry.Context = ReadMultiLineContent(reader, fields[1]);
+                    break;
+                case "msgid":
+                    entry.Original = ReadMultiLineContent(reader, fields[1]);
+                    break;
+                case "msgstr":
+                    entry.Translated = ReadMultiLineContent(reader, fields[1]);
+                    break;
+                default:
+                    throw new FormatException("Unknown line '" + line + "'");
+            }
+        }
+
+        static PoHeader Entry2Header(PoEntry entry)
+        {
+            PoHeader header = new PoHeader();
+            var option = StringSplitOptions.RemoveEmptyEntries;
+            foreach (string line in entry.Translated.Split(new[] { '\n' }, option)) {
+                var fields = line.Split(new[] { ": " }, 2, StringSplitOptions.None);
+                if (fields.Length != 2)
+                    throw new FormatException("Invalid format line: " + line);
+
+                ParseHeaderLine(header, fields[0], fields[1]);
+            }
+
+            return header;
+        }
+
+        static void ParseHeaderLine(PoHeader header, string key, string value)
+        {
+            switch (key) {
+                case "Project-Id-Version":
+                    header.ProjectIdVersion = value;
+                    break;
+                case "Report-Msgid-Bugs-To":
+                    header.ReportMsgidBugsTo = value;
+                    break;
+
+                case "POT-Creation-Date":
+                    header.CreationDate = value;
+                    break;
+                case "PO-Revision-Date":
+                    header.RevisionDate = value;
+                    break;
+
+                case "Last-Translator":
+                    header.LastTranslator = value;
+                    break;
+                case "Language-Team":
+                    header.LanguageTeam = value;
+                    break;
+                case "Language":
+                    header.Language = value;
+                    break;
+
+                case "Plural-Forms":
+                    header.PluralForms = value;
+                    break;
+
+                case "MIME-Version":
+                    if (value != "1.0")
+                        throw new FormatException("Invalid MIME version");
+                    break;
+
+                case "Content-Type":
+                    if (value != "text/plain; charset=UTF-8")
+                        throw new FormatException("Invalid Content-Type");
+                    break;
+                case "Content-Transfer-Encoding":
+                    if (value != "8bit")
+                        throw new FormatException("Invalid Content-Transfer-Encoding");
+                    break;
+
+                default:
+                    // Ignore extended / tool-specific fields
+                    if (key.Length > 2 && key.Substring(0, 2) == "X-") {
+                        header.Extensions[key.Substring(2)] = value;
+                        break;
+                    }
+
+                    throw new FormatException("Unknown header key: " + key);
+            }
+        }
+
+        static string ReadMultiLineComment(TextReader reader, string line, string comment)
+        {
+            StringBuilder builder = new StringBuilder(line);
+            while (reader.PeekToToken(" ") == comment) {
+                // We just remove the comment token and take advantage that
+                // there is an space after it.
+                builder.Append(reader.ReadLine().Substring(comment.Length));
+            }
+
+            return builder.ToString();
+        }
+
+        static string ReadMultiLineContent(TextReader reader, string currentLine)
+        {
+            StringBuilder content = new StringBuilder(ParseMultiLine(currentLine));
+
+            while (!reader.Stream.EndOfStream && reader.Peek() == '"')
+                content.Append(ParseMultiLine(reader.ReadLine()));
+
+            return content.ToString();
+        }
+
+        static string ParseMultiLine(string line)
+        {
+            if (line.Length < 2)
+                throw new FormatException("Invalid line quotes");
+
+            if (line[0] != '"' || line[line.Length - 1] != '"')
+                throw new FormatException("Line quotes in invalid position");
+
+            line = line.Substring(1, line.Length - 2);
+            return line.Replace("\\n", "\n").Replace("\\\"", "\"");
+        }
+    }
+}

--- a/src/Yarhl.Media/Text/Po2Binary.cs
+++ b/src/Yarhl.Media/Text/Po2Binary.cs
@@ -25,16 +25,13 @@
 namespace Yarhl.Media.Text
 {
     using System;
-    using System.Text;
     using Yarhl.FileFormat;
     using Yarhl.IO;
 
     /// <summary>
     /// Po to Binary converter.
     /// </summary>
-    public class Po2Binary :
-        IConverter<Po, BinaryFormat>,
-        IConverter<IBinary, Po>
+    public class Po2Binary : IConverter<Po, BinaryFormat>
     {
         /// <summary>
         /// Convert the specified PO into a Binary stream.
@@ -58,37 +55,6 @@ namespace Yarhl.Media.Text
             }
 
             return binary;
-        }
-
-        /// <summary>
-        /// Convert the specified Binary stream into a PO object.
-        /// </summary>
-        /// <returns>The converted PO object.</returns>
-        /// <param name="source">Source binary stream.</param>
-        public Po Convert(IBinary source)
-        {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
-
-            TextReader reader = new TextReader(source.Stream);
-            Po po = new Po();
-
-            // Read the header if any
-            PoEntry entry = ReadEntry(reader);
-            if (entry == null)
-                return po;
-
-            if (entry.Original.Length == 0)
-                po.Header = Entry2Header(entry);
-            else
-                po.Add(entry);
-
-            // Read other entries
-            while ((entry = ReadEntry(reader)) != null) {
-                po.Add(entry);
-            }
-
-            return po;
         }
 
         static void WriteHeader(PoHeader header, TextWriter writer)
@@ -154,187 +120,6 @@ namespace Yarhl.Media.Text
 
                 idx = nextIdx + 2;
             } while (idx != 1);
-        }
-
-        static PoEntry ReadEntry(TextReader reader)
-        {
-            // Skip all the blank lines before the block of text
-            string line = string.Empty;
-            while (reader.PeekLine()?.Trim().Length == 0)
-                reader.ReadLine();
-
-            // If nothing to read, EOF
-            if (reader.Stream.EndOfStream)
-                return null;
-
-            PoEntry entry = new PoEntry();
-            while (!reader.Stream.EndOfStream) {
-                // Get the next line
-                line = reader.ReadLine();
-
-                // If it's blank, then this block finished
-                if (string.IsNullOrWhiteSpace(line))
-                    break;
-
-                ParseLine(reader, entry, line);
-            }
-
-            return entry;
-        }
-
-        static void ParseLine(TextReader reader, PoEntry entry, string line)
-        {
-            string[] fields = line.Split(new[] { ' ' }, 2);
-            if (fields.Length != 2)
-                throw new FormatException("Invalid line format: " + line);
-
-            switch (fields[0]) {
-                case "#":
-                    entry.TranslatorComment = ReadMultiLineComment(
-                        reader,
-                        fields[1].TrimStart(),
-                        "# ");
-                    break;
-                case "#.":
-                    entry.ExtractedComments = ReadMultiLineComment(
-                        reader,
-                        fields[1],
-                        "#.");
-                    break;
-                case "#:":
-                    entry.Reference = fields[1];
-                    break;
-                case "#,":
-                    entry.Flags = fields[1];
-                    break;
-
-                case "#|":
-                    string[] subfields = fields[1].Split(new[] { ' ' }, 2);
-                    if (subfields[0] == "msgctxt")
-                        entry.PreviousContext = subfields[1];
-                    else if (subfields[0] == "msgid")
-                        entry.PreviousOriginal = subfields[1];
-                    else
-                        throw new FormatException("Unknown previous field: " + line);
-                    break;
-
-                case "msgctxt":
-                    entry.Context = ReadMultiLineContent(reader, fields[1]);
-                    break;
-                case "msgid":
-                    entry.Original = ReadMultiLineContent(reader, fields[1]);
-                    break;
-                case "msgstr":
-                    entry.Translated = ReadMultiLineContent(reader, fields[1]);
-                    break;
-                default:
-                    throw new FormatException("Unknown line '" + line + "'");
-            }
-        }
-
-        static PoHeader Entry2Header(PoEntry entry)
-        {
-            PoHeader header = new PoHeader();
-            var option = StringSplitOptions.RemoveEmptyEntries;
-            foreach (string line in entry.Translated.Split(new[] { '\n' }, option)) {
-                var fields = line.Split(new[] { ": " }, 2, StringSplitOptions.None);
-                if (fields.Length != 2)
-                    throw new FormatException("Invalid format line: " + line);
-
-                ParseHeaderLine(header, fields[0], fields[1]);
-            }
-
-            return header;
-        }
-
-        static void ParseHeaderLine(PoHeader header, string key, string value)
-        {
-            switch (key) {
-                case "Project-Id-Version":
-                    header.ProjectIdVersion = value;
-                    break;
-                case "Report-Msgid-Bugs-To":
-                    header.ReportMsgidBugsTo = value;
-                    break;
-
-                case "POT-Creation-Date":
-                    header.CreationDate = value;
-                    break;
-                case "PO-Revision-Date":
-                    header.RevisionDate = value;
-                    break;
-
-                case "Last-Translator":
-                    header.LastTranslator = value;
-                    break;
-                case "Language-Team":
-                    header.LanguageTeam = value;
-                    break;
-                case "Language":
-                    header.Language = value;
-                    break;
-
-                case "Plural-Forms":
-                    header.PluralForms = value;
-                    break;
-
-                case "MIME-Version":
-                    if (value != "1.0")
-                        throw new FormatException("Invalid MIME version");
-                    break;
-
-                case "Content-Type":
-                    if (value != "text/plain; charset=UTF-8")
-                        throw new FormatException("Invalid Content-Type");
-                    break;
-                case "Content-Transfer-Encoding":
-                    if (value != "8bit")
-                        throw new FormatException("Invalid Content-Transfer-Encoding");
-                    break;
-
-                default:
-                    // Ignore extended / tool-specific fields
-                    if (key.Length > 2 && key.Substring(0, 2) == "X-") {
-                        header.Extensions[key.Substring(2)] = value;
-                        break;
-                    }
-
-                    throw new FormatException("Unknown header key: " + key);
-            }
-        }
-
-        static string ReadMultiLineComment(TextReader reader, string line, string comment)
-        {
-            StringBuilder builder = new StringBuilder(line);
-            while (reader.PeekToToken(" ") == comment) {
-                // We just remove the comment token and take advantage that
-                // there is an space after it.
-                builder.Append(reader.ReadLine().Substring(comment.Length));
-            }
-
-            return builder.ToString();
-        }
-
-        static string ReadMultiLineContent(TextReader reader, string currentLine)
-        {
-            StringBuilder content = new StringBuilder(ParseMultiLine(currentLine));
-
-            while (!reader.Stream.EndOfStream && reader.Peek() == '"')
-                content.Append(ParseMultiLine(reader.ReadLine()));
-
-            return content.ToString();
-        }
-
-        static string ParseMultiLine(string line)
-        {
-            if (line.Length < 2)
-                throw new FormatException("Invalid line quotes");
-
-            if (line[0] != '"' || line[line.Length - 1] != '"')
-                throw new FormatException("Line quotes in invalid position");
-
-            line = line.Substring(1, line.Length - 2);
-            return line.Replace("\\n", "\n").Replace("\\\"", "\"");
         }
     }
 }

--- a/src/Yarhl.UnitTests/Media/Text/Po2BinaryTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/Po2BinaryTests.cs
@@ -426,7 +426,7 @@ msgstr """"
         [Test]
         public void NullBinaryThrowException()
         {
-            Po2Binary converter = new Po2Binary();
+            Binary2Po converter = new Binary2Po();
             Assert.Throws<ArgumentNullException>(() => converter.Convert((BinaryFormat)null));
         }
 


### PR DESCRIPTION
### Description
The name of the converter for PO was confusing because the class `Po2Binary` was doing also `Binary to PO`. Also, since the two conversions doesn't shared logic or methods, the class was large with unrelated methods mixed.

That's why I decided to split into two class so it's more readible and easier to improve:
* Po2Binary: from a `PO` class into a `BinaryFormat`
* Binary2Po: from any `IBinary` type into a PO class.

If you were using the `ConvertTo/TransformTo` methods instead of `ConvertWith/TransformWith`, there is no breaking change.