### PR TITLE
Disable auto-comment on release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -9,9 +9,6 @@ on:
     branches: [ develop ]
     # Stable
     tags: [ "v*" ]
-  release:
-    types:
-      - published
 
 env:
   NET_SDK: '5.0.101'

--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -1,24 +1,18 @@
 # Configuration values used when creating new releases
 create:
- include-footer: false
- include-sha-section: false
- allow-update-to-published: false
+  include-footer: false
+  include-sha-section: false
+  allow-update-to-published: false
 
 # Configuration values used when exporting release notes
 export:
- include-created-date-in-title: true
- created-date-string-format: MMMM dd, yyyy
- perform-regex-removal: false
+  include-created-date-in-title: true
+  created-date-string-format: MMMM dd, yyyy
+  perform-regex-removal: false
 
 # Configuration values used when closing a milestone
 close:
- use-issue-comments: true
- issue-comment: |-
-   :tada: This issue has been resolved in version {milestone} :tada:
-
-   The release is available on:
-
-   - [GitHub release](https://github.com/{owner}/{repository}/releases/tag/{milestone})
+  use-issue-comments: false
 
 # The labels that will be used to include issues in release notes.
 issue-labels-include:


### PR DESCRIPTION
### Description

Sorry for the spam in the previous release :sweat_smile:

Disable triggering a comment alerting the new release is out because anyway if you watch the release you will receive an email with the release notes. Also fix triggering twice build on release
