### PR TITLE
Thread safe IStream between DataStreams

### DIFF
--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -22,6 +22,7 @@ namespace Yarhl.UnitTests.IO
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
+    using System.Threading.Tasks;
     using NUnit.Framework;
     using Yarhl.FileFormat;
     using Yarhl.IO;
@@ -1577,6 +1578,67 @@ namespace Yarhl.UnitTests.IO
 
             stream1.Dispose();
             stream2.Dispose();
+        }
+
+        [Test]
+        public void ReadAndWriteStreamsInParallel()
+        {
+            int streamCount = 100;
+            int testDataLength = 1024;
+            Random rdn = new Random();
+
+            byte[] data = new byte[streamCount * testDataLength];
+            for (int i = 0; i < data.Length; i++) {
+                data[i] = (byte)rdn.Next(256);
+            }
+
+            byte[] zeros = new byte[streamCount * testDataLength];
+
+            DataStream source = new DataStream();
+            source.Write(data, 0, data.Length);
+
+            DataStream[] streams = new DataStream[streamCount];
+            for (int i = 0; i < streamCount; i++)
+            {
+                streams[i] = new DataStream(source, testDataLength * i, testDataLength);
+            }
+
+            DataStream result = new DataStream();
+            result.Write(zeros, 0, zeros.Length);
+            result.Position = 0;
+
+            DataStream[] writeStreams = new DataStream[streamCount];
+            for (int i = 0; i < streamCount; i++)
+            {
+                writeStreams[i] = new DataStream(result, testDataLength * i, testDataLength);
+            }
+
+            byte[][] read = new byte[streamCount][];
+            for (int i = 0; i < streamCount; i++)
+            {
+                read[i] = new byte[testDataLength];
+            }
+
+            Parallel.For(0, streamCount, i =>
+            {
+                streams[i].Read(read[i], 0, testDataLength);
+            });
+
+            Parallel.For(0, streamCount, i =>
+            {
+                writeStreams[i].Write(read[i], 0, testDataLength);
+            });
+
+            for (int i = 0; i < streamCount; i++)
+            {
+                Assert.That(streams[i].Compare(writeStreams[i]), Is.True);
+                streams[i].Dispose();
+                writeStreams[i].Dispose();
+            }
+
+            Assert.That(source.Compare(result), Is.True);
+            source.Dispose();
+            result.Dispose();
         }
 
         public class DummyBinaryConverter : IConverter<BinaryFormat, byte>

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -36,7 +36,9 @@ namespace Yarhl.UnitTests.IO
         [SetUp]
         public void SetUp()
         {
-            baseStream = new RecyclableMemoryStream();
+            baseStream = new RecyclableMemoryStream {
+                LockObj = new object(),
+            };
         }
 
         [TearDown]

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -36,9 +36,7 @@ namespace Yarhl.UnitTests.IO
         [SetUp]
         public void SetUp()
         {
-            baseStream = new RecyclableMemoryStream {
-                LockObj = new object(),
-            };
+            baseStream = new RecyclableMemoryStream();
         }
 
         [TearDown]

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -571,9 +571,9 @@ namespace Yarhl.IO
             if (BaseStream == null || !hasOwnsership)
                 return;
 
-            Instances[BaseStream] -= 1;
-
             lock (BaseStream.LockObj) {
+                Instances[BaseStream] -= 1;
+
                 if (freeManagedResourcesAlso && Instances[BaseStream] == 0) {
                     BaseStream.Dispose();
                     Instances.TryRemove(BaseStream, out _);

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -48,11 +48,7 @@ namespace Yarhl.IO
         /// </summary>
         public DataStream()
         {
-            BaseStream = new RecyclableMemoryStream
-            {
-                LockObj = new object(),
-            };
-
+            BaseStream = new RecyclableMemoryStream();
             canExpand = true;
             Offset = 0;
             length = 0;

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -593,7 +593,8 @@ namespace Yarhl.IO
             }
 
             if (!Instances.ContainsKey(BaseStream)) {
-                Instances.TryAdd(BaseStream, 1);
+                if (!Instances.TryAdd(BaseStream, 1))
+                    Instances[BaseStream] += 1;
             } else {
                 Instances[BaseStream] += 1;
             }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -602,8 +602,7 @@ namespace Yarhl.IO
 
             lock (BaseStream.LockObj) {
                 if (!Instances.ContainsKey(BaseStream)) {
-                    if (!Instances.TryAdd(BaseStream, 1))
-                        Instances[BaseStream] += 1;
+                    Instances.TryAdd(BaseStream, 1);
                 } else {
                     Instances[BaseStream] += 1;
                 }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -188,10 +188,14 @@ namespace Yarhl.IO
                     if (!canExpand) {
                         throw new InvalidOperationException(
                             "Cannot change the size of sub-streams.");
-                    } else if (value > BaseStream.Length) {
-                        // If we can expand, it's not a substream so forget
-                        // about offset (always 0). Increase base stream too.
-                        BaseStream.SetLength(value);
+                    }
+
+                    lock (BaseStream.LockObj) {
+                        if (value > BaseStream.Length) {
+                            // If we can expand, it's not a substream so forget
+                            // about offset (always 0). Increase base stream too.
+                            BaseStream.SetLength(value);
+                        }
                     }
                 }
 

--- a/src/Yarhl/IO/IStream.cs
+++ b/src/Yarhl/IO/IStream.cs
@@ -27,9 +27,9 @@ namespace Yarhl.IO
     public interface IStream : IDisposable
     {
         /// <summary>
-        /// Gets or sets the lock object of this stream (and all its substreams).
+        /// Gets the lock object of this stream (and all its substreams).
         /// </summary>
-        object LockObj { get; set; }
+        object LockObj { get; }
 
         /// <summary>
         /// Gets or sets the position from the start of this stream.

--- a/src/Yarhl/IO/IStream.cs
+++ b/src/Yarhl/IO/IStream.cs
@@ -27,6 +27,11 @@ namespace Yarhl.IO
     public interface IStream : IDisposable
     {
         /// <summary>
+        /// Gets or sets the lock object of this stream (and all its substreams).
+        /// </summary>
+        object LockObj { get; set; }
+
+        /// <summary>
         /// Gets or sets the position from the start of this stream.
         /// </summary>
         long Position { get; set; }

--- a/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
+++ b/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
@@ -36,6 +36,7 @@ namespace Yarhl.IO.StreamFormat
         public RecyclableMemoryStream()
             : base(Manager.GetStream())
         {
+            LockObj = new object();
         }
 
         /// <summary>

--- a/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
+++ b/src/Yarhl/IO/StreamFormat/RecyclableMemoryStream.cs
@@ -36,7 +36,6 @@ namespace Yarhl.IO.StreamFormat
         public RecyclableMemoryStream()
             : base(Manager.GetStream())
         {
-            LockObj = new object();
         }
 
         /// <summary>

--- a/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
+++ b/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
@@ -34,6 +34,7 @@ namespace Yarhl.IO.StreamFormat
         public StreamWrapper(Stream stream)
         {
             BaseStream = stream;
+            LockObj = new object();
         }
 
         /// <summary>
@@ -41,6 +42,7 @@ namespace Yarhl.IO.StreamFormat
         /// </summary>
         protected StreamWrapper()
         {
+            LockObj = new object();
         }
 
         /// <summary>
@@ -49,6 +51,14 @@ namespace Yarhl.IO.StreamFormat
         public Stream BaseStream {
             get;
             protected set;
+        }
+
+        /// <summary>
+        /// Gets or sets the lock object of this stream (and all its substreams).
+        /// </summary>
+        public object LockObj {
+            get;
+            set;
         }
 
         /// <summary>

--- a/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
+++ b/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
@@ -54,11 +54,10 @@ namespace Yarhl.IO.StreamFormat
         }
 
         /// <summary>
-        /// Gets or sets the lock object of this stream (and all its substreams).
+        /// Gets the lock object of this stream (and all its substreams).
         /// </summary>
         public object LockObj {
             get;
-            set;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description
Add locks to make DataStream thread-safe on reading and writing a shared `IStream`.

**NOTE**: This pull request doesn't address making a `DataStream` completely thread-safe. It will fix the use case when different `DataStream` share the same underlying `IStream` in different threads but it doesn't fix the case when the same `DataStream` is accesed from different threads.

### Example
```
Parallel.For(0, streamCount, i =>
{
    streams[i].Read(read[i], 0, dataLength);
});
```
