### PR TITLE
Fix code style issues

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,6 @@
 
     "extensions": [
         "ms-dotnettools.csharp",
-        "k--kato.docomment",
         "shardulm94.trailing-spaces",
         "cake-build.cake-vscode",
         "streetsidesoftware.code-spell-checker",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "editor.rulers": [
+        80,
+        120
+    ],
+    "editor.renderWhitespace": "boundary",
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "[markdown]": {
+        "editor.formatOnSave": true,
+    },
+    "[csharp]": {
+        "editor.defaultFormatter": "ms-dotnettools.csharp",
+        "editor.formatOnType": true
+    },
+    "prettier.proseWrap": "always",
+}

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -113,13 +113,13 @@ csharp_preferred_modifier_order = public,private,protected,internal,static,exter
 
 ## C# formatting rules
 ### New line preferences
-csharp_new_line_before_open_brace = local_functions,methods,types:warning
-csharp_new_line_before_else = false:warning
-csharp_new_line_before_catch = false:warning
-csharp_new_line_before_finally = false:warning
-csharp_new_line_before_members_in_object_initializers = true:warning
-csharp_new_line_before_members_in_anonymous_types = true:warning
-csharp_new_line_between_query_expression_clauses = true:warning
+csharp_new_line_before_open_brace = local_functions,methods,types
+csharp_new_line_before_else = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_finally = false
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
 
 ### Indentation preferences
 csharp_indent_case_contents = true:warning

--- a/src/Yarhl.Media/Text/Encodings/EucJpEncoding.cs
+++ b/src/Yarhl.Media/Text/Encodings/EucJpEncoding.cs
@@ -364,9 +364,9 @@ namespace Yarhl.Media.Text.Encodings
                         .GetManifestResourceStream(path);
 
                     using (var reader = new StreamReader(stream)) {
-                      #pragma warning disable IDISP003
+#pragma warning disable IDISP003
                         stream = null;  // Avoid disposing twice
-                      #pragma warning restore IDISP003
+#pragma warning restore IDISP003
 
                         while (!reader.EndOfStream) {
                             string line = reader.ReadLine();

--- a/src/Yarhl.UnitTests/FileFormat/Converters.cs
+++ b/src/Yarhl.UnitTests/FileFormat/Converters.cs
@@ -22,9 +22,9 @@ namespace Yarhl.UnitTests.FileFormat
     using System;
     using Yarhl.FileFormat;
 
-  // Disable file may only contain a single class since we aren't going
-  // to create a file per test converter.
-  #pragma warning disable SA1402, SA1649
+    // Disable file may only contain a single class since we aren't going
+    // to create a file per test converter.
+#pragma warning disable SA1402, SA1649
 
     public interface IInterface
     {
@@ -201,6 +201,6 @@ namespace Yarhl.UnitTests.FileFormat
         }
     }
 
-  #pragma warning restore SA1402, SA1649
+#pragma warning restore SA1402, SA1649
 
 }

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1782,8 +1782,7 @@ namespace Yarhl.UnitTests.IO
             source.Write(data, 0, data.Length);
 
             DataStream[] streams = new DataStream[streamCount];
-            for (int i = 0; i < streamCount; i++)
-            {
+            for (int i = 0; i < streamCount; i++) {
                 streams[i] = new DataStream(source, testDataLength * i, testDataLength);
             }
 
@@ -1792,29 +1791,24 @@ namespace Yarhl.UnitTests.IO
             result.Position = 0;
 
             DataStream[] writeStreams = new DataStream[streamCount];
-            for (int i = 0; i < streamCount; i++)
-            {
+            for (int i = 0; i < streamCount; i++) {
                 writeStreams[i] = new DataStream(result, testDataLength * i, testDataLength);
             }
 
             byte[][] read = new byte[streamCount][];
-            for (int i = 0; i < streamCount; i++)
-            {
+            for (int i = 0; i < streamCount; i++) {
                 read[i] = new byte[testDataLength];
             }
 
-            Parallel.For(0, streamCount, i =>
-            {
+            Parallel.For(0, streamCount, i => {
                 streams[i].Read(read[i], 0, testDataLength);
             });
 
-            Parallel.For(0, streamCount, i =>
-            {
+            Parallel.For(0, streamCount, i => {
                 writeStreams[i].Write(read[i], 0, testDataLength);
             });
 
-            for (int i = 0; i < streamCount; i++)
-            {
+            for (int i = 0; i < streamCount; i++) {
                 Assert.That(streams[i].Compare(writeStreams[i]), Is.True);
                 streams[i].Dispose();
                 writeStreams[i].Dispose();

--- a/src/Yarhl.UnitTests/IO/DataWriterTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataWriterTests.cs
@@ -1233,8 +1233,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteUsingReflection()
         {
-            var obj = new ComplexObject
-            {
+            var obj = new ComplexObject {
                 IntegerValue = 1,
                 LongValue = 2,
                 IgnoredIntegerValue = 3,
@@ -1262,11 +1261,9 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteNestedObjectUsingReflection()
         {
-            var obj = new NestedObject()
-            {
+            var obj = new NestedObject() {
                 IntegerValue = 10,
-                ComplexValue = new ComplexObject
-                {
+                ComplexValue = new ComplexObject {
                     IntegerValue = 1,
                     LongValue = 2,
                     IgnoredIntegerValue = 3,
@@ -1298,8 +1295,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteBooleanUsingReflection()
         {
-            var obj = new ObjectWithDefaultBooleanAttribute()
-            {
+            var obj = new ObjectWithDefaultBooleanAttribute() {
                 IntegerValue = 1,
                 BooleanValue = false,
                 IgnoredIntegerValue = 3,
@@ -1327,8 +1323,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteCustomBooleanUsingReflection()
         {
-            var obj = new ObjectWithCustomBooleanAttribute()
-            {
+            var obj = new ObjectWithCustomBooleanAttribute() {
                 IntegerValue = 1,
                 BooleanValue = false,
                 IgnoredIntegerValue = 5,
@@ -1356,8 +1351,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteBooleanWithoutAttributeThrowsException()
         {
-            var obj = new ObjectWithoutBooleanAttribute()
-            {
+            var obj = new ObjectWithoutBooleanAttribute() {
                 IntegerValue = 1,
                 BooleanValue = true,
                 IgnoredIntegerValue = 3,

--- a/src/Yarhl/FileSystem/NavigableNode.cs
+++ b/src/Yarhl/FileSystem/NavigableNode.cs
@@ -58,8 +58,7 @@ namespace Yarhl.FileSystem
         /// <summary>
         /// Gets the node name.
         /// </summary>
-        public string Name
-        {
+        public string Name {
             get;
             private set;
         }
@@ -156,8 +155,7 @@ namespace Yarhl.FileSystem
 
             // Add method modifies the nodes collection, so we need a IList and we can't use a 'foreach' loop.
             List<T> nodesList = nodes.ToList();
-            for (int i = 0; i < nodesList.Count; i++)
-            {
+            for (int i = 0; i < nodesList.Count; i++) {
                 T node = nodesList[i];
                 Add(node);
             }
@@ -313,8 +311,7 @@ namespace Yarhl.FileSystem
         private bool IsDescendantOf(T node)
         {
             T current = this.Parent;
-            while (current != null)
-            {
+            while (current != null) {
                 if (current == node)
                     return true;
 

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -155,8 +155,7 @@ namespace Yarhl.FileSystem
             var format = new BinaryFormat(DataStreamFactory.FromFile(filePath, mode));
             Node node;
             try {
-                node = new Node(nodeName, format)
-                {
+                node = new Node(nodeName, format) {
                     Tags = { ["FileInfo"] = new FileInfo(filePath) },
                 };
             } catch {

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -259,17 +259,17 @@ namespace Yarhl.IO
                 throw new ObjectDisposedException(nameof(DataStream));
 
             switch (mode) {
-            case SeekMode.Current:
-                Position += shift;
-                break;
-            case SeekMode.Start:
-                Position = shift;
-                break;
-            case SeekMode.End:
-                Position = Length - shift;
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(mode));
+                case SeekMode.Current:
+                    Position += shift;
+                    break;
+                case SeekMode.Start:
+                    Position = shift;
+                    break;
+                case SeekMode.End:
+                    Position = Length - shift;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode));
             }
         }
 

--- a/src/Yarhl/IO/DataWriter.cs
+++ b/src/Yarhl/IO/DataWriter.cs
@@ -434,8 +434,7 @@ namespace Yarhl.IO
             if (serializable) {
                 WriteUsingReflection(type, val);
             } else {
-                switch (val)
-                {
+                switch (val) {
                     case long l:
                         Write(l);
                         break;

--- a/src/Yarhl/IO/FileOpenMode.cs
+++ b/src/Yarhl/IO/FileOpenMode.cs
@@ -75,16 +75,16 @@ namespace Yarhl.IO
         public static FileMode ToFileMode(this FileOpenMode openMode)
         {
             switch (openMode) {
-            case FileOpenMode.Read:
-                return FileMode.Open;
-            case FileOpenMode.Write:
-                return FileMode.Create;
-            case FileOpenMode.Append:
-                return FileMode.Append;
-            case FileOpenMode.ReadWrite:
-                return FileMode.OpenOrCreate;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(openMode));
+                case FileOpenMode.Read:
+                    return FileMode.Open;
+                case FileOpenMode.Write:
+                    return FileMode.Create;
+                case FileOpenMode.Append:
+                    return FileMode.Append;
+                case FileOpenMode.ReadWrite:
+                    return FileMode.OpenOrCreate;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(openMode));
             }
         }
 
@@ -96,16 +96,16 @@ namespace Yarhl.IO
         public static FileAccess ToFileAccess(this FileOpenMode openMode)
         {
             switch (openMode) {
-            case FileOpenMode.Read:
-                return FileAccess.Read;
-            case FileOpenMode.Write:
-                return FileAccess.Write;
-            case FileOpenMode.Append:
-                return FileAccess.Write;
-            case FileOpenMode.ReadWrite:
-                return FileAccess.ReadWrite;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(openMode));
+                case FileOpenMode.Read:
+                    return FileAccess.Read;
+                case FileOpenMode.Write:
+                    return FileAccess.Write;
+                case FileOpenMode.Append:
+                    return FileAccess.Write;
+                case FileOpenMode.ReadWrite:
+                    return FileAccess.ReadWrite;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(openMode));
             }
         }
     }


### PR DESCRIPTION
### Description

Fix small issues in code style after applying the `.editorconfig` rules to every C# file.

Also, define default settings to use the C# formatter on type. This is required as the VS Code plugin for XML comments is obsolete and the feature is implemented in the default C# plugin when "format on type" is enabled.
