### PR TITLE
Support .NET 5.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "0.38.4",
+      "version": "1.0.0-rc0001",
       "commands": [
         "dotnet-cake"
       ]

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,9 @@
 ### Description
+
 A clear and concise description of what the bug or feature is.
 
 ### Example
+
 Small example on how to use the new classes and methods.
 
-
-Linked issue:
+This closes #

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ your solution (.sln) file with the following content:
 
 ## Build
 
-Since the unit tests are validated against .NET Core and .NET Framework or Mono
-both runtime must be installed on the machine. Then run:
+Since the unit tests are validated against .NET 5, .NET Core and .NET Framework
+and Mono, the three runtimes must be installed on the machine. Then run:
 
 ```sh
 dotnet tool restore

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,12 @@ steps:
     packageType: sdk
     version: 3.1.x
 
+- task: UseDotNet@2
+  displayName: 'Install .NET 5.0 SDK'
+  inputs:
+    packageType: sdk
+    version: 5.0.x
+
 - script: dotnet tool restore
   displayName: 'Restore build tool'
 

--- a/build.cake
+++ b/build.cake
@@ -42,7 +42,7 @@ var warnAsErrorOption = warnAsError
 
 string netFrameworkVersion = "48";
 string netFrameworkOldVersion = "461";
-string netCoreVersion = "5.0";
+string netCoreVersion = "3.1";
 string netVersion = "5.0";
 string netstandardVersion = "2.0";
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>3.0.1-alpha01</Version>
+        <Version>3.0.1-alpha02</Version>
         <Product>SceneGate</Product>
 
         <Authors>SceneGate</Authors>
@@ -13,20 +13,20 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <SystemCompositionPackageVersion>1.4.0</SystemCompositionPackageVersion>
+        <SystemCompositionPackageVersion>5.0.0</SystemCompositionPackageVersion>
         <SystemRuntimeLoaderPackageVersion>4.3.0</SystemRuntimeLoaderPackageVersion>
-        <EncodingCodePagesPackageVersion>4.7.0</EncodingCodePagesPackageVersion>
-        <RecyclableStreamsPackageVersion>1.3.3</RecyclableStreamsPackageVersion>
+        <EncodingCodePagesPackageVersion>5.0.0</EncodingCodePagesPackageVersion>
+        <RecyclableStreamsPackageVersion>1.3.6</RecyclableStreamsPackageVersion>
         <MicrosoftCSharpPackageVersion>4.7.0</MicrosoftCSharpPackageVersion>
         <ReferenceAssembliesPackageVersion>1.0.0</ReferenceAssembliesPackageVersion>
 
         <NUnitPackageVersion>3.12.0</NUnitPackageVersion>
-        <NUnit3TestAdapterPackageVersion>3.16.1</NUnit3TestAdapterPackageVersion>
-        <NetTestSdkPackageVersion>16.5.0</NetTestSdkPackageVersion>
+        <NUnit3TestAdapterPackageVersion>3.17.0</NUnit3TestAdapterPackageVersion>
+        <NetTestSdkPackageVersion>16.8.3</NetTestSdkPackageVersion>
         <BenchmarkDotNetPackageVersion>0.12.1</BenchmarkDotNetPackageVersion>
 
         <StyleCopAnalyzerPackageVersion>1.1.118</StyleCopAnalyzerPackageVersion>
         <FxCopAnalyzerPackageVersion>2.9.8</FxCopAnalyzerPackageVersion>
-        <SonarAnalyzerPackageVersion>8.6.0.16497</SonarAnalyzerPackageVersion>
+        <SonarAnalyzerPackageVersion>8.15.0.24505</SonarAnalyzerPackageVersion>
     </PropertyGroup>
 </Project>

--- a/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
+++ b/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Yarhl.IntegrationTests</AssemblyName>
     <Description>Plugin integration tests for Yarhl.</Description>
 
-    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461;net48;net5.0</TargetFrameworks>
     <RootNamespace>Yarhl.IntegrationTests</RootNamespace>
     <CodeAnalysisRuleSet>..\SceneGate.Test.ruleset</CodeAnalysisRuleSet>
     <!-- Mark the project as being a test project -->

--- a/src/Yarhl.PerformanceTests/Yarhl.PerformanceTests.csproj
+++ b/src/Yarhl.PerformanceTests/Yarhl.PerformanceTests.csproj
@@ -6,7 +6,7 @@
     <Description>Performance tests for Yarhl.</Description>
     <IsPackable>false</IsPackable>
 
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <RootNamespace>Yarhl.PerformanceTests</RootNamespace>
     <CodeAnalysisRuleSet>..\SceneGate.Test.ruleset</CodeAnalysisRuleSet>
     <!-- Mark the project as being a test project -->

--- a/src/Yarhl.UnitTests/Media/Text/Encodings/EucJpEncodingTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/Encodings/EucJpEncodingTests.cs
@@ -50,11 +50,6 @@ namespace Yarhl.UnitTests.Media.Text.Encodings
                 new EncoderReplacementFallback("@"));
             Assert.IsInstanceOf<DecoderReplacementFallback>(encoder.DecoderFallback);
             Assert.IsInstanceOf<EncoderReplacementFallback>(encoder.EncoderFallback);
-
-            // We can't override original
-            Encoding baseEncoding = encoder;
-            Assert.IsNotInstanceOf<DecoderReplacementFallback>(baseEncoding.DecoderFallback);
-            Assert.IsNotInstanceOf<EncoderReplacementFallback>(baseEncoding.EncoderFallback);
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
+++ b/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Yarhl.UnitTests</AssemblyName>
     <Description>Yarhl unit tests.</Description>
 
-    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461;net48;net5.0</TargetFrameworks>
     <RootNamespace>Yarhl.UnitTests</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <CodeAnalysisRuleSet>..\SceneGate.Test.ruleset</CodeAnalysisRuleSet>

--- a/src/Yarhl/AssemblyUtils.cs
+++ b/src/Yarhl/AssemblyUtils.cs
@@ -22,7 +22,9 @@ namespace Yarhl
     using System;
     using System.Collections.Generic;
     using System.Reflection;
+  #if !NET461
     using System.Runtime.InteropServices;
+  #endif
     using System.Runtime.Loader;
 
     /// <summary>
@@ -37,12 +39,21 @@ namespace Yarhl
         /// <returns>The assemblies.</returns>
         public static IEnumerable<Assembly> LoadAssemblies(this IEnumerable<string> paths)
         {
+          #if NET461
+            return LoadAssembliesNetFramework(paths);
+          #else
             string framework = RuntimeInformation.FrameworkDescription;
             if (framework.StartsWith(".NET Core", StringComparison.Ordinal)) {
                 return LoadAssembliesNetCore(paths);
-            } else {
+            } else if (framework.StartsWith(".NET Framework", StringComparison.Ordinal)) {
                 return LoadAssembliesNetFramework(paths);
+            } else if (framework.StartsWith("Mono", StringComparison.Ordinal)) {
+                return LoadAssembliesNetFramework(paths);
+            } else {
+                // .NET 5.0.0 or later
+                return LoadAssembliesNetCore(paths);
             }
+          #endif
         }
 
         /// <summary>

--- a/src/Yarhl/IO/DataWriter.cs
+++ b/src/Yarhl/IO/DataWriter.cs
@@ -321,7 +321,7 @@ namespace Yarhl.IO
             if (encoding == null)
                 encoding = DefaultEncoding;
 
-            if (!string.IsNullOrEmpty(terminator) && !text.EndsWith(terminator, StringComparison.InvariantCulture))
+            if (!string.IsNullOrEmpty(terminator) && !text.EndsWith(terminator, StringComparison.Ordinal))
                 text = string.Concat(text, terminator);
 
             int textSize = encoding.GetByteCount(text);
@@ -401,7 +401,7 @@ namespace Yarhl.IO
             if (encoding == null)
                 encoding = DefaultEncoding;
 
-            if (!string.IsNullOrEmpty(terminator) && !text.EndsWith(terminator, StringComparison.InvariantCulture))
+            if (!string.IsNullOrEmpty(terminator) && !text.EndsWith(terminator, StringComparison.Ordinal))
                 text = string.Concat(text, terminator);
 
             int textSize = encoding.GetByteCount(text);


### PR DESCRIPTION
Support latest version of .NET: .NET 5.0. Also improve the compatibility pre-.NET Framework 4.7.2 by fixing an issue loading assemblies (the API wasn't available, no idea how it was compiling).

Build script is a bit a mess but will be fixed once we port to [PleOps.Cake](https://github.com/pleonex/PleOps.Cake) in #123 

This closes #153

Thanks to @Kaplas80 for helping to debug and fix the .NET 5 porting issues!