### PR TITLE
Support float and double types in ReadByType and WriteOfType

### DIFF
--- a/src/Yarhl.UnitTests/IO/DataReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataReaderTests.cs
@@ -802,8 +802,10 @@ namespace Yarhl.UnitTests.IO
                 0x06, 0x00,
                 0x07,
                 0x08,
+                0x39, 0x00,
                 0x61,
-                0x38, 0x00,
+                0x00, 0x00, 0x30, 0x41,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x28, 0x40,
             };
             stream.Write(expected, 0, expected.Length);
 
@@ -840,13 +842,21 @@ namespace Yarhl.UnitTests.IO
             Assert.IsInstanceOf<sbyte>(sbyteValue);
             Assert.AreEqual(8, sbyteValue);
 
+            dynamic stringValue = reader.ReadByType(typeof(string));
+            Assert.IsInstanceOf<string>(stringValue);
+            Assert.AreEqual("9", stringValue);
+
             dynamic charValue = reader.ReadByType(typeof(char));
             Assert.IsInstanceOf<char>(charValue);
             Assert.AreEqual('a', charValue);
 
-            dynamic stringValue = reader.ReadByType(typeof(string));
-            Assert.IsInstanceOf<string>(stringValue);
-            Assert.AreEqual("8", stringValue);
+            dynamic floatValue = reader.ReadByType(typeof(float));
+            Assert.IsInstanceOf<float>(floatValue);
+            Assert.AreEqual(11, floatValue);
+
+            dynamic doubleValue = reader.ReadByType(typeof(double));
+            Assert.IsInstanceOf<double>(doubleValue);
+            Assert.AreEqual(12, doubleValue);
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/DataWriterTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataWriterTests.cs
@@ -749,7 +749,8 @@ namespace Yarhl.UnitTests.IO
             writer.WriteOfType(typeof(sbyte), 8);
             writer.WriteOfType(typeof(string), 9);
             writer.WriteOfType(typeof(char), 'a');
-            writer.WriteOfType(typeof(string), "8");
+            writer.WriteOfType(typeof(float), 11);
+            writer.WriteOfType(typeof(double), 12);
 
             byte[] expected = {
                 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -762,7 +763,8 @@ namespace Yarhl.UnitTests.IO
                 0x08,
                 0x39, 0x00,
                 0x61,
-                0x38, 0x00,
+                0x00, 0x00, 0x30, 0x41,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x28, 0x40,
             };
             Assert.AreEqual(expected.Length, stream.Length);
 
@@ -788,7 +790,8 @@ namespace Yarhl.UnitTests.IO
             writer.WriteOfType<sbyte>(8);
             writer.WriteOfType<string>("9");
             writer.WriteOfType<char>('a');
-            writer.WriteOfType<string>("8");
+            writer.WriteOfType<float>(11);
+            writer.WriteOfType<double>(12);
 
             byte[] expected = {
                 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -801,7 +804,8 @@ namespace Yarhl.UnitTests.IO
                 0x08,
                 0x39, 0x00,
                 0x61,
-                0x38, 0x00,
+                0x00, 0x00, 0x30, 0x41,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x28, 0x40,
             };
             Assert.AreEqual(expected.Length, stream.Length);
 

--- a/src/Yarhl/IO/DataReader.cs
+++ b/src/Yarhl/IO/DataReader.cs
@@ -425,6 +425,10 @@ namespace Yarhl.IO
                 return ReadChar();
             if (type == typeof(string))
                 return ReadString();
+            if (type == typeof(float))
+                return ReadSingle();
+            if (type == typeof(double))
+                return ReadDouble();
 
             throw new FormatException("Unsupported type");
         }

--- a/src/Yarhl/IO/DataWriter.cs
+++ b/src/Yarhl/IO/DataWriter.cs
@@ -395,6 +395,14 @@ namespace Yarhl.IO
                     Write(str);
                     break;
 
+                case float f:
+                    Write(f);
+                    break;
+
+                case double d:
+                    Write(d);
+                    break;
+
                 default:
                     throw new FormatException("Unsupported type");
             }


### PR DESCRIPTION
### Description
Add `float` and `double` types to `DataReader.ReadByType` and `DataWriter.WriteOfType`.

### Example
```cs
writer.WriteOfType<double>(12);
var v = reader.ReadByType<double>();
```

Linked issue: No
