### PR TITLE
Solved DataStreamFactory does not check if the file exists when openi…

### DIFF
--- a/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
@@ -364,6 +364,25 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void CreateFromPathChecksIfFileExists()
+        {
+            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Assert.That(File.Exists(tempFile), Is.False);
+            Assert.That(
+                () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Read),
+                Throws.Exception);
+            Assert.That(
+                () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Write),
+                Throws.Nothing);
+            Assert.That(
+                () => DataStreamFactory.FromFile(tempFile, FileOpenMode.ReadWrite),
+                Throws.Nothing);
+            Assert.That(
+                () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Append),
+                Throws.Exception);
+        }
+
+        [Test]
         public void CreateFromSectionPathWritesFile()
         {
             string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
@@ -380,6 +380,19 @@ namespace Yarhl.UnitTests.IO
             Assert.That(
                 () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Append),
                 Throws.Exception);
+
+            Assert.That(
+                () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Read, 0, 0),
+                Throws.Exception);
+            Assert.That(
+                () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Write, 0, 0),
+                Throws.Exception);
+            Assert.That(
+                () => DataStreamFactory.FromFile(tempFile, FileOpenMode.ReadWrite, 0, 0),
+                Throws.Exception);
+            Assert.That(
+                () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Append, 0, 0),
+                Throws.Exception);
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
@@ -379,7 +379,7 @@ namespace Yarhl.UnitTests.IO
                 Throws.Nothing);
             Assert.That(
                 () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Append),
-                Throws.Exception);
+                Throws.Nothing);
 
             Assert.That(
                 () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Read, 0, 0),

--- a/src/Yarhl/IO/DataStreamFactory.cs
+++ b/src/Yarhl/IO/DataStreamFactory.cs
@@ -138,7 +138,7 @@ namespace Yarhl.IO
         {
             if (string.IsNullOrEmpty(path))
                 throw new ArgumentNullException(nameof(path));
-            if ((mode == FileOpenMode.Read || mode == FileOpenMode.Append) && !File.Exists(path)) {
+            if (mode == FileOpenMode.Read && !File.Exists(path)) {
                 throw new FileNotFoundException(nameof(path));
             }
 
@@ -158,7 +158,7 @@ namespace Yarhl.IO
         {
             if (string.IsNullOrEmpty(path))
                 throw new ArgumentNullException(nameof(path));
-            if ((mode == FileOpenMode.Read || mode == FileOpenMode.Append) && !File.Exists(path)) {
+            if (mode == FileOpenMode.Read && !File.Exists(path)) {
                 throw new FileNotFoundException(nameof(path));
             }
 

--- a/src/Yarhl/IO/DataStreamFactory.cs
+++ b/src/Yarhl/IO/DataStreamFactory.cs
@@ -138,6 +138,9 @@ namespace Yarhl.IO
         {
             if (string.IsNullOrEmpty(path))
                 throw new ArgumentNullException(nameof(path));
+            if ((mode == FileOpenMode.Read || mode == FileOpenMode.Append) && !File.Exists(path)) {
+                throw new FileNotFoundException(nameof(path));
+            }
 
             var baseStream = new LazyFileStream(path, mode);
             return new DataStream(baseStream);

--- a/src/Yarhl/IO/DataStreamFactory.cs
+++ b/src/Yarhl/IO/DataStreamFactory.cs
@@ -158,6 +158,9 @@ namespace Yarhl.IO
         {
             if (string.IsNullOrEmpty(path))
                 throw new ArgumentNullException(nameof(path));
+            if ((mode == FileOpenMode.Read || mode == FileOpenMode.Append) && !File.Exists(path)) {
+                throw new FileNotFoundException(nameof(path));
+            }
 
             long fileSize = new FileInfo(path).Length;
             if (offset < 0 || offset > fileSize)


### PR DESCRIPTION
### Description
Added a `!File.Exists(path)` in the `FromFile(string path, FileOpenMode mode)` with a check that detects if you are using a `Read` or an `Append FileOpenMode`.
The check is not needed in the `FromFile(string path, FileOpenMode mode, long offset, long length)` as the `FileInfo` invoke already detects if the file exists before opening, a `FileNotFoundException` will be thrown in both cases.

Closes #135 