### PR TITLE
Fix #132

### DIFF
--- a/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
@@ -117,6 +117,18 @@ namespace Yarhl.UnitTests.FileSystem
         }
 
         [Test]
+        public void AddNodeWithSameNameRootIsNotParent()
+        {
+            using var node1 = new DummyNavigable("Node");
+            using var node2 = new DummyNavigable("Node");
+            node1.Add(node2);
+
+            Assert.AreSame(node1, node2.Parent);
+            Assert.AreEqual(1, node1.Children.Count);
+            Assert.AreSame(node2, node1.Children[0]);
+        }
+
+        [Test]
         public void ChildrenGetsByName()
         {
             using var parentNode = new DummyNavigable("MyParent");

--- a/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
@@ -93,13 +93,29 @@ namespace Yarhl.UnitTests.FileSystem
         [Test]
         public void AddChildUpdatesChildrenAndParent()
         {
-            using var parentNode = new DummyNavigable("MyParent");
-            var node = new DummyNavigable("MyChild");
-            parentNode.Add(node);
+            using var parent1 = new DummyNavigable("parent1");
+            using var parent2 = new DummyNavigable("parent2");
+            using var child1 = new DummyNavigable("child1");
+            using var child2 = new DummyNavigable("child2");
 
-            Assert.AreSame(parentNode, node.Parent);
-            Assert.AreEqual(1, parentNode.Children.Count);
-            Assert.AreSame(node, parentNode.Children[0]);
+            parent1.Add(child1);
+            parent2.Add(child2);
+
+            Assert.AreSame(parent1, child1.Parent);
+            Assert.AreSame(parent2, child2.Parent);
+            Assert.AreEqual(1, parent1.Children.Count);
+            Assert.AreEqual(1, parent2.Children.Count);
+            Assert.AreSame(child1, parent1.Children[0]);
+            Assert.AreSame(child2, parent2.Children[0]);
+
+            parent1.Add(child2);
+
+            Assert.AreSame(parent1, child1.Parent);
+            Assert.AreSame(parent1, child2.Parent);
+            Assert.AreEqual(2, parent1.Children.Count);
+            Assert.AreEqual(0, parent2.Children.Count);
+            Assert.AreSame(child1, parent1.Children[0]);
+            Assert.AreSame(child2, parent1.Children[1]);
         }
 
         [Test]
@@ -126,6 +142,23 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.AreSame(node1, node2.Parent);
             Assert.AreEqual(1, node1.Children.Count);
             Assert.AreSame(node2, node1.Children[0]);
+        }
+
+        [Test]
+        public void AddNonRelatedNodesWithSimilarNames()
+        {
+            using var root1 = new DummyNavigable("data");
+            using var root2 = new DummyNavigable("data");
+            using var child1 = new DummyNavigable("node_parent");
+            using var child2 = new DummyNavigable("node");
+
+            root1.Add(child1);
+            root2.Add(child2);
+            child1.Add(child2);
+
+            Assert.AreSame(child1, child2.Parent);
+            Assert.AreEqual(1, child1.Children.Count);
+            Assert.AreSame(child2, child1.Children[0]);
         }
 
         [Test]

--- a/src/Yarhl/FileSystem/NavigableNode.cs
+++ b/src/Yarhl/FileSystem/NavigableNode.cs
@@ -124,8 +124,8 @@ namespace Yarhl.FileSystem
             if (node == null)
                 throw new ArgumentNullException(nameof(node));
 
-            // If the path of the node is fully inside our path, it's a parent.
-            if (Path.StartsWith(node.Path, StringComparison.Ordinal))
+            // If "this" has a parent node and the path of the node is fully inside our path, it's a parent.
+            if (Parent != null && Path.StartsWith(node.Path, StringComparison.Ordinal))
                 throw new ArgumentException("Cannot add one parent as child", nameof(node));
 
             // Update the parent of the child

--- a/src/Yarhl/FileSystem/NavigableNode.cs
+++ b/src/Yarhl/FileSystem/NavigableNode.cs
@@ -21,6 +21,7 @@ namespace Yarhl.FileSystem
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Node with navigation features inside a FileSystem.
@@ -145,7 +146,7 @@ namespace Yarhl.FileSystem
         /// Add a list of nodes.
         /// </summary>
         /// <param name="nodes">List of nodes to add.</param>
-        public void Add(IList<T> nodes)
+        public void Add(IEnumerable<T> nodes)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(NavigableNode<T>));
@@ -153,10 +154,11 @@ namespace Yarhl.FileSystem
             if (nodes == null)
                 throw new ArgumentNullException(nameof(nodes));
 
-            // Do not use a 'foreach'. Add method modifies the nodes collection.
-            for (int i = 0; i < nodes.Count; i++)
+            // Add method modifies the nodes collection, so we need a IList and we can't use a 'foreach' loop.
+            List<T> nodesList = nodes.ToList();
+            for (int i = 0; i < nodesList.Count; i++)
             {
-                T node = nodes[i];
+                T node = nodesList[i];
                 Add(node);
             }
         }


### PR DESCRIPTION
### Description
Just checking the node path in `NavigableNode.Add` method may lead to false positives and throw an exception when the nodes have the same name.

Linked issue:
#132 