### PR TITLE
Fix decoding issues in ReadString of DataReader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0 AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
 WORKDIR /app
 
 # Install mono

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ steps:
     version: 3.1.x
 
 - script: |
-    SYMLINK=6_0_0
+    SYMLINK=6_8_0
     MONOPREFIX=/Library/Frameworks/Mono.framework/Versions/$SYMLINK
     echo "##vso[task.setvariable variable=DYLD_FALLBACK_LIBRARY_PATH;]$MONOPREFIX/lib:/lib:/usr/lib:$DYLD_LIBRARY_FALLBACK_PATH"
     echo "##vso[task.setvariable variable=PKG_CONFIG_PATH;]$MONOPREFIX/lib/pkgconfig:$MONOPREFIX/share/pkgconfig:$PKG_CONFIG_PATH"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,26 +15,16 @@ pool:
 trigger:
   batch: true
   branches:
-    include:
-    - master
-    - features/*
     exclude:
     - gh-pages
 
 steps:
 # Prerequisites:
 - task: UseDotNet@2
-  displayName: 'Install .NET Core 2.2 SDK for Sonar'
+  displayName: 'Install .NET Core 3.1 SDK'
   inputs:
     packageType: sdk
-    version: 2.2.x
-  condition: eq(variables['Agent.OS'], 'Windows_NT')
-
-- task: UseDotNet@2
-  displayName: 'Install .NET Core 3.0 SDK'
-  inputs:
-    packageType: sdk
-    version: 3.0.x
+    version: 3.1.x
 
 - script: |
     SYMLINK=6_0_0
@@ -56,11 +46,9 @@ steps:
   displayName: '[MacOS] Build, test and validate'
   condition: eq(variables['Agent.OS'], 'Darwin')
 
-- powershell: .\build.ps1 --verbosity=diagnostic --target=CI-Windows --pr-number=$Env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER --pr-base=$Env:SYSTEM_PULLREQUEST_SOURCEBRANCH --pr-branch=$Env:SYSTEM_PULLREQUEST_TARGETBRANCH --branch=$Env:BUILD_SOURCEBRANCHNAME
+- powershell: .\build.ps1 --verbosity=diagnostic --target=CI-Windows
   displayName: '[Windows] Build, test and validate'
   condition: eq(variables['Agent.OS'], 'Windows_NT')
-  env:
-    SONAR_TOKEN: $(SONAR_TOKEN)
 
 # Integrate results in Azure DevOps
 - task: PublishTestResults@2
@@ -85,10 +73,9 @@ steps:
     targetPath: artifacts/
   condition: eq(variables['Agent.OS'], 'Linux')
 
-# Disable because of bugs in DocFX
-# - task: PublishPipelineArtifact@0
-#   displayName: '[Linux] Publish doc artifacts'
-#   inputs:
-#     artifactName: 'Documentation'
-#     targetPath: docs/_site/
-#   condition: eq(variables['Agent.OS'], 'Linux')
+- task: PublishPipelineArtifact@0
+  displayName: '[Linux] Publish doc artifacts'
+  inputs:
+    artifactName: 'Documentation'
+    targetPath: docs/_site/
+  condition: eq(variables['Agent.OS'], 'Linux')

--- a/build.cake
+++ b/build.cake
@@ -19,18 +19,18 @@
 // SOFTWARE.
 
 // NUnit tests
-#tool nuget:?package=NUnit.ConsoleRunner&version=3.10.0
+#tool nuget:?package=NUnit.ConsoleRunner&version=3.11.1
 
 // Gendarme: decompress zip
 #addin nuget:?package=Cake.Compression&loaddependencies=true&version=0.2.4
 
 // Test coverage
-#addin nuget:?package=altcover.api&version=6.0.700
+#addin nuget:?package=altcover.api&version=6.8.761
 #tool nuget:?package=ReportGenerator&version=4.2.15
 
 // Documentation
 #addin nuget:?package=Cake.DocFx&version=0.13.1
-#tool nuget:?package=docfx.console&version=2.46.0
+#tool nuget:?package=docfx.console&version=2.51.0
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
@@ -40,13 +40,8 @@ var warnAsErrorOption = warnAsError
     ? MSBuildTreatAllWarningsAs.Error
     : MSBuildTreatAllWarningsAs.Default;
 
-var pullRequestNumber = Argument("pr-number", string.Empty);
-var pullRequestBase = Argument("pr-base", string.Empty);
-var pullRequestBranch = Argument("pr-branch", string.Empty);
-var branchName = Argument("branch", string.Empty);
-
 string netVersion = "48";
-string netcoreVersion = "3.0";
+string netcoreVersion = "3.1";
 string netstandardVersion = "2.0";
 
 string solutionPath = "src/Yarhl.sln";
@@ -81,7 +76,9 @@ Task("Build")
         Configuration = configuration,
         Verbosity = DotNetCoreVerbosity.Minimal,
         MSBuildSettings = new DotNetCoreMSBuildSettings()
-            .TreatAllWarningsAs(warnAsErrorOption),
+            .TreatAllWarningsAs(warnAsErrorOption)
+            .SetConsoleLoggerSettings(new MSBuildLoggerSettings { NoSummary = true })
+            .WithProperty("GenerateFullPaths", "true"),
     });
 
     // Copy Yarhl.Media for the integration tests

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>3.0.0-alpha10</Version>
+        <Version>3.0.0-alpha11</Version>
         <Product>SceneGate</Product>
 
         <Authors>SceneGate</Authors>
@@ -13,20 +13,20 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <SystemCompositionPackageVersion>1.3.0</SystemCompositionPackageVersion>
+        <SystemCompositionPackageVersion>1.4.0</SystemCompositionPackageVersion>
         <SystemRuntimeLoaderPackageVersion>4.3.0</SystemRuntimeLoaderPackageVersion>
-        <EncodingCodePagesPackageVersion>4.6.0</EncodingCodePagesPackageVersion>
-        <RecyclableStreamsPackageVersion>1.2.2</RecyclableStreamsPackageVersion>
-        <MicrosoftCSharpPackageVersion>4.6.0</MicrosoftCSharpPackageVersion>
-        <ReferenceAssembliesPackageVersion>1.0.0-preview.2</ReferenceAssembliesPackageVersion>
+        <EncodingCodePagesPackageVersion>4.7.0</EncodingCodePagesPackageVersion>
+        <RecyclableStreamsPackageVersion>1.3.3</RecyclableStreamsPackageVersion>
+        <MicrosoftCSharpPackageVersion>4.7.0</MicrosoftCSharpPackageVersion>
+        <ReferenceAssembliesPackageVersion>1.0.0</ReferenceAssembliesPackageVersion>
 
         <NUnitPackageVersion>3.12.0</NUnitPackageVersion>
-        <NUnit3TestAdapterPackageVersion>3.15.1</NUnit3TestAdapterPackageVersion>
-        <NetTestSdkPackageVersion>16.3.0</NetTestSdkPackageVersion>
-        <BenchmarkDotNetPackageVersion>0.11.5</BenchmarkDotNetPackageVersion>
+        <NUnit3TestAdapterPackageVersion>3.16.1</NUnit3TestAdapterPackageVersion>
+        <NetTestSdkPackageVersion>16.5.0</NetTestSdkPackageVersion>
+        <BenchmarkDotNetPackageVersion>0.12.1</BenchmarkDotNetPackageVersion>
 
         <StyleCopAnalyzerPackageVersion>1.1.118</StyleCopAnalyzerPackageVersion>
-        <FxCopAnalyzerPackageVersion>2.9.6</FxCopAnalyzerPackageVersion>
-        <SonarAnalyzerPackageVersion>7.17.0.9346</SonarAnalyzerPackageVersion>
+        <FxCopAnalyzerPackageVersion>2.9.8</FxCopAnalyzerPackageVersion>
+        <SonarAnalyzerPackageVersion>8.6.0.16497</SonarAnalyzerPackageVersion>
     </PropertyGroup>
 </Project>

--- a/src/SceneGate.Test.ruleset
+++ b/src/SceneGate.Test.ruleset
@@ -11,6 +11,9 @@
 
     <!-- No need of null checking for quick test method implementations. -->
     <Rule Id="CA1062" Action="None" />
+
+    <!-- Disposing dummy objects make the test code more complex with no benefit. -->
+    <Rule Id="CA2000" Action="None" />
   </Rules>
   <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
     <!-- Testing of different class and interface implementations. -->

--- a/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
+++ b/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Yarhl.IntegrationTests</AssemblyName>
     <Description>Plugin integration tests for Yarhl.</Description>
 
-    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <RootNamespace>Yarhl.IntegrationTests</RootNamespace>
     <CodeAnalysisRuleSet>..\SceneGate.Test.ruleset</CodeAnalysisRuleSet>
     <!-- Mark the project as being a test project -->

--- a/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
+++ b/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Yarhl.IntegrationTests</AssemblyName>
     <Description>Plugin integration tests for Yarhl.</Description>
 
-    <TargetFrameworks>net48;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Yarhl.IntegrationTests</RootNamespace>
     <CodeAnalysisRuleSet>..\SceneGate.Test.ruleset</CodeAnalysisRuleSet>
     <!-- Mark the project as being a test project -->

--- a/src/Yarhl.PerformanceTests/Yarhl.PerformanceTests.csproj
+++ b/src/Yarhl.PerformanceTests/Yarhl.PerformanceTests.csproj
@@ -6,7 +6,7 @@
     <Description>Performance tests for Yarhl.</Description>
     <IsPackable>false</IsPackable>
 
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Yarhl.PerformanceTests</RootNamespace>
     <CodeAnalysisRuleSet>..\SceneGate.Test.ruleset</CodeAnalysisRuleSet>
     <!-- Mark the project as being a test project -->

--- a/src/Yarhl.UnitTests/IO/DataReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataReaderTests.cs
@@ -666,6 +666,24 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void ReadToTokenWithCodeUnitFalsePositive()
+        {
+            // It may happen in some-encodings with variable length size
+            // that single-bytes code unit match a byte of other code units.
+            // It doesn't happen in UTF-16 since it was well-designed :D
+            byte[] buffer = {
+                0x82, 0x50, 0x41, 0x40, 0x00
+            };
+            stream.Write(buffer, 0, buffer.Length);
+
+            stream.Position = 0;
+            string text = reader.ReadStringToToken("@", Encoding.GetEncoding("shift-jis"));
+
+            Assert.That(text, Is.EqualTo("１A"));
+            Assert.That(stream.Position, Is.EqualTo(4));
+        }
+
+        [Test]
         public void ReadToTokenMultipleBuffers()
         {
             for (int i = 0; i < 150; i++)

--- a/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
+++ b/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Yarhl.UnitTests</AssemblyName>
     <Description>Yarhl unit tests.</Description>
 
-    <TargetFrameworks>net48;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Yarhl.UnitTests</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <CodeAnalysisRuleSet>..\SceneGate.Test.ruleset</CodeAnalysisRuleSet>

--- a/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
+++ b/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Yarhl.UnitTests</AssemblyName>
     <Description>Yarhl unit tests.</Description>
 
-    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <RootNamespace>Yarhl.UnitTests</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <CodeAnalysisRuleSet>..\SceneGate.Test.ruleset</CodeAnalysisRuleSet>

--- a/src/Yarhl/IO/DataReader.cs
+++ b/src/Yarhl/IO/DataReader.cs
@@ -224,8 +224,16 @@ namespace Yarhl.IO
         /// <summary>
         /// Reads a char.
         /// </summary>
+        /// <remarks>
+        /// This method read one code units. A code unit may not represent a full
+        /// grapheme. This method may return corrupted code units and may
+        /// advance a wrong number of bytes if the given number of code units to
+        /// read are not enough to represent a grapheme.
+        /// </remarks>
         /// <returns>The next char.</returns>
-        /// <param name="encoding">Optional encoding to use.</param>
+        /// <param name="encoding">
+        /// Encoding to use or <c>null</c> to use <see cref="DefaultEncoding" />.
+        /// </param>
         public char ReadChar(Encoding encoding = null)
         {
             return ReadChars(1, encoding)[0];
@@ -234,9 +242,17 @@ namespace Yarhl.IO
         /// <summary>
         /// Reads an array of chars.
         /// </summary>
-        /// <returns>The chars read.</returns>
-        /// <param name="count">The number of chars to read.</param>
-        /// <param name="encoding">Optional encoding to use.</param>
+        /// <remarks>
+        /// This method reads code units. A code unit may not represent a full
+        /// grapheme. This method may return corrupted code units and may
+        /// advance a wrong number of bytes if the given number of code units to
+        /// read are not enough to represent a grapheme.
+        /// </remarks>
+        /// <returns>The chars (code-units) read.</returns>
+        /// <param name="count">The number of chars (code-units) to read.</param>
+        /// <param name="encoding">
+        /// Encoding to use or <c>null</c> to use <see cref="DefaultEncoding" />.
+        /// </param>
         public char[] ReadChars(int count, Encoding encoding = null)
         {
             if (encoding == null)
@@ -245,22 +261,31 @@ namespace Yarhl.IO
             long startPos = Stream.Position;
             long streamLength = Stream.Length;
 
-            // Reads the maximum number of bytes possible to get that number of chars
-            int charLength = encoding.GetMaxByteCount(count);
-            if (charLength > streamLength - startPos)
-                charLength = (int)(streamLength - startPos);
+            // By cloning the encoding, it becomes non-readonly so we can
+            // change the DecoderFallback to one that won't throw exceptions
+            // if it finds non-text bytes. Yarhl issue #134
+            Encoding encodingNoException = (Encoding)encoding.Clone();
+            encodingNoException.DecoderFallback = DecoderFallback.ReplacementFallback;
 
-            byte[] buffer = ReadBytes(charLength);
-            char[] charArray = encoding.GetChars(buffer);
+            // Read as much as bytes as we can to try to decode the given number
+            // of chars.
+            int maxBytes = encoding.GetMaxByteCount(count);
+            if (maxBytes > streamLength - startPos) {
+                maxBytes = (int)(streamLength - startPos);
+            }
 
-            if (charArray.Length > count)
-                Array.Resize(ref charArray, count);
-            else if (charArray.Length < count)
+            byte[] buffer = ReadBytes(maxBytes);
+            char[] charArray = encodingNoException.GetChars(buffer);
+
+            if (charArray.Length < count) {
                 throw new EndOfStreamException();
+            }
 
-            // Adjust position
-            int actualCharLength = encoding.GetByteCount(charArray);
-            Stream.Seek(startPos + actualCharLength, SeekMode.Start);
+            // Now that we have the required chars, check how many bytes actually
+            // takes to get them and decode again with the original fallbacks
+            int exactBytes = encoding.GetByteCount(charArray, 0, count);
+            charArray = encoding.GetChars(buffer, 0, exactBytes);
+            Stream.Seek(startPos + exactBytes, SeekMode.Start);
 
             return charArray;
         }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.35.0" />
+    <package id="Cake" version="0.37.0" />
 </packages>


### PR DESCRIPTION
### Description
There were some issues calling `DataReader.ReadString()` because it may try to decode half code units of characters. `ReadChars` has a limitation of returning the given number of characters, and some times it may break the decoding process. In `ReadString` I took the same approach as `ReadLine` from the `TextReader` using buffers and trying to decode and search a token.

It also fixes some issues related to old framework and dependencies.

This fixes #134
