### PR TITLE
Remove double slashes in path

### DIFF
--- a/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
@@ -557,7 +557,7 @@ namespace Yarhl.UnitTests.FileSystem
             File.Create(tempFile).Dispose();
 
             Node node = NodeFactory.FromDirectory(
-                string.Concat(root, "//", child),
+                string.Concat(root, Path.DirectorySeparatorChar, Path.DirectorySeparatorChar, child),
                 "*",
                 "Issue139",
                 true);

--- a/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
@@ -541,5 +541,35 @@ namespace Yarhl.UnitTests.FileSystem
                 () => NodeFactory.FromSubstream("node", null, 0, 0),
                 Throws.ArgumentNullException);
         }
+
+        [Test]
+        public void CreateFromDirectoryWithDoubleSlashes()
+        {
+            // Issue #139
+            string root = Path.GetTempPath();
+            string child = Path.GetRandomFileName();
+            string tempDir = Path.Combine(root, child);
+            Directory.CreateDirectory(tempDir);
+
+            string tempFolder = Path.Combine(tempDir, "folder");
+            Assert.That(Directory.CreateDirectory(tempFolder).Exists, Is.True);
+            string tempFile = Path.Combine(tempFolder, "file.txt");
+            File.Create(tempFile).Dispose();
+
+            Node node = NodeFactory.FromDirectory(
+                string.Concat(root, "//", child),
+                "*",
+                "Issue139",
+                true);
+
+            Directory.Delete(tempDir, true);
+
+            Assert.AreEqual(1, node.Children.Count);
+            Assert.That(node.Children["folder"], Is.Not.Null);
+            Assert.AreEqual(1, node.Children["folder"].Children.Count);
+            Assert.That(node.Children["folder"].Children["file.txt"], Is.Not.Null);
+
+            node.Dispose();
+        }
     }
 }

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -208,6 +208,9 @@ namespace Yarhl.FileSystem
             var options = subDirectories ?
                 SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
 
+            // This sanitizes the path and remove double slashes
+            dirPath = Path.GetFullPath(dirPath);
+
             Node folder = CreateContainer(nodeName);
             folder.Tags["DirectoryInfo"] = new DirectoryInfo(dirPath);
 


### PR DESCRIPTION
### Description
Fixes bug when calling `NodeFactory.FromDirectory` using a path with double slashes.

### Example
```cs
Node node = NodeFactory.FromDirectory("/tmp//oypdxh0j.dkq", "*", "name", true);
```

Closes #139 