### PR TITLE
Load information into tag

### DIFF
--- a/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
@@ -316,6 +316,39 @@ namespace Yarhl.UnitTests.FileSystem
         }
 
         [Test]
+        public void CreateFromDirectoryHasValidInfo()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDir);
+
+            string tempFolder = Path.Combine(tempDir, "folder");
+            Assert.That(Directory.CreateDirectory(tempFolder).Exists, Is.True);
+
+            string tempFile1 = Path.Combine(tempFolder, "file1.bin");
+            File.Create(tempFile1).Dispose();
+
+            Node node = NodeFactory.FromDirectory(tempDir, "*", "MyDir", true);
+
+            Assert.That(node.Tags.Count, Is.EqualTo(1));
+            Assert.That(node.Tags.ContainsKey("DirectoryInfo"), Is.True);
+            Assert.That(node.Tags.ContainsKey("FileInfo"), Is.False);
+            Assert.That(node.Tags["DirectoryInfo"], Is.TypeOf<DirectoryInfo>());
+
+            Assert.That(node.Children["folder"].Tags.Count, Is.EqualTo(1));
+            Assert.That(node.Children["folder"].Tags.ContainsKey("DirectoryInfo"), Is.True);
+            Assert.That(node.Children["folder"].Tags.ContainsKey("FileInfo"), Is.False);
+            Assert.That(node.Children["folder"].Tags["DirectoryInfo"], Is.TypeOf<DirectoryInfo>());
+
+            Assert.That(node.Children["folder"].Children["file1.bin"].Tags.Count, Is.EqualTo(1));
+            Assert.That(node.Children["folder"].Children["file1.bin"].Tags.ContainsKey("DirectoryInfo"), Is.False);
+            Assert.That(node.Children["folder"].Children["file1.bin"].Tags.ContainsKey("FileInfo"), Is.True);
+            Assert.That(node.Children["folder"].Children["file1.bin"].Tags["FileInfo"], Is.TypeOf<FileInfo>());
+
+            node.Dispose();
+            Directory.Delete(tempDir, true);
+        }
+
+        [Test]
         public void CreateContainersAndAdd()
         {
             using Node root = new Node("root");

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -155,9 +155,10 @@ namespace Yarhl.FileSystem
             var format = new BinaryFormat(DataStreamFactory.FromFile(filePath, mode));
             Node node;
             try {
-                node = new Node(nodeName, format);
-                var fileInfo = new FileInfo(filePath);
-                node.Tags["FileInfo"] = fileInfo;
+                node = new Node(nodeName, format)
+                {
+                    Tags = { ["FileInfo"] = new FileInfo(filePath) },
+                };
             } catch {
                 format.Dispose();
                 throw;
@@ -222,8 +223,7 @@ namespace Yarhl.FileSystem
 
                 int rootPathLength = $"{NodeSystem.PathSeparator}{nodeName}".Length;
                 string nodePath = Path.GetFullPath(string.Concat(dirPath, node.Path.Substring(rootPathLength)));
-                var directoryInfo = new DirectoryInfo(nodePath);
-                node.Tags["DirectoryInfo"] = directoryInfo;
+                node.Tags["DirectoryInfo"] = new DirectoryInfo(nodePath);
             }
 
             return folder;


### PR DESCRIPTION
### Description
Create a node tag to store the file or directory information.

### Example
```
DirectoryInfo info = node.Tags["DirectoryInfo"];
DateTime creationTime = info.CreationTime;
```
or
```
FileInfo info = node.Tags["FileInfo"];
DateTime creationTime = info.CreationTime;
```
See [DirectoryInfo](https://docs.microsoft.com/en-us/dotnet/api/system.io.directoryinfo?view=netstandard-2.0) and [FileInfo](https://docs.microsoft.com/en-us/dotnet/api/system.io.fileinfo?view=netstandard-2.0) for all available properties.

Linked issue:
#127 