### PR TITLE
Merge nodes

### DIFF
--- a/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
@@ -466,6 +466,31 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.IsTrue(subchild1.Disposed);
         }
 
+        [Test]
+        public void MergeNodeChildren()
+        {
+            using var parent1 = new DummyNavigable("Parent1");
+            using var child1 = new DummyNavigable("Child");
+            using var subchild1 = new DummyNavigable("Subchild1");
+
+            using var parent2 = new DummyNavigable("Parent2");
+            using var child2 = new DummyNavigable("Child");
+            using var child3 = new DummyNavigable("Child2");
+            using var subchild2 = new DummyNavigable("Subchild2");
+
+            parent1.Add(child1);
+            child1.Add(subchild1);
+
+            parent2.Add(child2);
+            parent2.Add(child3);
+            child2.Add(subchild2);
+
+            parent1.Add(parent2.Children, false);
+
+            Assert.AreEqual(2, parent1.Children.Count);
+            Assert.AreEqual(2, child1.Children.Count);
+        }
+
         class DummyNavigable : NavigableNode<DummyNavigable>
         {
             public DummyNavigable(string name)

--- a/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
@@ -473,10 +473,15 @@ namespace Yarhl.UnitTests.FileSystem
             using var child1 = new DummyNavigable("Child");
             using var subchild1 = new DummyNavigable("Subchild1");
 
+            child1.Tags.Add("Tag1", "Value1");
+
             using var parent2 = new DummyNavigable("Parent2");
             using var child2 = new DummyNavigable("Child");
             using var child3 = new DummyNavigable("Child2");
             using var subchild2 = new DummyNavigable("Subchild2");
+
+            child2.Tags.Add("Tag1", "Value2");
+            child2.Tags.Add("Tag2", "Value3");
 
             parent1.Add(child1);
             child1.Add(subchild1);
@@ -489,6 +494,9 @@ namespace Yarhl.UnitTests.FileSystem
 
             Assert.AreEqual(2, parent1.Children.Count);
             Assert.AreEqual(2, child1.Children.Count);
+            Assert.AreEqual(2, child1.Tags.Count);
+            Assert.AreEqual("Value1", child1.Tags["Tag1"]);
+            Assert.AreEqual("Value3", child1.Tags["Tag2"]);
         }
 
         class DummyNavigable : NavigableNode<DummyNavigable>

--- a/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
@@ -425,7 +425,7 @@ namespace Yarhl.UnitTests.FileSystem
             using var child = new DummyNavigable("child");
             node.Add(child);
             node.Dispose();
-            Assert.That(node.RemoveChildren, Throws.TypeOf<ObjectDisposedException>());
+            Assert.That(() => node.RemoveChildren(), Throws.TypeOf<ObjectDisposedException>());
         }
 
         [Test]
@@ -464,39 +464,6 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.IsTrue(child1.Disposed);
             Assert.IsTrue(child2.Disposed);
             Assert.IsTrue(subchild1.Disposed);
-        }
-
-        [Test]
-        public void MergeNodeChildren()
-        {
-            using var parent1 = new DummyNavigable("Parent1");
-            using var child1 = new DummyNavigable("Child");
-            using var subchild1 = new DummyNavigable("Subchild1");
-
-            child1.Tags.Add("Tag1", "Value1");
-
-            using var parent2 = new DummyNavigable("Parent2");
-            using var child2 = new DummyNavigable("Child");
-            using var child3 = new DummyNavigable("Child2");
-            using var subchild2 = new DummyNavigable("Subchild2");
-
-            child2.Tags.Add("Tag1", "Value2");
-            child2.Tags.Add("Tag2", "Value3");
-
-            parent1.Add(child1);
-            child1.Add(subchild1);
-
-            parent2.Add(child2);
-            parent2.Add(child3);
-            child2.Add(subchild2);
-
-            parent1.Add(parent2.Children, false);
-
-            Assert.AreEqual(2, parent1.Children.Count);
-            Assert.AreEqual(2, child1.Children.Count);
-            Assert.AreEqual(2, child1.Tags.Count);
-            Assert.AreEqual("Value1", child1.Tags["Tag1"]);
-            Assert.AreEqual("Value3", child1.Tags["Tag2"]);
         }
 
         class DummyNavigable : NavigableNode<DummyNavigable>

--- a/src/Yarhl.UnitTests/FileSystem/NodeContainerFormatTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeContainerFormatTests.cs
@@ -127,6 +127,62 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.Throws<ArgumentNullException>(() => format.MoveChildrenTo(null));
         }
 
+        [Test]
+        public void MoveChildrenToNodeRemovesChildrenFromSource()
+        {
+            using NodeContainerFormat source = new NodeContainerFormat();
+            Node sourceRoot = source.Root;
+
+            using NodeContainerFormat destination = new NodeContainerFormat();
+
+            using Node child = new Node("Child");
+
+            source.Root.Add(child);
+            source.MoveChildrenTo(destination.Root);
+
+            Assert.That(sourceRoot.Children.Count, Is.Zero);
+            Assert.That(destination.Root.Children.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void MoveChildrenToNodeCanMergeContainers()
+        {
+            using Node source = new Node("source", new NodeContainerFormat());
+            using Node destination = new Node("destination", new NodeContainerFormat());
+
+            using Node folder1 = new Node("Folder1", new NodeContainerFormat());
+            using Node folder2 = new Node("Folder2", new NodeContainerFormat());
+            using Node folder3 = new Node("Folder1", new NodeContainerFormat());
+
+            using Node node1 = new Node("File1");
+            using Node node2 = new Node("File2");
+            using Node node3 = new Node("File3");
+            using Node node4 = new Node("File4");
+
+            folder1.Add(node1);
+            folder1.Add(node2);
+            folder2.Add(node3);
+            folder3.Add(node4);
+
+            destination.Add(folder1);
+            destination.Add(folder2);
+            source.Add(folder3);
+
+            Assert.That(source.Children.Count, Is.EqualTo(1));
+            Assert.That(destination.Children.Count, Is.EqualTo(2));
+            Assert.That(folder1.Children.Count, Is.EqualTo(2));
+            Assert.That(folder2.Children.Count, Is.EqualTo(1));
+            Assert.That(folder3.Children.Count, Is.EqualTo(1));
+
+            source.GetFormatAs<NodeContainerFormat>().MoveChildrenTo(destination, true);
+
+            Assert.That(source.Children.Count, Is.Zero);
+            Assert.That(destination.Children.Count, Is.EqualTo(2));
+            Assert.That(folder1.Children.Count, Is.EqualTo(3));
+            Assert.That(folder2.Children.Count, Is.EqualTo(1));
+            Assert.That(folder3.Children.Count, Is.Zero);
+        }
+
         protected override NodeContainerFormat CreateDummyFormat()
         {
             return new NodeContainerFormat();

--- a/src/Yarhl/FileSystem/NavigableNode.cs
+++ b/src/Yarhl/FileSystem/NavigableNode.cs
@@ -111,14 +111,12 @@ namespace Yarhl.FileSystem
         /// Add a node.
         /// </summary>
         /// <remarks>
-        /// <para>Updates the parent of the child node to match this instance.</para>
+        /// <para>Updates the parent of the child node to match this instance.
+        /// If the node already contains a child with the same name it will be replaced.
+        /// Otherwise the node is added.</para>
         /// </remarks>
         /// <param name="node">Node to add.</param>
-        /// <param name="replace">If set to <see langword="true" /> and the node already
-        /// contains a child with the same name it will be replaced.
-        /// If set to <see langword="false" />, the node already
-        /// contains a child with the same name and it has children, it will be merged.</param>
-        public void Add(T node, bool replace = true)
+        public void Add(T node)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(NavigableNode<T>));
@@ -138,18 +136,8 @@ namespace Yarhl.FileSystem
             if (index == -1) {
                 children.Add(node);
             } else {
-                if (!replace && children[index].children.Count > 0) {
-                    foreach (KeyValuePair<string, dynamic> tag in node.Tags) {
-                        if (!children[index].Tags.ContainsKey(tag.Key)) {
-                            children[index].Tags.Add(tag);
-                        }
-                    }
-
-                    children[index].Add(node.children, false);
-                } else {
-                    children[index].Dispose();
-                    children[index] = node;
-                }
+                children[index].Dispose();
+                children[index] = node;
             }
         }
 
@@ -157,11 +145,7 @@ namespace Yarhl.FileSystem
         /// Add a list of nodes.
         /// </summary>
         /// <param name="nodes">List of nodes to add.</param>
-        /// <param name="replace">If set to <see langword="true" /> and the node already
-        /// contains a child with the same name it will be replaced.
-        /// If set to <see langword="false" />, the node already
-        /// contains a child with the same name and it has children, it will be merged.</param>
-        public void Add(IEnumerable<T> nodes, bool replace = true)
+        public void Add(IEnumerable<T> nodes)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(NavigableNode<T>));
@@ -170,7 +154,7 @@ namespace Yarhl.FileSystem
                 throw new ArgumentNullException(nameof(nodes));
 
             foreach (T node in nodes)
-                Add(node, replace);
+                Add(node);
         }
 
         /// <summary>
@@ -229,13 +213,17 @@ namespace Yarhl.FileSystem
         /// <summary>
         /// Removes and dispose all the children from the node.
         /// </summary>
-        public void RemoveChildren()
+        /// <param name="dispose">If set to <see langword="true" /> disposes the nodes before remove them.</param>
+        public void RemoveChildren(bool dispose = true)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(NavigableNode<T>));
 
-            foreach (var child in Children)
-                child.Dispose();
+            if (dispose) {
+                foreach (T child in Children)
+                    child.Dispose();
+            }
+
             children.Clear();
         }
 

--- a/src/Yarhl/FileSystem/NavigableNode.cs
+++ b/src/Yarhl/FileSystem/NavigableNode.cs
@@ -116,7 +116,8 @@ namespace Yarhl.FileSystem
         /// Otherwise the node is added.</para>
         /// </remarks>
         /// <param name="node">Node to add.</param>
-        public void Add(T node)
+        /// <param name="replace"></param>
+        public void Add(T node, bool replace = true)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(NavigableNode<T>));
@@ -136,8 +137,12 @@ namespace Yarhl.FileSystem
             if (index == -1) {
                 children.Add(node);
             } else {
-                children[index].Dispose();
-                children[index] = node;
+                if (!replace && children[index].children.Count > 0) {
+                    children[index].Add(node.children, false);
+                } else {
+                    children[index].Dispose();
+                    children[index] = node;
+                }
             }
         }
 
@@ -145,7 +150,8 @@ namespace Yarhl.FileSystem
         /// Add a list of nodes.
         /// </summary>
         /// <param name="nodes">List of nodes to add.</param>
-        public void Add(IEnumerable<T> nodes)
+        /// <param name="replace"></param>
+        public void Add(IEnumerable<T> nodes, bool replace = true)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(NavigableNode<T>));
@@ -154,7 +160,7 @@ namespace Yarhl.FileSystem
                 throw new ArgumentNullException(nameof(nodes));
 
             foreach (T node in nodes)
-                Add(node);
+                Add(node, replace);
         }
 
         /// <summary>

--- a/src/Yarhl/FileSystem/NavigableNode.cs
+++ b/src/Yarhl/FileSystem/NavigableNode.cs
@@ -111,12 +111,13 @@ namespace Yarhl.FileSystem
         /// Add a node.
         /// </summary>
         /// <remarks>
-        /// <para>Updates the parent of the child node to match this instance.
-        /// If the node already contains a child with the same name it will be replaced.
-        /// Otherwise the node is added.</para>
+        /// <para>Updates the parent of the child node to match this instance.</para>
         /// </remarks>
         /// <param name="node">Node to add.</param>
-        /// <param name="replace"></param>
+        /// <param name="replace">If set to <see langword="true" /> and the node already
+        /// contains a child with the same name it will be replaced.
+        /// If set to <see langword="false" />, the node already
+        /// contains a child with the same name and it has children, it will be merged.</param>
         public void Add(T node, bool replace = true)
         {
             if (Disposed)
@@ -138,6 +139,12 @@ namespace Yarhl.FileSystem
                 children.Add(node);
             } else {
                 if (!replace && children[index].children.Count > 0) {
+                    foreach (KeyValuePair<string, dynamic> tag in node.Tags) {
+                        if (!children[index].Tags.ContainsKey(tag.Key)) {
+                            children[index].Tags.Add(tag);
+                        }
+                    }
+
                     children[index].Add(node.children, false);
                 } else {
                     children[index].Dispose();
@@ -150,7 +157,10 @@ namespace Yarhl.FileSystem
         /// Add a list of nodes.
         /// </summary>
         /// <param name="nodes">List of nodes to add.</param>
-        /// <param name="replace"></param>
+        /// <param name="replace">If set to <see langword="true" /> and the node already
+        /// contains a child with the same name it will be replaced.
+        /// If set to <see langword="false" />, the node already
+        /// contains a child with the same name and it has children, it will be merged.</param>
         public void Add(IEnumerable<T> nodes, bool replace = true)
         {
             if (Disposed)


### PR DESCRIPTION
### Description
Implements the option to merge tree nodes instead of replacing them. If we try to add a node with the same name than an existing one and the parameter is set to `false`, the method will merge their children and tags.

The default value is to keep the current behavior and replace nodes when they have the same name.

### Example
```
node1.Add(node2.Children, false);
```