### PR TITLE
Support Int24 type in binary (de)serializer

### DIFF
--- a/src/Yarhl.UnitTests/IO/DataReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataReaderTests.cs
@@ -34,6 +34,13 @@ namespace Yarhl.UnitTests.IO
         DataStream stream;
         DataReader reader;
 
+        enum Enum1
+        {
+            Value1,
+            Value2,
+            Value3,
+        }
+
         [OneTimeSetUp]
         public void FixtureSetUp()
         {
@@ -1189,11 +1196,19 @@ namespace Yarhl.UnitTests.IO
             Assert.AreEqual(Enum1.Value2, obj.EnumValue);
         }
 
-        private enum Enum1
+        [Test]
+        public void ReadObjectWithInt24()
         {
-            Value1,
-            Value2,
-            Value3,
+            byte[] expected = {
+                0x01, 0x00, 0x00,
+            };
+            stream.Write(expected, 0, expected.Length);
+
+            stream.Position = 0;
+
+            ObjectWithInt24 obj = reader.Read<ObjectWithInt24>();
+
+            Assert.AreEqual(1, obj.Int24Value);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
@@ -1464,6 +1479,21 @@ namespace Yarhl.UnitTests.IO
         {
             [BinaryEnum(ReadAs = typeof(byte))]
             public Enum1 EnumValue { get; set; }
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Microsoft.Performance",
+            "CA1812:Class never instantiated",
+            Justification = "The class is instantiated by reflection")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Sonar.CodeSmell",
+            "S3459:Unassigned auto-property",
+            Justification = "The properties are assigned by reflection")]
+        [Yarhl.IO.Serialization.Attributes.Serializable]
+        private class ObjectWithInt24
+        {
+            [BinaryInt24]
+            public int Int24Value { get; set; }
         }
     }
 }

--- a/src/Yarhl.UnitTests/IO/DataWriterTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataWriterTests.cs
@@ -30,6 +30,13 @@ namespace Yarhl.UnitTests.IO
     [TestFixture]
     public class DataWriterTests
     {
+        enum Enum1
+        {
+            Value1,
+            Value2,
+            Value3,
+        }
+
         [Test]
         public void ConstructorSetProperties()
         {
@@ -1505,7 +1512,7 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadCustomStringUsingReflectionWithUnknownEncodingThrowsException()
+        public void WriteCustomStringUsingReflectionWithUnknownEncodingThrowsException()
         {
             var obj = new ObjectWithCustomStringAttributeUnknownEncoding() {
                 IntegerValue = 1,
@@ -1522,7 +1529,7 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadObjectWithForcedEndianness()
+        public void WriteObjectWithForcedEndianness()
         {
             ObjectWithForcedEndianness obj = new ObjectWithForcedEndianness() {
                 LittleEndianInteger = 1,
@@ -1549,7 +1556,7 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadObjectWithEnum()
+        public void WriteObjectWithEnum()
         {
             ObjectWithEnum obj = new ObjectWithEnum() {
                 EnumValue = Enum1.Value2,
@@ -1571,11 +1578,27 @@ namespace Yarhl.UnitTests.IO
             Assert.IsTrue(expected.SequenceEqual(actual));
         }
 
-        private enum Enum1
+        [Test]
+        public void WriteObjectWithInt24()
         {
-            Value1,
-            Value2,
-            Value3,
+            ObjectWithInt24 obj = new ObjectWithInt24() {
+                Int24Value = 1,
+            };
+
+            using DataStream stream = new DataStream();
+            DataWriter writer = new DataWriter(stream);
+
+            writer.WriteOfType<ObjectWithInt24>(obj);
+
+            byte[] expected = {
+                0x01, 0x00, 0x00,
+            };
+            Assert.AreEqual(expected.Length, stream.Length);
+
+            stream.Position = 0;
+            byte[] actual = new byte[expected.Length];
+            stream.Read(actual, 0, expected.Length);
+            Assert.IsTrue(expected.SequenceEqual(actual));
         }
 
         [Yarhl.IO.Serialization.Attributes.Serializable]
@@ -1742,6 +1765,13 @@ namespace Yarhl.UnitTests.IO
         {
             [BinaryEnum(WriteAs = typeof(byte))]
             public Enum1 EnumValue { get; set; }
+        }
+
+        [Yarhl.IO.Serialization.Attributes.Serializable]
+        private class ObjectWithInt24
+        {
+            [BinaryInt24]
+            public int Int24Value { get; set; }
         }
     }
 }

--- a/src/Yarhl/IO/DataReader.cs
+++ b/src/Yarhl/IO/DataReader.cs
@@ -497,6 +497,10 @@ namespace Yarhl.IO
                     var attr = (BinaryBooleanAttribute)Attribute.GetCustomAttribute(property, typeof(BinaryBooleanAttribute));
                     dynamic value = ReadByType(attr.ReadAs);
                     property.SetValue(obj, value == (dynamic)attr.TrueValue);
+                } else if (property.PropertyType == typeof(int) && Attribute.IsDefined(property, typeof(BinaryInt24Attribute))) {
+                    // read the number as int24.
+                    int value = ReadInt24();
+                    property.SetValue(obj, value);
                 } else if (property.PropertyType.IsEnum && Attribute.IsDefined(property, typeof(BinaryEnumAttribute))) {
                     // enums can only be read if they have the attribute.
                     var attr = (BinaryEnumAttribute)Attribute.GetCustomAttribute(property, typeof(BinaryEnumAttribute));

--- a/src/Yarhl/IO/DataWriter.cs
+++ b/src/Yarhl/IO/DataWriter.cs
@@ -560,7 +560,7 @@ namespace Yarhl.IO
             WriteTimes(val, Stream.Position.Pad(padding) - Stream.Position);
         }
 
-        void WriteNumber(ulong number, byte numBytes)
+        void WriteNumber(ulong number, byte numBits)
         {
             byte start;
             byte end;
@@ -568,10 +568,10 @@ namespace Yarhl.IO
 
             if (Endianness == EndiannessMode.LittleEndian) {
                 start = 0;
-                end = numBytes;
+                end = numBits;
                 step = 8;
             } else {
-                start = (byte)(numBytes - 8);
+                start = (byte)(numBits - 8);
                 end = 0xF8; // When the counter var reach < 0 it overflows to 0-8=0xF8
                 step = -8;
             }
@@ -609,6 +609,9 @@ namespace Yarhl.IO
                     var attr = (BinaryBooleanAttribute)Attribute.GetCustomAttribute(property, typeof(BinaryBooleanAttribute));
                     dynamic typeValue = value ? attr.TrueValue : attr.FalseValue;
                     WriteOfType(attr.WriteAs, typeValue);
+                } else if (property.PropertyType == typeof(int) && Attribute.IsDefined(property, typeof(BinaryInt24Attribute))) {
+                    // write the number as int24
+                    WriteNumber((uint)value, 24);
                 } else if (property.PropertyType.IsEnum && Attribute.IsDefined(property, typeof(BinaryEnumAttribute))) {
                     // enums can only be written if they have the attribute.
                     var attr = (BinaryEnumAttribute)Attribute.GetCustomAttribute(property, typeof(BinaryEnumAttribute));

--- a/src/Yarhl/IO/Serialization/Attributes/BinaryInt24Attribute.cs
+++ b/src/Yarhl/IO/Serialization/Attributes/BinaryInt24Attribute.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Yarhl.IO.Serialization.Attributes
+{
+    using System;
+
+    /// <summary>
+    /// Property is an Int24 value.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class BinaryInt24Attribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
### Description
I forgot to add Int24 support in PR #151 

Property must be defined as `int` and use `BinaryInt24` attribute.

### Example
```csharp
[Yarhl.IO.Serialization.Attributes.Serializable]
private class ObjectWithInt24
{
    [BinaryInt24]
    public int Int24Value { get; set; }
}
```

Linked issue: No
