### PR TITLE
Implemented method Slice in DataStream

### DIFF
--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -974,12 +974,21 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0xCA);
             stream.WriteByte(0xFE);
 
+            DataStream testSlice = stream.Slice(2);
             Assert.That(
-                () => stream.Slice(2),
+                () => testSlice,
                 Throws.Nothing);
+            Assert.AreEqual(0, testSlice.Position);
+            Assert.AreEqual(2, testSlice.Offset);
+            Assert.AreEqual(stream.Length - testSlice.Offset, testSlice.Length);
+
+            testSlice = stream.Slice(2, 2);
             Assert.That(
-                () => stream.Slice(2, 2),
+                () => testSlice,
                 Throws.Nothing);
+            Assert.AreEqual(0, testSlice.Position);
+            Assert.AreEqual(2, testSlice.Offset);
+            Assert.AreEqual(2, testSlice.Length);
             Assert.That(
                 () => stream.Slice(10),
                 Throws.Exception);

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -954,7 +954,7 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadFormAfeterDisposeThrowException()
+        public void ReadFormAfterDisposeThrowException()
         {
             DataStream stream = new DataStream();
             stream.WriteByte(0xAF);
@@ -963,6 +963,32 @@ namespace Yarhl.UnitTests.IO
             stream.Dispose();
             Assert.IsTrue(stream.Disposed);
             Assert.Throws<ObjectDisposedException>(() => stream.ReadFormat<byte>());
+        }
+
+        [Test]
+        public void SliceStream()
+        {
+            DataStream stream = new DataStream();
+            stream.WriteByte(0xBE);
+            stream.WriteByte(0xBA);
+            stream.WriteByte(0xCA);
+            stream.WriteByte(0xFE);
+
+            Assert.That(
+                () => stream.Slice(2),
+                Throws.Nothing);
+            Assert.That(
+                () => stream.Slice(2, 2),
+                Throws.Nothing);
+            Assert.That(
+                () => stream.Slice(10),
+                Throws.Exception);
+            Assert.That(
+                () => stream.Slice(10, 10),
+                Throws.Exception);
+            Assert.That(
+                () => stream.Slice(2, 10),
+                Throws.Exception);
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -982,13 +982,13 @@ namespace Yarhl.UnitTests.IO
             Assert.AreEqual(2, testSlice.Offset);
             Assert.AreEqual(stream.Length - testSlice.Offset, testSlice.Length);
 
-            testSlice = stream.Slice(2, 2);
+            testSlice = stream.Slice(2, 1);
             Assert.That(
                 () => testSlice,
                 Throws.Nothing);
             Assert.AreEqual(0, testSlice.Position);
             Assert.AreEqual(2, testSlice.Offset);
-            Assert.AreEqual(2, testSlice.Length);
+            Assert.AreEqual(1, testSlice.Length);
             Assert.That(
                 () => stream.Slice(10),
                 Throws.Exception);

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -640,6 +640,29 @@ namespace Yarhl.IO
         }
 
         /// <summary>
+        /// Creates a substream starting in a defined position.
+        /// </summary>
+        /// <returns>The substream defined by offset and length parameters.</returns>
+        /// <param name="start">Defined starting position.</param>
+        public DataStream Slice(long start)
+        {
+            // TODO
+            return ParentDataStream;
+        }
+
+        /// <summary>
+        /// Creates a substream starting in a defined position and with a defined length.
+        /// </summary>
+        /// <returns>The substream defined by offset and length parameters.</returns>
+        /// <param name="start">Defined starting position.</param>
+        /// <param name="length">Defined length to be written.</param>
+        public DataStream Slice(long start, long length)
+        {
+            // TODO
+            return ParentDataStream;
+        }
+
+        /// <summary>
         /// Releases all resource used by the <see cref="DataStream"/>
         /// object.
         /// </summary>

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -649,10 +649,7 @@ namespace Yarhl.IO
             if (start < 0 || start > Length)
                 throw new ArgumentOutOfRangeException(nameof(start));
 
-            DataStream slicedStream = new DataStream();
-            WriteSegmentTo(start, slicedStream);
-
-            return slicedStream;
+            return new DataStream(this, start, Length - start);
         }
 
         /// <summary>
@@ -668,10 +665,7 @@ namespace Yarhl.IO
             if (length < 0 || start + length > Length)
                 throw new ArgumentOutOfRangeException(nameof(length));
 
-            DataStream slicedStream = new DataStream();
-            WriteSegmentTo(start, length, slicedStream);
-
-            return slicedStream;
+            return new DataStream(this, start, length);
         }
 
         /// <summary>

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -646,6 +646,9 @@ namespace Yarhl.IO
         /// <param name="start">Defined starting position.</param>
         public DataStream Slice(long start)
         {
+            if (start < 0 || start > Length)
+                throw new ArgumentOutOfRangeException(nameof(start));
+
             // TODO
             return ParentDataStream;
         }
@@ -658,6 +661,11 @@ namespace Yarhl.IO
         /// <param name="length">Defined length to be written.</param>
         public DataStream Slice(long start, long length)
         {
+            if (start < 0 || start > Length)
+                throw new ArgumentOutOfRangeException(nameof(start));
+            if (length < 0 || start + length > Length)
+                throw new ArgumentOutOfRangeException(nameof(length));
+
             // TODO
             return ParentDataStream;
         }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -649,8 +649,10 @@ namespace Yarhl.IO
             if (start < 0 || start > Length)
                 throw new ArgumentOutOfRangeException(nameof(start));
 
-            // TODO
-            return ParentDataStream;
+            DataStream slicedStream = new DataStream();
+            WriteSegmentTo(start, slicedStream);
+
+            return slicedStream;
         }
 
         /// <summary>
@@ -666,8 +668,10 @@ namespace Yarhl.IO
             if (length < 0 || start + length > Length)
                 throw new ArgumentOutOfRangeException(nameof(length));
 
-            // TODO
-            return ParentDataStream;
+            DataStream slicedStream = new DataStream();
+            WriteSegmentTo(start, length, slicedStream);
+
+            return slicedStream;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description
Added a `Slice` method based on the `Span<T>` seen in C# 8.0 using the new method `WriteSegmentTo()` as a base.
Using the method `Slice` will create a new DataStream based on a starting offset parameter or a starting offset parameter + length.
### Example
```
stream.Slice(long start)
stream.Slice(long start, long length)
```

Closes #143 