### PR TITLE
Sort nodes

### DIFF
--- a/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
@@ -466,11 +466,128 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.IsTrue(subchild1.Disposed);
         }
 
+        [Test]
+        public void SortChildrenWithDefaultComparer()
+        {
+            using DummyNavigable parent = new DummyNavigable("Parent");
+            using DummyNavigable child1 = new DummyNavigable("Child2");
+            using DummyNavigable child2 = new DummyNavigable("Child1");
+            using DummyNavigable subchild1 = new DummyNavigable("Subchild2");
+            using DummyNavigable subchild2 = new DummyNavigable("Subchild1");
+
+            child1.Add(subchild1);
+            child1.Add(subchild2);
+            parent.Add(child1);
+            parent.Add(child2);
+
+            Assert.That(parent.Children[0].Name, Is.EqualTo("Child2"));
+            Assert.That(parent.Children[1].Name, Is.EqualTo("Child1"));
+            Assert.That(child1.Children[0].Name, Is.EqualTo("Subchild2"));
+            Assert.That(child1.Children[1].Name, Is.EqualTo("Subchild1"));
+
+            parent.SortChildren();
+
+            Assert.That(parent.Children[0].Name, Is.EqualTo("Child1"));
+            Assert.That(parent.Children[1].Name, Is.EqualTo("Child2"));
+            Assert.That(child1.Children[0].Name, Is.EqualTo("Subchild1"));
+            Assert.That(child1.Children[1].Name, Is.EqualTo("Subchild2"));
+        }
+
+        [Test]
+        public void SortChildrenWithCustomComparer()
+        {
+            using DummyNavigable parent = new DummyNavigable("Parent");
+            using DummyNavigable child1 = new DummyNavigable("Child1");
+            using DummyNavigable child2 = new DummyNavigable("Child2");
+            using DummyNavigable subchild1 = new DummyNavigable("Subchild1");
+            using DummyNavigable subchild2 = new DummyNavigable("Subchild2");
+
+            child1.Add(subchild1);
+            child1.Add(subchild2);
+            parent.Add(child1);
+            parent.Add(child2);
+
+            Assert.That(parent.Children[0].Name, Is.EqualTo("Child1"));
+            Assert.That(parent.Children[1].Name, Is.EqualTo("Child2"));
+            Assert.That(child1.Children[0].Name, Is.EqualTo("Subchild1"));
+            Assert.That(child1.Children[1].Name, Is.EqualTo("Subchild2"));
+
+            parent.SortChildren(new ReverseNodeComparer());
+
+            Assert.That(parent.Children[0].Name, Is.EqualTo("Child2"));
+            Assert.That(parent.Children[1].Name, Is.EqualTo("Child1"));
+            Assert.That(child1.Children[0].Name, Is.EqualTo("Subchild2"));
+            Assert.That(child1.Children[1].Name, Is.EqualTo("Subchild1"));
+        }
+
+        [Test]
+        public void SortChildrenWithComparison()
+        {
+            using DummyNavigable parent = new DummyNavigable("Parent");
+            using DummyNavigable child1 = new DummyNavigable("Child1");
+            using DummyNavigable child2 = new DummyNavigable("Child2");
+            using DummyNavigable subchild1 = new DummyNavigable("Subchild1");
+            using DummyNavigable subchild2 = new DummyNavigable("Subchild2");
+
+            child1.Add(subchild1);
+            child1.Add(subchild2);
+            parent.Add(child1);
+            parent.Add(child2);
+
+            Assert.That(parent.Children[0].Name, Is.EqualTo("Child1"));
+            Assert.That(parent.Children[1].Name, Is.EqualTo("Child2"));
+            Assert.That(child1.Children[0].Name, Is.EqualTo("Subchild1"));
+            Assert.That(child1.Children[1].Name, Is.EqualTo("Subchild2"));
+
+            parent.SortChildren((x, y) =>
+            {
+                if (x == null)
+                {
+                    if (y == null)
+                    {
+                        return 0;
+                    }
+
+                    return 1;
+                }
+
+                if (y == null)
+                {
+                    return -1;
+                }
+
+                return string.Compare(y.Name, x.Name, StringComparison.CurrentCulture);
+            });
+
+            Assert.That(parent.Children[0].Name, Is.EqualTo("Child2"));
+            Assert.That(parent.Children[1].Name, Is.EqualTo("Child1"));
+            Assert.That(child1.Children[0].Name, Is.EqualTo("Subchild2"));
+            Assert.That(child1.Children[1].Name, Is.EqualTo("Subchild1"));
+        }
+
         class DummyNavigable : NavigableNode<DummyNavigable>
         {
             public DummyNavigable(string name)
                 : base(name)
             {
+            }
+        }
+
+        class ReverseNodeComparer : IComparer<DummyNavigable>
+        {
+            public int Compare(DummyNavigable x, DummyNavigable y)
+            {
+                if (x == null)
+                {
+                    return y == null ? 0 : 1;
+                }
+
+                if (y == null)
+                {
+                    return -1;
+                }
+
+                return string.Compare(y.Name, x.Name, StringComparison.CurrentCulture);
             }
         }
     }

--- a/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
@@ -539,30 +539,26 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.That(child1.Children[0].Name, Is.EqualTo("Subchild1"));
             Assert.That(child1.Children[1].Name, Is.EqualTo("Subchild2"));
 
-            parent.SortChildren((x, y) =>
-            {
-                if (x == null)
-                {
-                    if (y == null)
-                    {
-                        return 0;
-                    }
-
-                    return 1;
-                }
-
-                if (y == null)
-                {
-                    return -1;
-                }
-
-                return string.Compare(y.Name, x.Name, StringComparison.CurrentCulture);
-            });
+            parent.SortChildren((x, y) => string.Compare(y.Name, x.Name, StringComparison.CurrentCulture));
 
             Assert.That(parent.Children[0].Name, Is.EqualTo("Child2"));
             Assert.That(parent.Children[1].Name, Is.EqualTo("Child1"));
             Assert.That(child1.Children[0].Name, Is.EqualTo("Subchild2"));
             Assert.That(child1.Children[1].Name, Is.EqualTo("Subchild1"));
+        }
+
+        [Test]
+        public void SortChildrenAfterDisposeThrowsException()
+        {
+            var node = new DummyNavigable("node");
+            using var child = new DummyNavigable("child");
+            node.Add(child);
+            node.Dispose();
+            Assert.That(() => node.SortChildren(), Throws.TypeOf<ObjectDisposedException>());
+            Assert.That(() => node.SortChildren(new ReverseNodeComparer()), Throws.TypeOf<ObjectDisposedException>());
+            Assert.That(
+                () => node.SortChildren((x, y) => string.Compare(y.Name, x.Name, StringComparison.CurrentCulture)),
+                Throws.TypeOf<ObjectDisposedException>());
         }
 
         class DummyNavigable : NavigableNode<DummyNavigable>

--- a/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
@@ -577,16 +577,7 @@ namespace Yarhl.UnitTests.FileSystem
         {
             public int Compare(DummyNavigable x, DummyNavigable y)
             {
-                if (x == null)
-                {
-                    return y == null ? 0 : 1;
-                }
-
-                if (y == null)
-                {
-                    return -1;
-                }
-
+                // x and y cannot be null because Add methods don't allow null parameters.
                 return string.Compare(y.Name, x.Name, StringComparison.CurrentCulture);
             }
         }

--- a/src/Yarhl/FileSystem/NavigableNode.cs
+++ b/src/Yarhl/FileSystem/NavigableNode.cs
@@ -236,6 +236,9 @@ namespace Yarhl.FileSystem
         /// <param name="recursive">If set to <see langword="true" /> sorts the children nodes recursively.</param>
         public void SortChildren(bool recursive = true)
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(NavigableNode<T>));
+
             SortChildren(defaultComparer, recursive);
         }
 
@@ -246,6 +249,9 @@ namespace Yarhl.FileSystem
         /// <param name="recursive">If set to <see langword="true" /> sorts the children nodes recursively.</param>
         public void SortChildren(IComparer<T> comparer, bool recursive = true)
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(NavigableNode<T>));
+
             children.Sort(comparer);
 
             if (recursive) {
@@ -262,6 +268,9 @@ namespace Yarhl.FileSystem
         /// <param name="recursive">If set to <see langword="true" /> sorts the children nodes recursively.</param>
         public void SortChildren(Comparison<T> comparison, bool recursive = true)
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(NavigableNode<T>));
+
             children.Sort(comparison);
 
             if (recursive) {
@@ -288,7 +297,7 @@ namespace Yarhl.FileSystem
             Disposed = true;
         }
 
-        private class DefaultNavigableNodeComparer : IComparer<T>
+        private sealed class DefaultNavigableNodeComparer : IComparer<T>
         {
             public int Compare(T x, T y)
             {

--- a/src/Yarhl/FileSystem/NavigableNode.cs
+++ b/src/Yarhl/FileSystem/NavigableNode.cs
@@ -30,6 +30,7 @@ namespace Yarhl.FileSystem
         where T : NavigableNode<T>
     {
         readonly List<T> children;
+        readonly DefaultNavigableNodeComparer defaultComparer = new DefaultNavigableNodeComparer();
 
         /// <summary>
         /// Initializes a new instance of the
@@ -85,11 +86,7 @@ namespace Yarhl.FileSystem
         /// <summary>
         /// Gets a read-only list of children nodes.
         /// </summary>
-        public NavigableNodeCollection<T> Children
-        {
-            get;
-            private set;
-        }
+        public NavigableNodeCollection<T> Children { get; }
 
         /// <summary>
         /// Gets the dictionary of tags.
@@ -234,6 +231,51 @@ namespace Yarhl.FileSystem
         }
 
         /// <summary>
+        /// Sorts the children nodes using the default comparer.
+        /// </summary>
+        /// <param name="recursive">If set to <see langword="true" /> sorts the children nodes recursively.</param>
+        public void SortChildren(bool recursive = true)
+        {
+            SortChildren(defaultComparer, recursive);
+        }
+
+        /// <summary>
+        /// Sorts the children nodes using the specified comparer.
+        /// </summary>
+        /// <param name="comparer">The <see cref="System.Collections.Generic.IComparer{T}" /> implementation to use when comparing elements.</param>
+        /// <param name="recursive">If set to <see langword="true" /> sorts the children nodes recursively.</param>
+        public void SortChildren(IComparer<T> comparer, bool recursive = true)
+        {
+            children.Sort(comparer);
+
+            if (!recursive)
+                return;
+
+            foreach (T node in children)
+            {
+                node.SortChildren(comparer);
+            }
+        }
+
+        /// <summary>
+        /// Sorts the children nodes using the specified <see cref="System.Comparison{T}" />.
+        /// </summary>
+        /// <param name="comparison">The <see cref="System.Comparison{T}" /> to use when comparing elements.</param>
+        /// <param name="recursive">If set to <see langword="true" /> sorts the children nodes recursively.</param>
+        public void SortChildren(Comparison<T> comparison, bool recursive = true)
+        {
+            children.Sort(comparison);
+
+            if (!recursive)
+                return;
+
+            foreach (T node in children)
+            {
+                node.SortChildren(comparison);
+            }
+        }
+
+        /// <summary>
         /// Releases all resource used by the
         /// <see cref="Yarhl.FileSystem.NavigableNode{T}"/> object.
         /// </summary>
@@ -248,6 +290,24 @@ namespace Yarhl.FileSystem
                 RemoveChildren();
 
             Disposed = true;
+        }
+
+        private class DefaultNavigableNodeComparer : IComparer<T>
+        {
+            public int Compare(T x, T y)
+            {
+                if (x == null)
+                {
+                    return y == null ? 0 : -1;
+                }
+
+                if (y == null)
+                {
+                    return 1;
+                }
+
+                return string.Compare(x.Name, y.Name, StringComparison.CurrentCulture);
+            }
         }
     }
 }

--- a/src/Yarhl/FileSystem/NavigableNode.cs
+++ b/src/Yarhl/FileSystem/NavigableNode.cs
@@ -248,12 +248,10 @@ namespace Yarhl.FileSystem
         {
             children.Sort(comparer);
 
-            if (!recursive)
-                return;
-
-            foreach (T node in children)
-            {
-                node.SortChildren(comparer);
+            if (recursive) {
+                foreach (T node in children) {
+                    node.SortChildren(comparer);
+                }
             }
         }
 
@@ -266,12 +264,10 @@ namespace Yarhl.FileSystem
         {
             children.Sort(comparison);
 
-            if (!recursive)
-                return;
-
-            foreach (T node in children)
-            {
-                node.SortChildren(comparison);
+            if (recursive) {
+                foreach (T node in children) {
+                    node.SortChildren(comparison);
+                }
             }
         }
 
@@ -296,16 +292,7 @@ namespace Yarhl.FileSystem
         {
             public int Compare(T x, T y)
             {
-                if (x == null)
-                {
-                    return y == null ? 0 : -1;
-                }
-
-                if (y == null)
-                {
-                    return 1;
-                }
-
+                // x and y cannot be null because Add methods don't allow null parameters.
                 return string.Compare(x.Name, y.Name, StringComparison.CurrentCulture);
             }
         }

--- a/src/Yarhl/Gendarme.ignore
+++ b/src/Yarhl/Gendarme.ignore
@@ -93,3 +93,7 @@ R: Gendarme.Rules.Performance.AvoidUnneededFieldInitializationRule
 M: System.Void Yarhl.IO.DataStream::.ctor()
 M: System.Void Yarhl.IO.DataStream::.ctor(Yarhl.IO.IStream,System.Int64,System.Int64,System.Boolean)
 M: System.Void Yarhl.IO.DataStream::.ctor(Yarhl.IO.DataStream,System.Int64,System.Int64)
+
+R: Gendarme.Rules.Performance.AvoidUncalledPrivateCodeRule
+# False positive, it's called inside the Sort method
+M: System.Int32 Yarhl.FileSystem.NavigableNode`1/DefaultNavigableNodeComparer::Compare(T,T)


### PR DESCRIPTION
### Description
Implements the sort children nodes functionality. The default sort method is by name, but you can define other sorting strategies. See [List.Sort](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.sort) methods.

### Example
```
node.SortChildren();
```