### PR TITLE
 Implement Stream.WriteTo with custom offset

### DIFF
--- a/src/Yarhl.UnitTests/FileFormat/ConvertFormatTests.cs
+++ b/src/Yarhl.UnitTests/FileFormat/ConvertFormatTests.cs
@@ -87,11 +87,8 @@ namespace Yarhl.UnitTests.FileFormat
         public void ConvertToThrowsIfConstructorFails()
         {
             using var test = new StringFormatTest { Value = "3" };
-            var ex = Assert.Throws<Exception>(() =>
+            Assert.Throws<Exception>(() =>
                 ConvertFormat.To(typeof(ushort), test));
-            Assert.AreEqual(
-                "Exception of type 'System.Exception' was thrown.",
-                ex.Message);
 
             // Just for coverage
             var converter = new FormatTestBadConstructor("2");

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1445,6 +1445,24 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void WriteSegmentToChangingOffset()
+        {
+            DataStream stream1 = new DataStream();
+            stream1.WriteByte(0xCA);
+            stream1.WriteByte(0xFE);
+            stream1.WriteByte(0x00);
+            stream1.WriteByte(0xFF);
+            DataStream stream2 = new DataStream();
+            stream1.WriteSegmentTo(2, stream2);
+            stream2.Position = 0;
+            Assert.AreEqual(0x00, stream2.ReadByte());
+            Assert.AreEqual(0xFF, stream2.ReadByte());
+            Assert.IsTrue(stream2.Length == 2);
+            stream1.Dispose();
+            stream2.Dispose();
+        }
+
+        [Test]
         public void WriteSegmentToNullFile()
         {
             DataStream stream1 = new DataStream();

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1432,6 +1432,27 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void WriteSegmentToFileCreatesParentFolder()
+        {
+            string tempFile = Path.Combine(
+                Path.GetTempPath(),
+                Path.GetRandomFileName(),
+                Path.GetRandomFileName());
+
+            DataStream stream = new DataStream();
+            stream.WriteByte(0xCA);
+            stream.WriteByte(0xFE);
+            stream.WriteSegmentTo(0, 2, tempFile);
+
+            DataStream fileStream = DataStreamFactory.FromFile(tempFile, FileOpenMode.Read);
+            Assert.That(() => stream.Compare(fileStream), Is.True);
+
+            fileStream.Dispose();
+            File.Delete(tempFile);
+            stream.Dispose();
+        }
+
+        [Test]
         public void WriteSegmentToNullStream()
         {
             DataStream stream = new DataStream();
@@ -1455,6 +1476,20 @@ namespace Yarhl.UnitTests.IO
             stream1.Dispose();
             DataStream stream2 = new DataStream();
             Assert.Throws<ObjectDisposedException>(() => stream1.WriteSegmentTo(0, 2, stream2));
+        }
+
+        [Test]
+        public void WriteSegmentToDisposedStream()
+        {
+            DataStream stream1 = new DataStream();
+            stream1.WriteByte(0xCA);
+            stream1.WriteByte(0xFE);
+            stream1.WriteByte(0x00);
+            stream1.WriteByte(0xFF);
+            DataStream stream2 = new DataStream();
+            stream2.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => stream1.WriteSegmentTo(0, 2, stream2));
+            stream1.Dispose();
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1406,6 +1406,24 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void WriteSegmentToVariableLengthChangingOffset()
+        {
+            DataStream stream1 = new DataStream();
+            stream1.WriteByte(0xCA);
+            stream1.WriteByte(0xFE);
+            stream1.WriteByte(0x00);
+            stream1.WriteByte(0xFF);
+            DataStream stream2 = new DataStream();
+            stream1.WriteSegmentTo(1, 2, stream2);
+            stream2.Position = 0;
+            Assert.AreEqual(0xFE, stream2.ReadByte());
+            Assert.AreEqual(0x00, stream2.ReadByte());
+            Assert.IsTrue(stream2.Length == 2);
+            stream1.Dispose();
+            stream2.Dispose();
+        }
+
+        [Test]
         public void WriteSegmentToNullFile()
         {
             DataStream stream1 = new DataStream();
@@ -1428,7 +1446,7 @@ namespace Yarhl.UnitTests.IO
             stream1.WriteByte(0x00);
             stream1.WriteByte(0xFF);
             stream1.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => stream1.WriteSegmentTo(0, 2, "/ex"));
+            Assert.Throws<ObjectDisposedException>(() => stream1.WriteSegmentTo(1, 2, "/ex"));
         }
 
         [Test]
@@ -1442,7 +1460,11 @@ namespace Yarhl.UnitTests.IO
             DataStream stream = new DataStream();
             stream.WriteByte(0xCA);
             stream.WriteByte(0xFE);
-            stream.WriteSegmentTo(0, 2, tempFile);
+            stream.WriteByte(0x01);
+            stream.WriteByte(0x02);
+            stream.WriteByte(0x03);
+            stream.WriteByte(0x04);
+            stream.WriteSegmentTo(1, 2, tempFile);
 
             DataStream fileStream = DataStreamFactory.FromFile(tempFile, FileOpenMode.Read);
             Assert.That(() => stream.Compare(fileStream), Is.True);
@@ -1461,7 +1483,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.WriteByte(0xFF);
             Assert.Throws<ArgumentNullException>(
-                () => stream.WriteSegmentTo(0, 2, (DataStream)null));
+                () => stream.WriteSegmentTo(1, 2, (DataStream)null));
             stream.Dispose();
         }
 

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1420,7 +1420,7 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void WriteSegmentToAfterDispose()
+        public void WriteSegmentToFileAfterDispose()
         {
             DataStream stream1 = new DataStream();
             stream1.WriteByte(0xCA);
@@ -1429,6 +1429,32 @@ namespace Yarhl.UnitTests.IO
             stream1.WriteByte(0xFF);
             stream1.Dispose();
             Assert.Throws<ObjectDisposedException>(() => stream1.WriteSegmentTo(0, 2, "/ex"));
+        }
+
+        [Test]
+        public void WriteSegmentToNullStream()
+        {
+            DataStream stream = new DataStream();
+            stream.WriteByte(0xCA);
+            stream.WriteByte(0xFE);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0xFF);
+            Assert.Throws<ArgumentNullException>(
+                () => stream.WriteSegmentTo(0, 2, (DataStream)null));
+            stream.Dispose();
+        }
+
+        [Test]
+        public void WriteSegmentToStreamAfterDispose()
+        {
+            DataStream stream1 = new DataStream();
+            stream1.WriteByte(0xCA);
+            stream1.WriteByte(0xFE);
+            stream1.WriteByte(0x00);
+            stream1.WriteByte(0xFF);
+            stream1.Dispose();
+            DataStream stream2 = new DataStream();
+            Assert.Throws<ObjectDisposedException>(() => stream1.WriteSegmentTo(0, 2, stream2));
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1388,6 +1388,24 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void WriteSegmentToVariableLength()
+        {
+            DataStream stream1 = new DataStream();
+            stream1.WriteByte(0xCA);
+            stream1.WriteByte(0xFE);
+            stream1.WriteByte(0x00);
+            stream1.WriteByte(0xFF);
+            DataStream stream2 = new DataStream();
+            stream1.WriteSegmentTo(0, 2, stream2);
+            stream2.Position = 0;
+            Assert.AreEqual(0xCA, stream2.ReadByte());
+            Assert.AreEqual(0xFE, stream2.ReadByte());
+            Assert.IsTrue(stream2.Length == 2);
+            stream1.Dispose();
+            stream2.Dispose();
+        }
+
+        [Test]
         public void CompareTwoEqualStreams()
         {
             DataStream stream1 = new DataStream();

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1406,6 +1406,32 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void WriteSegmentToNullFile()
+        {
+            DataStream stream1 = new DataStream();
+            stream1.WriteByte(0xCA);
+            stream1.WriteByte(0xFE);
+            stream1.WriteByte(0x00);
+            stream1.WriteByte(0xFF);
+            Assert.Throws<ArgumentNullException>(
+                () => stream1.WriteSegmentTo(0, 2, (string)null));
+            Assert.Throws<ArgumentNullException>(() => stream1.WriteSegmentTo(0, 2, string.Empty));
+            stream1.Dispose();
+        }
+
+        [Test]
+        public void WriteSegmentToAfterDispose()
+        {
+            DataStream stream1 = new DataStream();
+            stream1.WriteByte(0xCA);
+            stream1.WriteByte(0xFE);
+            stream1.WriteByte(0x00);
+            stream1.WriteByte(0xFF);
+            stream1.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => stream1.WriteSegmentTo(0, 2, "/ex"));
+        }
+
+        [Test]
         public void CompareTwoEqualStreams()
         {
             DataStream stream1 = new DataStream();

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -511,6 +511,36 @@ namespace Yarhl.IO
         }
 
         /// <summary>
+        /// Writes the stream into another DataStream starting in a defined position.
+        /// </summary>
+        /// <param name="start">Defined starting position.</param>
+        /// <param name="stream">Output DataStream.</param>
+        public void WriteSegmentTo(long start, DataStream stream)
+        {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(DataStream));
+
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+            if (stream.Disposed)
+                throw new ObjectDisposedException(nameof(stream));
+
+            long currPos = Position;
+            Seek(start, SeekMode.Start);
+
+            const int BufferSize = 70 * 1024;
+            byte[] buffer = new byte[Length > BufferSize ? BufferSize : Length];
+
+            while (!EndOfStream)
+            {
+                int read = BlockRead(this, buffer);
+                stream.Write(buffer, 0, read);
+            }
+
+            Seek(currPos, SeekMode.Start);
+        }
+
+        /// <summary>
         /// Compare the content of the stream with another one.
         /// </summary>
         /// <returns>The result of the comparaison.</returns>

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -509,10 +509,10 @@ namespace Yarhl.IO
         /// <summary>
         /// Writes a defined length stream into another DataStream starting in a defined position.
         /// </summary>
-        /// <param name="start">Defined starting position.</param>    
+        /// <param name="start">Defined starting position.</param>
         /// <param name="length">Defined length to be written.</param>
         /// <param name="stream">Output DataStream.</param>
-        public void WriteSegmentTo(long start, long length, DataStream stream)
+        public void WriteSegmentTo(long start, int length, DataStream stream)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(DataStream));
@@ -527,11 +527,8 @@ namespace Yarhl.IO
 
             byte[] buffer = new byte[length];
 
-            while (!EndOfStream)
-            {
-                int read = BlockRead(this, buffer);
-                stream.Write(buffer, 0, read);
-            }
+            int read = BlockRead(this, buffer);
+            stream.Write(buffer, 0, read);
 
             Seek(currPos, SeekMode.Start);
         }
@@ -569,7 +566,7 @@ namespace Yarhl.IO
         /// <param name="start">Defined starting position.</param>
         /// <param name="length">Defined length to be written.</param>
         /// <param name="fileOut">Output file path.</param>
-        public void WriteSegmentTo(long start, long length, string fileOut)
+        public void WriteSegmentTo(long start, int length, string fileOut)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(DataStream));

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -497,8 +497,7 @@ namespace Yarhl.IO
             const int BufferSize = 70 * 1024;
             byte[] buffer = new byte[Length > BufferSize ? BufferSize : Length];
 
-            while (!EndOfStream)
-            {
+            while (!EndOfStream) {
                 int read = BlockRead(this, buffer);
                 stream.Write(buffer, 0, read);
             }
@@ -512,7 +511,7 @@ namespace Yarhl.IO
         /// <param name="start">Defined starting position.</param>
         /// <param name="length">Defined length to be written.</param>
         /// <param name="stream">Output DataStream.</param>
-        public void WriteSegmentTo(long start, int length, DataStream stream)
+        public void WriteSegmentTo(long start, long length, DataStream stream)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(DataStream));
@@ -525,10 +524,13 @@ namespace Yarhl.IO
             long currPos = Position;
             Seek(start, SeekMode.Start);
 
-            byte[] buffer = new byte[length];
+            const int BufferSize = 70 * 1024;
+            byte[] buffer = new byte[length > BufferSize ? BufferSize : length];
 
-            int read = BlockRead(this, buffer);
-            stream.Write(buffer, 0, read);
+            while (!EndOfStream) {
+                int read = BlockRead(this, buffer);
+                stream.Write(buffer, 0, read);
+            }
 
             Seek(currPos, SeekMode.Start);
         }
@@ -549,13 +551,11 @@ namespace Yarhl.IO
             // Parent dir can be empty if we just specified the file name.
             // In that case, the folder (cwd) already exists.
             string parentDir = Path.GetDirectoryName(fileOut);
-            if (!string.IsNullOrEmpty(parentDir))
-            {
+            if (!string.IsNullOrEmpty(parentDir)) {
                 Directory.CreateDirectory(parentDir);
             }
 
-            using (var stream = DataStreamFactory.FromFile(fileOut, FileOpenMode.Write))
-            {
+            using (var stream = DataStreamFactory.FromFile(fileOut, FileOpenMode.Write)) {
                 WriteSegmentTo(start, stream);
             }
         }
@@ -566,7 +566,7 @@ namespace Yarhl.IO
         /// <param name="start">Defined starting position.</param>
         /// <param name="length">Defined length to be written.</param>
         /// <param name="fileOut">Output file path.</param>
-        public void WriteSegmentTo(long start, int length, string fileOut)
+        public void WriteSegmentTo(long start, long length, string fileOut)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(DataStream));
@@ -577,8 +577,7 @@ namespace Yarhl.IO
             // Parent dir can be empty if we just specified the file name.
             // In that case, the folder (cwd) already exists.
             string parentDir = Path.GetDirectoryName(fileOut);
-            if (!string.IsNullOrEmpty(parentDir))
-            {
+            if (!string.IsNullOrEmpty(parentDir)) {
                 Directory.CreateDirectory(parentDir);
             }
 

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -524,13 +524,10 @@ namespace Yarhl.IO
             long currPos = Position;
             Seek(start, SeekMode.Start);
 
-            const int BufferSize = 70 * 1024;
-            byte[] buffer = new byte[length > BufferSize ? BufferSize : length];
+            byte[] buffer = new byte[length];
 
-            while (!EndOfStream) {
-                int read = BlockRead(this, buffer);
-                stream.Write(buffer, 0, read);
-            }
+            int read = BlockRead(this, buffer);
+            stream.Write(buffer, 0, read);
 
             Seek(currPos, SeekMode.Start);
         }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -544,7 +544,7 @@ namespace Yarhl.IO
         /// Writes a defined length stream into another DataStream starting in a defined position.
         /// </summary>
         /// <param name="start">Defined starting position.</param>    
-        /// /// <param name="length">Defined length to be written.</param>
+        /// <param name="length">Defined length to be written.</param>
         /// <param name="stream">Output DataStream.</param>
         public void WriteSegmentTo(long start, long length, DataStream stream)
         {
@@ -559,7 +559,6 @@ namespace Yarhl.IO
             long currPos = Position;
             Seek(start, SeekMode.Start);
 
-            const int BufferSize = 70 * 1024;
             byte[] buffer = new byte[length];
 
             while (!EndOfStream)
@@ -569,6 +568,61 @@ namespace Yarhl.IO
             }
 
             Seek(currPos, SeekMode.Start);
+        }
+
+        /// <summary>
+        /// Writes the stream into a file starting in a defined position.
+        /// </summary>
+        /// /// <param name="start">Defined starting position.</param>
+        /// <param name="fileOut">Output file path.</param>
+        public void WriteSegmentTo(long start, string fileOut)
+        {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(DataStream));
+
+            if (string.IsNullOrEmpty(fileOut))
+                throw new ArgumentNullException(nameof(fileOut));
+
+            // Parent dir can be empty if we just specified the file name.
+            // In that case, the folder (cwd) already exists.
+            string parentDir = Path.GetDirectoryName(fileOut);
+            if (!string.IsNullOrEmpty(parentDir))
+            {
+                Directory.CreateDirectory(parentDir);
+            }
+
+            using (var stream = DataStreamFactory.FromFile(fileOut, FileOpenMode.Write))
+            {
+                WriteSegmentTo(start, stream);
+            }
+        }
+
+        /// <summary>
+        /// Writes a defined length stream into a file starting in a defined position.
+        /// </summary>
+        /// <param name="start">Defined starting position.</param>
+        /// <param name="length">Defined length to be written.</param>
+        /// <param name="fileOut">Output file path.</param>
+        public void WriteSegmentTo(long start, long length, string fileOut)
+        {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(DataStream));
+
+            if (string.IsNullOrEmpty(fileOut))
+                throw new ArgumentNullException(nameof(fileOut));
+
+            // Parent dir can be empty if we just specified the file name.
+            // In that case, the folder (cwd) already exists.
+            string parentDir = Path.GetDirectoryName(fileOut);
+            if (!string.IsNullOrEmpty(parentDir))
+            {
+                Directory.CreateDirectory(parentDir);
+            }
+
+            using (var stream = DataStreamFactory.FromFile(fileOut, FileOpenMode.Write))
+            {
+                WriteSegmentTo(start, length, stream);
+            }
         }
 
         /// <summary>

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -464,22 +464,7 @@ namespace Yarhl.IO
         /// <param name="fileOut">Output file path.</param>
         public void WriteTo(string fileOut)
         {
-            if (Disposed)
-                throw new ObjectDisposedException(nameof(DataStream));
-
-            if (string.IsNullOrEmpty(fileOut))
-                throw new ArgumentNullException(nameof(fileOut));
-
-            // Parent dir can be empty if we just specified the file name.
-            // In that case, the folder (cwd) already exists.
-            string parentDir = Path.GetDirectoryName(fileOut);
-            if (!string.IsNullOrEmpty(parentDir)) {
-                Directory.CreateDirectory(parentDir);
-            }
-
-            using (var stream = DataStreamFactory.FromFile(fileOut, FileOpenMode.Write)) {
-                WriteTo(stream);
-            }
+            WriteSegmentTo(0, fileOut);
         }
 
         /// <summary>
@@ -488,26 +473,7 @@ namespace Yarhl.IO
         /// <param name="stream">Output DataStream.</param>
         public void WriteTo(DataStream stream)
         {
-            if (Disposed)
-                throw new ObjectDisposedException(nameof(DataStream));
-
-            if (stream == null)
-                throw new ArgumentNullException(nameof(stream));
-            if (stream.Disposed)
-                throw new ObjectDisposedException(nameof(stream));
-
-            long currPos = Position;
-            Seek(0, SeekMode.Start);
-
-            const int BufferSize = 70 * 1024;
-            byte[] buffer = new byte[Length > BufferSize ? BufferSize : Length];
-
-            while (!EndOfStream) {
-                int read = BlockRead(this, buffer);
-                stream.Write(buffer, 0, read);
-            }
-
-            Seek(currPos, SeekMode.Start);
+            WriteSegmentTo(0, stream);
         }
 
         /// <summary>

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -495,7 +495,7 @@ namespace Yarhl.IO
             Seek(start, SeekMode.Start);
 
             const int BufferSize = 70 * 1024;
-            byte[] buffer = new byte[Length > BufferSize ? BufferSize : Length];
+            byte[] buffer = new byte[Length - start > BufferSize ? BufferSize : Length - start];
 
             while (!EndOfStream) {
                 int read = BlockRead(this, buffer);

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -541,6 +541,37 @@ namespace Yarhl.IO
         }
 
         /// <summary>
+        /// Writes a defined length stream into another DataStream starting in a defined position.
+        /// </summary>
+        /// <param name="start">Defined starting position.</param>    
+        /// /// <param name="length">Defined length to be written.</param>
+        /// <param name="stream">Output DataStream.</param>
+        public void WriteSegmentTo(long start, long length, DataStream stream)
+        {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(DataStream));
+
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+            if (stream.Disposed)
+                throw new ObjectDisposedException(nameof(stream));
+
+            long currPos = Position;
+            Seek(start, SeekMode.Start);
+
+            const int BufferSize = 70 * 1024;
+            byte[] buffer = new byte[length];
+
+            while (!EndOfStream)
+            {
+                int read = BlockRead(this, buffer);
+                stream.Write(buffer, 0, read);
+            }
+
+            Seek(currPos, SeekMode.Start);
+        }
+
+        /// <summary>
         /// Compare the content of the stream with another one.
         /// </summary>
         /// <returns>The result of the comparaison.</returns>


### PR DESCRIPTION
### Description
Now there's a `Stream.WriteSegmentTo` function so you can provide a custom offset to it and it will write in the determined position, it's just a change in the use of `Seek` in the `WriteTo` function.
`WriteTo` also changed to work with `WriteSegmentTo(0, stream);`
As @pleonex suggested, there's also an overload of this function with a custom length, the function will define the size of the buffer with the provided length instead of reading the length of the stream.


### Example
`WriteSegmentTo(long start, DataStream stream)`
`WriteSegmentTo(long start, long length, DataStream stream)`

Linked issue:
#73 