### PR TITLE
DataStream.WriteTo does not create the file when the length is zero

### DIFF
--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1397,7 +1397,9 @@ namespace Yarhl.UnitTests.IO
 
             DataStream stream1 = new DataStream();
             stream1.WriteTo(tempFile);
-            Assert.AreEqual(0, new FileStream(tempFile, FileMode.Open).Length);
+            FileStream fs = new FileStream(tempFile, FileMode.Open);
+            Assert.AreEqual(0, fs.Length);
+            fs.Dispose();
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1400,6 +1400,7 @@ namespace Yarhl.UnitTests.IO
             FileStream fs = new FileStream(tempFile, FileMode.Open);
             Assert.AreEqual(0, fs.Length);
             fs.Dispose();
+            File.Delete(tempFile);
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1388,6 +1388,19 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void WriteToWhenLengthZero()
+        {
+            string tempFile = Path.Combine(
+                Path.GetTempPath(),
+                Path.GetRandomFileName(),
+                Path.GetRandomFileName());
+
+            DataStream stream1 = new DataStream();
+            stream1.WriteTo(tempFile);
+            Assert.AreEqual(0, new FileStream(tempFile, FileMode.Open).Length);
+        }
+
+        [Test]
         public void WriteSegmentToVariableLength()
         {
             DataStream stream1 = new DataStream();

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1397,7 +1397,7 @@ namespace Yarhl.UnitTests.IO
 
             DataStream stream1 = new DataStream();
             stream1.WriteTo(tempFile);
-            FileStream fs = new FileStream(tempFile, FileMode.Open);
+            FileStream fs = new FileStream(tempFile, FileMode.Open, FileAccess.Read);
             Assert.AreEqual(0, fs.Length);
             fs.Dispose();
             File.Delete(tempFile);

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -563,7 +563,7 @@ namespace Yarhl.IO
                 Directory.CreateDirectory(parentDir);
             }
 
-            using (var stream = DataStreamFactory.FromFile(fileOut, FileOpenMode.Write)) {
+            using (var stream = DataStreamFactory.FromStream(new FileStream(fileOut, FileMode.OpenOrCreate))) {
                 WriteSegmentTo(start, stream);
             }
         }
@@ -589,8 +589,7 @@ namespace Yarhl.IO
                 Directory.CreateDirectory(parentDir);
             }
 
-            using (var stream = DataStreamFactory.FromFile(fileOut, FileOpenMode.Write))
-            {
+            using (var stream = DataStreamFactory.FromStream(new FileStream(fileOut, FileMode.OpenOrCreate))) {
                 WriteSegmentTo(start, length, stream);
             }
         }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -563,7 +563,7 @@ namespace Yarhl.IO
                 Directory.CreateDirectory(parentDir);
             }
 
-            using (var stream = DataStreamFactory.FromStream(new FileStream(fileOut, FileMode.OpenOrCreate))) {
+            using (var stream = DataStreamFactory.FromStream(new FileStream(fileOut, FileMode.OpenOrCreate, FileAccess.Write))) {
                 WriteSegmentTo(start, stream);
             }
         }
@@ -589,7 +589,7 @@ namespace Yarhl.IO
                 Directory.CreateDirectory(parentDir);
             }
 
-            using (var stream = DataStreamFactory.FromStream(new FileStream(fileOut, FileMode.OpenOrCreate))) {
+            using (var stream = DataStreamFactory.FromStream(new FileStream(fileOut, FileMode.OpenOrCreate, FileAccess.Write))) {
                 WriteSegmentTo(start, length, stream);
             }
         }


### PR DESCRIPTION
### Description
If the user has a `DataStream` with Length equals to zero, calling to `WriteTo(path)` will not create an empty file.
Bug solved by using `FileStream` instead of `LazyFileStream`.

### Example
`WriteTo` now has:
```
using (var stream = DataStreamFactory.FromStream(new FileStream(fileOut, FileMode.OpenOrCreate)))
            {
                WriteSegmentTo(start, stream);
            }
```

Closes #136  