### PR TITLE
Implement DataStream inheritance with Stream and support of Readers and Writers with Stream

### DIFF
--- a/Tests.runsettings
+++ b/Tests.runsettings
@@ -13,7 +13,7 @@
         <Configuration>
           <Format>cobertura</Format>
           <Exclude>[.*UnitTest]*,[.*IntegrationTest]*</Exclude>
-          <ExcludeByAttribute>GeneratedCodeAttribute,ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+          <ExcludeByAttribute>GeneratedCodeAttribute,ExcludeFromCodeCoverageAttribute,ObsoleteAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>
     </DataCollectors>

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#load "nuget:?package=PleOps.Cake&version=0.3.1"
+#load "nuget:?package=PleOps.Cake&version=0.4.0"
 
 Task("Define-Project")
     .Description("Fill specific project information")

--- a/docs/guides/Yarhl-nutshell.md
+++ b/docs/guides/Yarhl-nutshell.md
@@ -44,7 +44,7 @@ will dispose the `Stream` too.
 #### Comparison
 
 The `DataStream` class provides the
-[`Compare`](<xref:Yarhl.IO.DataStream.Compare(Yarhl.IO.DataStream)>) method to
+[`Compare`](<xref:Yarhl.IO.DataStream.Compare(System.IO.Stream)>) method to
 check if two streams are identical.
 
 #### Push and pop positions
@@ -167,7 +167,7 @@ public void LoadFile(string path)
 {
     using (var stream = DataStreamFactory.FromFile(path, FileOpenMode.Read)) {
         var reader = new DataReader(stream) {
-            DefaultEncoding = new EscapeOutRangeEnconding("ascii"),
+            DefaultEncoding = new EscapeOutRangeEncoding("ascii"),
             Endianness = EndiannessMode.BigEndian,
         };
 
@@ -296,7 +296,7 @@ contains a root folder, also known as `Node`. So let's see what a `Node` is.
 
 This is the main feature of Yarhl and the most important one, no doubt, 10/10
 Yarhl users would say so<sup>1</sup>. Yarhl has a virtual file system to handle
-your files while mantaining your computer intact, you can now delete your
+your files while maintaining your computer intact, you can now delete your
 "tests" folder and clean your desktop after-ages.
 
 <sup>1</sup> <small>None of Yarhl users wants to talk with me anymore. This may
@@ -383,7 +383,7 @@ foreach (var node in root.Children) {
 ```
 
 But if you want to iterate over the full tree of nodes, that is, including the
-children of your childrens (like `node` in the above example), you can use the
+children of your children (like `node` in the above example), you can use the
 `Navigator`.
 
 ```csharp

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,6 +12,7 @@
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.3"/>
         <PackageVersion Include="coverlet.collector" Version="1.3.0" />
         <PackageVersion Include="BenchmarkDotNet" Version="0.12.1" />
+        <PackageVersion Include="Moq" Version="4.15.2" />
 
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
 

--- a/src/Yarhl.Media/Text/Binary2Po.cs
+++ b/src/Yarhl.Media/Text/Binary2Po.cs
@@ -68,11 +68,11 @@ namespace Yarhl.Media.Text
                 reader.ReadLine();
 
             // If nothing to read, EOF
-            if (reader.Stream.EndOfStream)
+            if (reader.Stream.Position >= reader.Stream.Length)
                 return null;
 
             PoEntry entry = new PoEntry();
-            while (!reader.Stream.EndOfStream) {
+            while (reader.Stream.Position < reader.Stream.Length) {
                 // Get the next line
                 line = reader.ReadLine();
 
@@ -226,7 +226,7 @@ namespace Yarhl.Media.Text
         {
             StringBuilder content = new StringBuilder(ParseMultiLine(currentLine));
 
-            while (!reader.Stream.EndOfStream && reader.Peek() == '"')
+            while ((reader.Stream.Position < reader.Stream.Length) && reader.Peek() == '"')
                 content.Append(ParseMultiLine(reader.ReadLine()));
 
             return content.ToString();

--- a/src/Yarhl.UnitTests/IO/DataReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataReaderTests.cs
@@ -67,7 +67,7 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void EndiannesProperty()
+        public void EndiannessProperty()
         {
             Assert.AreEqual(EndiannessMode.LittleEndian, reader.Endianness);
             reader.Endianness = EndiannessMode.BigEndian;
@@ -83,17 +83,51 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void ReadPrimitiveThrowsExceptionWhenEof()
+        {
+            stream.Write(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }, 0, 8);
+
+            stream.Position = 8;
+            Assert.That(() => reader.ReadByte(), Throws.InstanceOf<EndOfStreamException>());
+            Assert.That(() => reader.ReadChar(), Throws.InstanceOf<EndOfStreamException>());
+
+            stream.Position = 7;
+            Assert.That(() => reader.ReadBytes(2), Throws.InstanceOf<EndOfStreamException>());
+            Assert.That(() => reader.ReadUInt16(), Throws.InstanceOf<EndOfStreamException>());
+            Assert.That(() => reader.ReadInt16(), Throws.InstanceOf<EndOfStreamException>());
+            Assert.That(() => reader.ReadInt24(), Throws.InstanceOf<EndOfStreamException>());
+            Assert.That(() => reader.ReadUInt32(), Throws.InstanceOf<EndOfStreamException>());
+            Assert.That(() => reader.ReadInt32(), Throws.InstanceOf<EndOfStreamException>());
+            Assert.That(() => reader.ReadInt64(), Throws.InstanceOf<EndOfStreamException>());
+            Assert.That(() => reader.ReadUInt64(), Throws.InstanceOf<EndOfStreamException>());
+            Assert.That(() => reader.ReadInt64(), Throws.InstanceOf<EndOfStreamException>());
+            Assert.That(() => reader.ReadUInt64(), Throws.InstanceOf<EndOfStreamException>());
+        }
+
+        [Test]
+        public void ReadPrimiteThrowExceptionWithInvalidEndianness()
+        {
+            stream.Write(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }, 0, 8);
+            stream.Position = 0;
+            reader.Endianness = (EndiannessMode)0x100;
+
+            Assert.That(() => reader.ReadUInt16(), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => reader.ReadInt16(), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => reader.ReadInt24(), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => reader.ReadUInt32(), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => reader.ReadInt32(), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => reader.ReadInt64(), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => reader.ReadUInt64(), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => reader.ReadSingle(), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => reader.ReadDouble(), Throws.InstanceOf<NotSupportedException>());
+        }
+
+        [Test]
         public void ReadByte()
         {
             stream.WriteByte(0xAF);
             stream.Position = 0;
             Assert.AreEqual(0xAF, reader.ReadByte());
-        }
-
-        [Test]
-        public void ReadByteThrowExceptionWhenEof()
-        {
-            Assert.Throws<EndOfStreamException>(() => reader.ReadByte());
         }
 
         [Test]
@@ -124,16 +158,6 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadUInt16InvalidEndianness()
-        {
-            byte[] buffer = { 0xCA, 0xFE };
-            stream.Write(buffer, 0, buffer.Length);
-            stream.Position = 0;
-            reader.Endianness = (EndiannessMode)0x100;
-            Assert.AreEqual(0xFFFF, reader.ReadUInt16());
-        }
-
-        [Test]
         public void ReadInt16LE()
         {
             byte[] buffer = { 0x24, 0x92 };
@@ -150,16 +174,6 @@ namespace Yarhl.UnitTests.IO
             stream.Position = 0;
             reader.Endianness = EndiannessMode.BigEndian;
             Assert.AreEqual(-28124, reader.ReadInt16());
-        }
-
-        [Test]
-        public void ReadInt16InvalidEndianness()
-        {
-            byte[] buffer = { 0x92, 0x24 };
-            stream.Write(buffer, 0, buffer.Length);
-            stream.Position = 0;
-            reader.Endianness = (EndiannessMode)0x100;
-            Assert.AreEqual(-1, reader.ReadInt16());
         }
 
         [Test]
@@ -182,16 +196,6 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadInt24InvalidEndianness()
-        {
-            byte[] buffer = { 0xCA, 0xFE, 0xAF };
-            stream.Write(buffer, 0, buffer.Length);
-            stream.Position = 0;
-            reader.Endianness = (EndiannessMode)0x100;
-            Assert.AreEqual(-1, reader.ReadInt24());
-        }
-
-        [Test]
         public void ReadUInt32LE()
         {
             byte[] buffer = { 0xCA, 0xFE, 0xBA, 0xBE };
@@ -208,16 +212,6 @@ namespace Yarhl.UnitTests.IO
             stream.Position = 0;
             reader.Endianness = EndiannessMode.BigEndian;
             Assert.AreEqual(0xCAFEBABE, reader.ReadUInt32());
-        }
-
-        [Test]
-        public void ReadUInt32InvalidEndianness()
-        {
-            byte[] buffer = { 0xCA, 0xFE, 0xBA, 0xBE };
-            stream.Write(buffer, 0, buffer.Length);
-            stream.Position = 0;
-            reader.Endianness = (EndiannessMode)0x100;
-            Assert.AreEqual(0xFFFFFFFF, reader.ReadUInt32());
         }
 
         [Test]
@@ -240,16 +234,6 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadInt32InvalidEndianness()
-        {
-            byte[] buffer = { 0x9B, 0xA1, 0xB1, 0x0D };
-            stream.Write(buffer, 0, buffer.Length);
-            stream.Position = 0;
-            reader.Endianness = (EndiannessMode)0x100;
-            Assert.AreEqual(-1, reader.ReadInt32());
-        }
-
-        [Test]
         public void ReadUInt64LE()
         {
             byte[] buffer = { 0xDC, 0xAC, 0x34, 0x12, 0xBE, 0xBA, 0xFE, 0xCA };
@@ -269,16 +253,6 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadUInt64InvalidEndianness()
-        {
-            byte[] buffer = { 0xCA, 0xFE, 0xBA, 0xBE, 0x12, 0x34, 0xAC, 0xDC };
-            stream.Write(buffer, 0, buffer.Length);
-            stream.Position = 0;
-            reader.Endianness = (EndiannessMode)0x100;
-            Assert.AreEqual(0xFFFFFFFFFFFFFFFF, reader.ReadUInt64());
-        }
-
-        [Test]
         public void ReadInt64LE()
         {
             byte[] buffer = { 0x52, 0x55, 0x7F, 0xC2, 0xF3, 0xB8, 0xC6, 0xF7 };
@@ -295,16 +269,6 @@ namespace Yarhl.UnitTests.IO
             stream.Position = 0;
             reader.Endianness = EndiannessMode.BigEndian;
             Assert.AreEqual(-592582943872953006, reader.ReadInt64());
-        }
-
-        [Test]
-        public void ReadInt164InvalidEndianness()
-        {
-            byte[] buffer = { 0xF7, 0xC6, 0xB8, 0xF3, 0xC2, 0x7F, 0x55, 0x52 };
-            stream.Write(buffer, 0, buffer.Length);
-            stream.Position = 0;
-            reader.Endianness = (EndiannessMode)0x100;
-            Assert.AreEqual(-1, reader.ReadInt64());
         }
 
         [Test]
@@ -347,16 +311,6 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadSingleInvalidEndianness()
-        {
-            byte[] buffer = { 0x40, 0x48, 0xF5, 0xC3 };
-            stream.Write(buffer, 0, buffer.Length);
-            stream.Position = 0;
-            reader.Endianness = (EndiannessMode)0x100;
-            Assert.That(reader.ReadSingle(), Is.EqualTo(float.NaN));
-        }
-
-        [Test]
         public void ReadDoubleLE()
         {
             byte[] buffer = { 0x1F, 0x85, 0xEB, 0x51, 0xB8, 0x1E, 0x09, 0xC0 };
@@ -376,16 +330,6 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadDoubleInvalidEndianness()
-        {
-            byte[] buffer = { 0x40, 0x09, 0x1E, 0xB8, 0x51, 0xEB, 0x85, 0x1F };
-            stream.Write(buffer, 0, buffer.Length);
-            stream.Position = 0;
-            reader.Endianness = (EndiannessMode)0x100;
-            Assert.That(reader.ReadDouble, Is.EqualTo(double.NaN));
-        }
-
-        [Test]
         public void ReadByteArray()
         {
             byte[] buffer = { 0xF7, 0xC6, 0xB8, 0xF3, 0xC2, 0x7F, 0x55, 0x52 };
@@ -397,11 +341,9 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadByteArrayThrowExceptionWhenEof()
+        public void ReadByteArrayGuards()
         {
-            stream.WriteByte(0xFF);
-            stream.Position = 0;
-            Assert.Throws<EndOfStreamException>(() => reader.ReadBytes(2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => reader.ReadBytes(-2));
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -23,6 +23,7 @@ namespace Yarhl.UnitTests.IO
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Threading.Tasks;
+    using Moq;
     using NUnit.Framework;
     using Yarhl.FileFormat;
     using Yarhl.IO;
@@ -235,7 +236,7 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void DiposingLastStreamDisposeBaseStream()
+        public void DisposingLastStreamDisposeBaseStream()
         {
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
@@ -253,7 +254,7 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void DiposeCloseCorrectStream()
+        public void DisposeCloseCorrectStream()
         {
             using IStream baseStream1 = new RecyclableMemoryStream();
             baseStream1.WriteByte(0xCA);
@@ -346,7 +347,7 @@ namespace Yarhl.UnitTests.IO
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream);
             Assert.AreEqual(2, stream.Length);
-            stream.Length = 1;
+            stream.SetLength(1);
             Assert.AreEqual(1, stream.Length);
             stream.Dispose();
         }
@@ -372,13 +373,13 @@ namespace Yarhl.UnitTests.IO
 
             DataStream childStream3 = new DataStream(parentStream, 0, 1);
             Assert.That(
-                () => childStream3.Length = 2,
+                () => childStream3.SetLength(2),
                 Throws.InvalidOperationException);
             Assert.That(
-                () => childStream3.Length = 0,
+                () => childStream3.SetLength(0),
                 Throws.Nothing);
             Assert.That(
-                () => childStream3.Length = 1,
+                () => childStream3.SetLength(1),
                 Throws.InvalidOperationException);
 
             childStream.Dispose();
@@ -405,13 +406,13 @@ namespace Yarhl.UnitTests.IO
             parentStream.Position = 2;
             parentStream.WriteByte(0x03);
             Assert.That(
-                () => childStream3.Length = 3,
+                () => childStream3.SetLength(3),
                 Throws.Nothing);
             Assert.That(
-                () => childStream3.Length = 0,
+                () => childStream3.SetLength(0),
                 Throws.Nothing);
             Assert.That(
-                () => childStream3.Length = 1,
+                () => childStream3.SetLength(1),
                 Throws.Nothing);
 
             childStream.Dispose();
@@ -441,13 +442,13 @@ namespace Yarhl.UnitTests.IO
 
             DataStream childStream3 = new DataStream(parentStream, 0, 1, false);
             Assert.That(
-                () => childStream3.Length = 2,
+                () => childStream3.SetLength(2),
                 Throws.InvalidOperationException);
             Assert.That(
-                () => childStream3.Length = 0,
+                () => childStream3.SetLength(0),
                 Throws.Nothing);
             Assert.That(
-                () => childStream3.Length = 1,
+                () => childStream3.SetLength(1),
                 Throws.InvalidOperationException);
 
             childStream.Dispose();
@@ -471,13 +472,13 @@ namespace Yarhl.UnitTests.IO
             DataStream childStream3 = new DataStream();
             childStream3.BaseStream.WriteByte(0x03);
             Assert.That(
-                () => childStream3.Length = 1,
+                () => childStream3.SetLength(1),
                 Throws.Nothing);
             Assert.That(
-                () => childStream3.Length = 0,
+                () => childStream3.SetLength(0),
                 Throws.Nothing);
             Assert.That(
-                () => childStream3.Length = 1,
+                () => childStream3.SetLength(1),
                 Throws.Nothing);
 
             childStream.Dispose();
@@ -489,7 +490,7 @@ namespace Yarhl.UnitTests.IO
         public void CanPreallocateLengthForSubstream()
         {
             using DataStream parent = new DataStream();
-            parent.Length = 11;
+            parent.SetLength(11);
             parent.WriteByte(0xFF);
             Assert.That(parent.Length, Is.EqualTo(11));
 
@@ -508,7 +509,7 @@ namespace Yarhl.UnitTests.IO
             baseStream.WriteByte(0xCA);
             DataStream stream = new DataStream(baseStream, 0, 1, false);
             stream.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => stream.Length = 1);
+            Assert.Throws<ObjectDisposedException>(() => stream.SetLength(1));
         }
 
         [Test]
@@ -516,7 +517,7 @@ namespace Yarhl.UnitTests.IO
         {
             baseStream.WriteByte(0xCA);
             DataStream stream = new DataStream(baseStream, 0, 0, false);
-            Assert.Throws<ArgumentOutOfRangeException>(() => stream.Length = -2);
+            Assert.Throws<ArgumentOutOfRangeException>(() => stream.SetLength(-2));
             stream.Dispose();
         }
 
@@ -526,9 +527,9 @@ namespace Yarhl.UnitTests.IO
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             using DataStream stream = new DataStream(baseStream);
-            stream.Seek(2, SeekMode.Start);
+            stream.Seek(2, SeekOrigin.Begin);
             Assert.AreEqual(2, stream.Position);
-            stream.Length = 1;
+            stream.SetLength(1);
             Assert.AreEqual(1, stream.Position);
         }
 
@@ -539,7 +540,7 @@ namespace Yarhl.UnitTests.IO
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2, false);
             Assert.IsFalse(stream.EndOfStream);
-            stream.Seek(2, SeekMode.Start);
+            stream.Seek(2, SeekOrigin.Begin);
             Assert.IsTrue(stream.EndOfStream);
             stream.Dispose();
         }
@@ -550,7 +551,7 @@ namespace Yarhl.UnitTests.IO
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 1, 1, false);
-            stream.Seek(1, SeekMode.Start);
+            stream.Seek(1, SeekOrigin.Begin);
             Assert.AreEqual(1, stream.Position);
             Assert.AreEqual(2, stream.AbsolutePosition);
             stream.Dispose();
@@ -562,7 +563,7 @@ namespace Yarhl.UnitTests.IO
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2, false);
-            stream.Seek(1, SeekMode.Start);
+            stream.Seek(1, SeekOrigin.Begin);
             Assert.AreEqual(1, stream.Position);
             stream.Dispose();
         }
@@ -573,9 +574,9 @@ namespace Yarhl.UnitTests.IO
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2, false);
-            stream.Seek(1, SeekMode.Start);
+            stream.Seek(1, SeekOrigin.Begin);
             Assert.AreEqual(1, stream.Position);
-            stream.Seek(1, SeekMode.Current);
+            stream.Seek(1, SeekOrigin.Current);
             Assert.AreEqual(2, stream.Position);
             stream.Dispose();
         }
@@ -586,7 +587,7 @@ namespace Yarhl.UnitTests.IO
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2, false);
-            stream.Seek(0, SeekMode.End);
+            stream.Seek(0, SeekOrigin.End);
             Assert.AreEqual(2, stream.Position);
             stream.Dispose();
         }
@@ -604,12 +605,12 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void SeekWihtInvalidModeThrows()
+        public void SeekWithInvalidModeThrows()
         {
             DataStream stream = new DataStream();
             stream.WriteByte(0xCA);
             Assert.That(
-                () => stream.Seek(0, (SeekMode)0x100),
+                () => stream.Seek(0, (SeekOrigin)0x100),
                 Throws.TypeOf<ArgumentOutOfRangeException>());
             stream.Dispose();
         }
@@ -621,7 +622,7 @@ namespace Yarhl.UnitTests.IO
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2, false);
             stream.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => stream.Seek(1, SeekMode.Start));
+            Assert.Throws<ObjectDisposedException>(() => stream.Seek(1, SeekOrigin.Begin));
             Assert.AreEqual(0, stream.Position);
         }
 
@@ -631,9 +632,9 @@ namespace Yarhl.UnitTests.IO
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2, false);
-            Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek(10, SeekMode.End));
+            Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek(10, SeekOrigin.End));
             Assert.AreEqual(0, stream.Position);
-            Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek(-10, SeekMode.Current));
+            Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek(-10, SeekOrigin.Current));
             Assert.AreEqual(0, stream.Position);
             stream.Dispose();
         }
@@ -645,7 +646,7 @@ namespace Yarhl.UnitTests.IO
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2, false);
             stream.Position = 1;
-            Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek(10, SeekMode.Start));
+            Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek(10, SeekOrigin.Begin));
             Assert.AreEqual(1, stream.Position);
             stream.Dispose();
         }
@@ -657,7 +658,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0xA);
             stream.WriteByte(0xB);
             Assert.AreEqual(2, stream.Position);
-            stream.PushToPosition(-1, SeekMode.Current);
+            stream.PushToPosition(-1, SeekOrigin.Current);
             Assert.AreEqual(1, stream.Position);
             stream.Dispose();
         }
@@ -682,7 +683,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0xB);
             stream.Dispose();
             Assert.Throws<ObjectDisposedException>(() =>
-                stream.PushToPosition(-1, SeekMode.Current));
+                stream.PushToPosition(-1, SeekOrigin.Current));
         }
 
         [Test]
@@ -714,9 +715,9 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0xA);
             stream.WriteByte(0xB);
             Assert.AreEqual(2, stream.Position);
-            stream.PushToPosition(-1, SeekMode.Current);
+            stream.PushToPosition(-1, SeekOrigin.Current);
             Assert.AreEqual(1, stream.Position);
-            stream.PushToPosition(-1, SeekMode.Current);
+            stream.PushToPosition(-1, SeekOrigin.Current);
             Assert.AreEqual(0, stream.Position);
             stream.PushCurrentPosition();
             stream.Position = 2;
@@ -746,7 +747,7 @@ namespace Yarhl.UnitTests.IO
             DataStream stream = new DataStream();
             stream.WriteByte(0xA);
             stream.WriteByte(0xB);
-            stream.PushToPosition(-1, SeekMode.Current);
+            stream.PushToPosition(-1, SeekOrigin.Current);
             stream.Dispose();
             Assert.Throws<ObjectDisposedException>(stream.PopPosition);
         }
@@ -762,7 +763,7 @@ namespace Yarhl.UnitTests.IO
             stream.RunInPosition(
                 () => Assert.That(stream.ReadByte(), Is.EqualTo(0xBA)),
                 -2,
-                SeekMode.Current);
+                SeekOrigin.Current);
             stream.Dispose();
         }
 
@@ -777,7 +778,7 @@ namespace Yarhl.UnitTests.IO
             stream.RunInPosition(
                 () => Assert.That(stream.ReadByte(), Is.EqualTo(0xFE)),
                 1,
-                SeekMode.Start);
+                SeekOrigin.Begin);
             Assert.That(stream.Position, Is.EqualTo(4));
             stream.Dispose();
         }
@@ -829,13 +830,13 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadByteWhenEOSThrowsException()
+        public void ReadByteWhenEOSReturnsMinusOne()
         {
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2, false);
-            stream.Seek(0, SeekMode.End);
-            Assert.Throws<EndOfStreamException>(() => stream.ReadByte());
+            stream.Seek(0, SeekOrigin.End);
+            Assert.That(stream.ReadByte(), Is.EqualTo(-1));
             Assert.AreEqual(2, stream.Position);
             stream.Dispose();
         }
@@ -871,7 +872,7 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadBufferfterDisposeThrowException()
+        public void ReadBufferAfterDisposeThrowException()
         {
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
@@ -883,15 +884,17 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadBufferWhenEOSThrowsException()
+        public void ReadBufferWhenEOSReadsAsMuchAsPossible()
         {
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2, false);
-            stream.Seek(0, SeekMode.End);
+            stream.Seek(1, SeekOrigin.End);
             byte[] buffer = new byte[2];
-            Assert.Throws<EndOfStreamException>(() => stream.Read(buffer, 0, 1));
+            Assert.DoesNotThrow(() => stream.Read(buffer, 0, 2));
             Assert.AreEqual(2, stream.Position);
+            Assert.That(buffer[0], Is.EqualTo(0xFE));
+            Assert.That(buffer[1], Is.EqualTo(0x00));
             stream.Dispose();
         }
 
@@ -954,7 +957,7 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadFormAfeterDisposeThrowException()
+        public void ReadFormAfterDisposeThrowException()
         {
             DataStream stream = new DataStream();
             stream.WriteByte(0xAF);
@@ -1121,44 +1124,22 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void WriteToNullStream()
-        {
-            DataStream stream = new DataStream();
-            stream.WriteByte(0xCA);
-            stream.WriteByte(0xFE);
-            stream.WriteByte(0x00);
-            stream.WriteByte(0xFF);
-            Assert.Throws<ArgumentNullException>(
-                () => stream.WriteTo((DataStream)null));
-            stream.Dispose();
-        }
-
-        [Test]
-        public void WriteToDisposedStream()
+        public void WriteToStreamGuards()
         {
             DataStream stream1 = new DataStream();
             stream1.WriteByte(0xCA);
             stream1.WriteByte(0xFE);
             stream1.WriteByte(0x00);
             stream1.WriteByte(0xFF);
-            DataStream stream2 = new DataStream();
-            stream2.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => stream1.WriteTo(stream2));
-            stream1.Dispose();
-        }
 
-        [Test]
-        public void WriteToAfterDisposeStream()
-        {
-            DataStream stream1 = new DataStream();
-            stream1.WriteByte(0xCA);
-            stream1.WriteByte(0xFE);
-            stream1.WriteByte(0x00);
-            stream1.WriteByte(0xFF);
-            DataStream stream2 = new DataStream();
+            Assert.Throws<ArgumentNullException>(() => stream1.WriteTo((Stream)null));
+
+            DataStream disposedStream = new DataStream();
+            disposedStream.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => disposedStream.WriteTo(stream1));
+            Assert.Throws<ObjectDisposedException>(() => stream1.WriteTo(disposedStream));
+
             stream1.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => stream1.WriteTo(stream2));
-            stream2.Dispose();
         }
 
         [Test]
@@ -1318,6 +1299,17 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void WriteToFileGuards()
+        {
+            using var stream = new DataStream();
+            Assert.Throws<ArgumentNullException>(() => stream.WriteTo((string)null));
+            Assert.Throws<ArgumentNullException>(() => stream.WriteTo(string.Empty));
+
+            stream.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => stream.WriteTo("test"));
+        }
+
+        [Test]
         public void WriteToFileCreatesParentFolder()
         {
             string tempFile = Path.Combine(
@@ -1362,41 +1354,17 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void WriteToNullFile()
-        {
-            DataStream stream1 = new DataStream();
-            stream1.WriteByte(0xCA);
-            stream1.WriteByte(0xFE);
-            stream1.WriteByte(0x00);
-            stream1.WriteByte(0xFF);
-            Assert.Throws<ArgumentNullException>(
-                () => stream1.WriteTo((string)null));
-            Assert.Throws<ArgumentNullException>(() => stream1.WriteTo(string.Empty));
-            stream1.Dispose();
-        }
-
-        [Test]
-        public void WriteToAfterDispose()
-        {
-            DataStream stream1 = new DataStream();
-            stream1.WriteByte(0xCA);
-            stream1.WriteByte(0xFE);
-            stream1.WriteByte(0x00);
-            stream1.WriteByte(0xFF);
-            stream1.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => stream1.WriteTo("/ex"));
-        }
-
-        [Test]
-        public void WriteToWhenLengthZero()
+        public void WriteToWhenLengthZeroCreatesEmptyFile()
         {
             string tempFile = Path.Combine(
                 Path.GetTempPath(),
                 Path.GetRandomFileName(),
                 Path.GetRandomFileName());
 
-            DataStream stream1 = new DataStream();
-            stream1.WriteTo(tempFile);
+            DataStream stream = new DataStream();
+            stream.WriteTo(tempFile);
+
+            Assert.That(File.Exists(tempFile), Is.True);
             FileStream fs = new FileStream(tempFile, FileMode.Open, FileAccess.Read);
             Assert.AreEqual(0, fs.Length);
             fs.Dispose();
@@ -1404,104 +1372,81 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void WriteSegmentToVariableLength()
+        public void WriteSegmentToStreamWithOffset()
         {
-            DataStream stream1 = new DataStream();
+            using DataStream stream1 = new DataStream();
             stream1.WriteByte(0xCA);
             stream1.WriteByte(0xFE);
             stream1.WriteByte(0x00);
             stream1.WriteByte(0xFF);
-            DataStream stream2 = new DataStream();
-            stream1.WriteSegmentTo(0, 2, stream2);
-            stream2.Position = 0;
-            Assert.AreEqual(0xCA, stream2.ReadByte());
-            Assert.AreEqual(0xFE, stream2.ReadByte());
-            Assert.IsTrue(stream2.Length == 2);
-            stream1.Dispose();
-            stream2.Dispose();
-        }
 
-        [Test]
-        public void WriteSegmentToVariableLengthLongerThanSOH()
-        {
-            DataStream stream1 = new DataStream();
-            byte[] data = new byte[70 * 1024 * 2];
-            Random random = new Random();
-            random.NextBytes(data);
-            for (int i = 0; i < data.Length; i++) {
-                stream1.WriteByte(data[i]);
-            }
-
-            DataStream stream2 = new DataStream();
-            stream1.WriteSegmentTo(0, data.Length - 10, stream2);
-            stream2.Position = 0;
-            Assert.AreEqual(data[0], stream2.ReadByte());
-            Assert.AreEqual(data[1], stream2.ReadByte());
-            Assert.IsTrue(stream2.Length == data.Length - 10);
-            stream1.Dispose();
-            stream2.Dispose();
-        }
-
-        [Test]
-        public void WriteSegmentToVariableLengthChangingOffset()
-        {
-            DataStream stream1 = new DataStream();
-            stream1.WriteByte(0xCA);
-            stream1.WriteByte(0xFE);
-            stream1.WriteByte(0x00);
-            stream1.WriteByte(0xFF);
-            DataStream stream2 = new DataStream();
-            stream1.WriteSegmentTo(1, 2, stream2);
-            stream2.Position = 0;
-            Assert.AreEqual(0xFE, stream2.ReadByte());
-            Assert.AreEqual(0x00, stream2.ReadByte());
-            Assert.IsTrue(stream2.Length == 2);
-            stream1.Dispose();
-            stream2.Dispose();
-        }
-
-        [Test]
-        public void WriteSegmentToChangingOffset()
-        {
-            DataStream stream1 = new DataStream();
-            stream1.WriteByte(0xCA);
-            stream1.WriteByte(0xFE);
-            stream1.WriteByte(0x00);
-            stream1.WriteByte(0xFF);
-            DataStream stream2 = new DataStream();
+            using DataStream stream2 = new DataStream();
             stream1.WriteSegmentTo(2, stream2);
+
             stream2.Position = 0;
+            Assert.IsTrue(stream2.Length == 2);
             Assert.AreEqual(0x00, stream2.ReadByte());
             Assert.AreEqual(0xFF, stream2.ReadByte());
+        }
+
+        [Test]
+        public void WriteSegmentToFileWithOffset()
+        {
+            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+            using DataStream stream = new DataStream();
+            stream.WriteByte(0xCA);
+            stream.WriteByte(0xFE);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0xFF);
+            stream.WriteSegmentTo(2, tempFile);
+
+            DataStream fileStream = DataStreamFactory.FromFile(tempFile, FileOpenMode.Read);
+            Assert.That(fileStream.Length, Is.EqualTo(2));
+            Assert.That(fileStream.ReadByte(), Is.EqualTo(0x00));
+            Assert.That(fileStream.ReadByte(), Is.EqualTo(0xFF));
+
+            fileStream.Dispose();
+            File.Delete(tempFile);
+        }
+
+        [Test]
+        public void WriteSegmentToStreamWithOffsetAndLength()
+        {
+            using DataStream stream1 = new DataStream();
+            stream1.WriteByte(0xCA);
+            stream1.WriteByte(0xFE);
+            stream1.WriteByte(0x00);
+            stream1.WriteByte(0xFF);
+
+            using DataStream stream2 = new DataStream();
+            stream1.WriteSegmentTo(1, 2, stream2);
+
+            stream2.Position = 0;
             Assert.IsTrue(stream2.Length == 2);
-            stream1.Dispose();
-            stream2.Dispose();
+            Assert.AreEqual(0xFE, stream2.ReadByte());
+            Assert.AreEqual(0x00, stream2.ReadByte());
         }
 
         [Test]
-        public void WriteSegmentToNullFile()
+        public void WriteSegmentToFileWithOffsetAndLength()
         {
-            DataStream stream1 = new DataStream();
-            stream1.WriteByte(0xCA);
-            stream1.WriteByte(0xFE);
-            stream1.WriteByte(0x00);
-            stream1.WriteByte(0xFF);
-            Assert.Throws<ArgumentNullException>(
-                () => stream1.WriteSegmentTo(0, 2, (string)null));
-            Assert.Throws<ArgumentNullException>(() => stream1.WriteSegmentTo(0, 2, string.Empty));
-            stream1.Dispose();
-        }
+            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-        [Test]
-        public void WriteSegmentToFileAfterDispose()
-        {
-            DataStream stream1 = new DataStream();
-            stream1.WriteByte(0xCA);
-            stream1.WriteByte(0xFE);
-            stream1.WriteByte(0x00);
-            stream1.WriteByte(0xFF);
-            stream1.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => stream1.WriteSegmentTo(1, 2, "/ex"));
+            using DataStream stream = new DataStream();
+            stream.WriteByte(0xCA);
+            stream.WriteByte(0xFE);
+            stream.WriteByte(0x00);
+            stream.WriteByte(0xFF);
+            stream.WriteSegmentTo(1, 2, tempFile);
+
+            DataStream fileStream = DataStreamFactory.FromFile(tempFile, FileOpenMode.Read);
+            Assert.That(fileStream.Length, Is.EqualTo(2));
+            Assert.That(fileStream.ReadByte(), Is.EqualTo(0xFE));
+            Assert.That(fileStream.ReadByte(), Is.EqualTo(0x00));
+
+            fileStream.Dispose();
+            File.Delete(tempFile);
         }
 
         [Test]
@@ -1532,43 +1477,123 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void WriteSegmentToNullStream()
-        {
-            DataStream stream = new DataStream();
-            stream.WriteByte(0xCA);
-            stream.WriteByte(0xFE);
-            stream.WriteByte(0x00);
-            stream.WriteByte(0xFF);
-            Assert.Throws<ArgumentNullException>(
-                () => stream.WriteSegmentTo(1, 2, (DataStream)null));
-            stream.Dispose();
-        }
-
-        [Test]
-        public void WriteSegmentToStreamAfterDispose()
+        public void WriteSegmentToWithOffsetAndLengthLongerThanSOH()
         {
             DataStream stream1 = new DataStream();
-            stream1.WriteByte(0xCA);
-            stream1.WriteByte(0xFE);
-            stream1.WriteByte(0x00);
-            stream1.WriteByte(0xFF);
+            byte[] data = new byte[70 * 1024 * 2];
+            Random random = new Random();
+            random.NextBytes(data);
+            for (int i = 0; i < data.Length; i++) {
+                stream1.WriteByte(data[i]);
+            }
+
+            DataStream stream2 = new DataStream();
+            stream1.WriteSegmentTo(0, data.Length - 10, stream2);
+            stream2.Position = 0;
+            Assert.AreEqual(data[0], stream2.ReadByte());
+            Assert.AreEqual(data[1], stream2.ReadByte());
+            Assert.IsTrue(stream2.Length == data.Length - 10);
             stream1.Dispose();
-            DataStream stream2 = new DataStream();
-            Assert.Throws<ObjectDisposedException>(() => stream1.WriteSegmentTo(0, 2, stream2));
-        }
-
-        [Test]
-        public void WriteSegmentToDisposedStream()
-        {
-            DataStream stream1 = new DataStream();
-            stream1.WriteByte(0xCA);
-            stream1.WriteByte(0xFE);
-            stream1.WriteByte(0x00);
-            stream1.WriteByte(0xFF);
-            DataStream stream2 = new DataStream();
             stream2.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => stream1.WriteSegmentTo(0, 2, stream2));
-            stream1.Dispose();
+        }
+
+        [Test]
+        public void WriteSegmentToGuards()
+        {
+            using DataStream stream = new DataStream();
+            stream.Write(new byte[] { 1, 2, 3, 4 }, 0, 4);
+
+            using DataStream stream2 = new DataStream();
+
+            DataStream disposedStream = new DataStream();
+            disposedStream.Write(new byte[] { 5, 6, 7, 8 }, 0, 4);
+            disposedStream.Dispose();
+
+            // Null or empty
+            Assert.That(
+                () => stream.WriteSegmentTo(1, (string)null),
+                Throws.ArgumentNullException);
+            Assert.That(
+                () => stream.WriteSegmentTo(1, string.Empty),
+                Throws.ArgumentNullException);
+            Assert.That(
+                () => stream.WriteSegmentTo(1, (Stream)null),
+                Throws.ArgumentNullException);
+            Assert.That(
+                () => stream.WriteSegmentTo(1, 2, (string)null),
+                Throws.ArgumentNullException);
+            Assert.That(
+                () => stream.WriteSegmentTo(1, 2, string.Empty),
+                Throws.ArgumentNullException);
+            Assert.That(
+                () => stream.WriteSegmentTo(1, 2, (Stream)null),
+                Throws.ArgumentNullException);
+
+            // Index out range
+            Assert.That(
+                () => stream.WriteSegmentTo(-2, "test"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(5, "test"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(-2, stream2),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(5, stream2),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(-2, 1, "test"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(5, 0, "test"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(1, -1, "test"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(1, 5, "test"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(3, 2, "test"),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(-2, 1, stream2),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(5, 0, stream2),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(1, -1, stream2),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(1, 5, stream2),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(3, 2, stream2),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+
+            // From disposed stream
+            Assert.That(
+                () => disposedStream.WriteSegmentTo(1, "test"),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => disposedStream.WriteSegmentTo(1, stream),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => disposedStream.WriteSegmentTo(1, 2, "test"),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => disposedStream.WriteSegmentTo(1, 2, stream),
+                Throws.InstanceOf<ObjectDisposedException>());
+
+            // To disposed stream
+            Assert.That(
+                () => stream.WriteSegmentTo(1, disposedStream),
+                Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(
+                () => stream.WriteSegmentTo(1, 2, disposedStream),
+                Throws.InstanceOf<ObjectDisposedException>());
         }
 
         [Test]
@@ -1657,6 +1682,7 @@ namespace Yarhl.UnitTests.IO
             stream1.WriteByte(0xFF);
             stream2.Dispose();
             Assert.Throws<ObjectDisposedException>(() => stream1.Compare(stream2));
+            Assert.Throws<ObjectDisposedException>(() => stream2.Compare(stream1));
             stream1.Dispose();
         }
 
@@ -1819,11 +1845,40 @@ namespace Yarhl.UnitTests.IO
             result.Dispose();
         }
 
+        [Test]
+        public void TestStreamCanReadWriteAndSeek()
+        {
+            var stream = new DataStream();
+            Assert.That(stream.CanRead, Is.True);
+            Assert.That(stream.CanWrite, Is.True);
+            Assert.That(stream.CanSeek, Is.True);
+        }
+
+        [Test]
+        public void TestStreamFlushGuards()
+        {
+            var stream = new DataStream();
+            stream.Dispose();
+            Assert.That(() => stream.Flush(), Throws.InstanceOf<ObjectDisposedException>());
+        }
+
+        [Test]
+        public void TestFlushCallsStreamFlush()
+        {
+            var innerStream = new Mock<IStream>();
+            var streamLock = new object();
+            innerStream.Setup(s => s.LockObj).Returns(streamLock);
+
+            var stream = new DataStream(innerStream.Object);
+            stream.Flush();
+            innerStream.Verify(s => s.Flush(), Times.Once);
+        }
+
         public class DummyBinaryConverter : IConverter<BinaryFormat, byte>
         {
             public byte Convert(BinaryFormat source)
             {
-                return source.Stream.ReadByte();
+                return (byte)source.Stream.ReadByte();
             }
         }
     }

--- a/src/Yarhl.UnitTests/IO/DataWriterTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataWriterTests.cs
@@ -24,7 +24,6 @@ namespace Yarhl.UnitTests.IO
     using System.Text;
     using NUnit.Framework;
     using Yarhl.IO;
-    using Yarhl.IO.Serialization;
     using Yarhl.IO.Serialization.Attributes;
 
     [TestFixture]
@@ -46,7 +45,7 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void EndiannesProperty()
+        public void EndiannessProperty()
         {
             using DataStream stream = new DataStream();
             DataWriter writer = new DataWriter(stream);
@@ -63,6 +62,23 @@ namespace Yarhl.UnitTests.IO
             Assert.AreSame(Encoding.UTF8, writer.DefaultEncoding);
             writer.DefaultEncoding = Encoding.GetEncoding(932);
             Assert.AreSame(Encoding.GetEncoding(932), writer.DefaultEncoding);
+        }
+
+        [Test]
+        public void WritePrimiteThrowExceptionWithInvalidEndianness()
+        {
+            using var stream = new DataStream();
+            var writer = new DataWriter(stream);
+            writer.Endianness = (EndiannessMode)0x100;
+
+            Assert.That(() => writer.Write(0xCAFE), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => writer.Write(-28124), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => writer.Write(0xCAFEBABE), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => writer.Write(-1683902195), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => writer.Write(0xCAFEBABE1234ACDC), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => writer.Write(-592582943872953006), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => writer.Write(3.14f), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => writer.Write(-3.14d), Throws.InstanceOf<NotSupportedException>());
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/StreamFormat/StreamWrapperTests.cs
+++ b/src/Yarhl.UnitTests/IO/StreamFormat/StreamWrapperTests.cs
@@ -21,6 +21,7 @@ namespace Yarhl.UnitTests.IO.StreamFormat
 {
     using System;
     using System.IO;
+    using Moq;
     using NUnit.Framework;
     using Yarhl.IO.StreamFormat;
 
@@ -48,7 +49,7 @@ namespace Yarhl.UnitTests.IO.StreamFormat
         }
 
         [Test]
-        public void DiposeCloseStream()
+        public void DisposeCloseStream()
         {
             var stream = new MemoryStream();
             stream.WriteByte(0xAA);
@@ -207,6 +208,15 @@ namespace Yarhl.UnitTests.IO.StreamFormat
             Assert.That(
                 () => wrapper.Read(buffer, 0, 1),
                 Throws.InstanceOf<ObjectDisposedException>());
+        }
+
+        [Test]
+        public void TestFlushCallsStreamFlush()
+        {
+            var innerStream = new Mock<Stream>();
+            var stream = new StreamWrapper(innerStream.Object);
+            stream.Flush();
+            innerStream.Verify(s => s.Flush(), Times.Once);
         }
     }
 }

--- a/src/Yarhl.UnitTests/IO/StreamFormat/StreamWrapperTests.cs
+++ b/src/Yarhl.UnitTests/IO/StreamFormat/StreamWrapperTests.cs
@@ -216,7 +216,20 @@ namespace Yarhl.UnitTests.IO.StreamFormat
             var innerStream = new Mock<Stream>();
             var stream = new StreamWrapper(innerStream.Object);
             stream.Flush();
-            innerStream.Verify(s => s.Flush(), Times.Once);
+            Assert.That(
+                () => innerStream.Verify(s => s.Flush(), Times.Once),
+                Throws.Nothing);
+        }
+
+        [Test]
+        public void TestFlushThrowsIfDisposed()
+        {
+            var innerStream = new Mock<Stream>();
+            var stream = new StreamWrapper(innerStream.Object);
+            stream.Dispose();
+            Assert.That(
+                () => stream.Flush(),
+                Throws.InstanceOf<ObjectDisposedException>());
         }
     }
 }

--- a/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
+++ b/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
@@ -15,5 +15,6 @@
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
 </Project>

--- a/src/Yarhl/IO/IStream.cs
+++ b/src/Yarhl/IO/IStream.cs
@@ -43,7 +43,7 @@ namespace Yarhl.IO
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="IStream" />
-        /// has been dispsosed.
+        /// has been disposed.
         /// </summary>
         bool Disposed { get; }
 
@@ -55,6 +55,12 @@ namespace Yarhl.IO
         /// Some streams may not implement or support changing the length.
         /// </para></remarks>
         void SetLength(long length);
+
+        /// <summary>
+        /// Clears all buffers for this stream and causes any buffered data
+        /// to be written to the underlying device.
+        /// </summary>
+        void Flush();
 
         /// <summary>
         /// Reads the next byte.

--- a/src/Yarhl/IO/SeekMode.cs
+++ b/src/Yarhl/IO/SeekMode.cs
@@ -19,9 +19,12 @@
 // SOFTWARE.
 namespace Yarhl.IO
 {
+    using System;
+
     /// <summary>
     /// Seek mode for DataStream.
     /// </summary>
+    [Obsolete("Use overloads with System.IO.SeekOrigin")]
     public enum SeekMode
     {
         /// <summary>

--- a/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
+++ b/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
@@ -97,6 +97,9 @@ namespace Yarhl.IO.StreamFormat
         /// <inheritdoc />
         public virtual void Flush()
         {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(StreamWrapper));
+
             BaseStream.Flush();
         }
 

--- a/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
+++ b/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
@@ -75,7 +75,7 @@ namespace Yarhl.IO.StreamFormat
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="IStream" />
-        /// has been dispsosed.
+        /// has been disposed.
         /// </summary>
         public bool Disposed {
             get;
@@ -94,6 +94,12 @@ namespace Yarhl.IO.StreamFormat
             BaseStream.SetLength(length);
         }
 
+        /// <inheritdoc />
+        public virtual void Flush()
+        {
+            BaseStream.Flush();
+        }
+
         /// <summary>
         /// Reads from the stream to the buffer.
         /// </summary>
@@ -107,8 +113,9 @@ namespace Yarhl.IO.StreamFormat
                 throw new ObjectDisposedException(nameof(StreamWrapper));
 
             BaseStream.Position = Position;
-            Position += count;
-            return BaseStream.Read(buffer, index, count);
+            int read = BaseStream.Read(buffer, index, count);
+            Position += read;
+            return read;
         }
 
         /// <summary>

--- a/src/Yarhl/IO/TextReader.cs
+++ b/src/Yarhl/IO/TextReader.cs
@@ -21,6 +21,7 @@ namespace Yarhl.IO
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
     using System.Text;
 
@@ -44,7 +45,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to read from.</param>
         /// <remarks><para>The default encoding is UTF-8.</para></remarks>
-        public TextReader(DataStream stream)
+        public TextReader(Stream stream)
             : this(stream, Encoding.UTF8)
         {
         }
@@ -54,7 +55,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to read from.</param>
         /// <param name="encoding">Encoding to use.</param>
-        public TextReader(DataStream stream, string encoding)
+        public TextReader(Stream stream, string encoding)
             : this(stream, Encoding.GetEncoding(encoding))
         {
         }
@@ -64,7 +65,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to read from.</param>
         /// <param name="encoding">Encoding to use.</param>
-        public TextReader(DataStream stream, Encoding encoding)
+        public TextReader(Stream stream, Encoding encoding)
         {
             Stream = stream ?? throw new ArgumentNullException(nameof(stream));
             Encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
@@ -79,7 +80,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets the stream.
         /// </summary>
-        public DataStream Stream {
+        public Stream Stream {
             get;
             private set;
         }
@@ -156,7 +157,7 @@ namespace Yarhl.IO
                 throw new ArgumentNullException(nameof(token));
 
             // If starting is EOF, then return null
-            if (Stream.EndOfStream) {
+            if (Stream.Position >= Stream.Length) {
                 return null;
             }
 
@@ -176,7 +177,7 @@ namespace Yarhl.IO
             int matchIndex = -1;
 
             while (matchIndex == -1) {
-                if (Stream.EndOfStream) {
+                if (Stream.Position >= Stream.Length) {
                     break;
                 }
 
@@ -196,7 +197,7 @@ namespace Yarhl.IO
             if (matchIndex != -1) {
                 // We skip the bytes of the token too
                 string fullResult = text.Substring(0, matchIndex + token.Length);
-                Stream.Seek(startPos + Encoding.GetByteCount(fullResult), SeekMode.Start);
+                Stream.Seek(startPos + Encoding.GetByteCount(fullResult), SeekOrigin.Begin);
 
                 // Result without token
                 text = text.Substring(0, matchIndex);
@@ -245,7 +246,7 @@ namespace Yarhl.IO
         {
             long startPos = Stream.Position;
             char ch = Read();
-            Stream.Seek(startPos, SeekMode.Start);
+            Stream.Seek(startPos, SeekOrigin.Begin);
             return ch;
         }
 
@@ -258,7 +259,7 @@ namespace Yarhl.IO
         {
             long startPos = Stream.Position;
             char[] chars = Read(count);
-            Stream.Seek(startPos, SeekMode.Start);
+            Stream.Seek(startPos, SeekOrigin.Begin);
             return chars;
         }
 
@@ -271,7 +272,7 @@ namespace Yarhl.IO
         {
             long startPos = Stream.Position;
             string content = ReadToToken(token);
-            Stream.Seek(startPos, SeekMode.Start);
+            Stream.Seek(startPos, SeekOrigin.Begin);
             return content;
         }
 
@@ -283,7 +284,7 @@ namespace Yarhl.IO
         {
             long startPos = Stream.Position;
             string line = ReadLine();
-            Stream.Seek(startPos, SeekMode.Start);
+            Stream.Seek(startPos, SeekOrigin.Begin);
             return line;
         }
 
@@ -306,7 +307,7 @@ namespace Yarhl.IO
 
             // If it didn't fully match it wasn't a preamble, returns to 0
             if (!match) {
-                Stream.Seek(0, SeekMode.Start);
+                Stream.Seek(0, SeekOrigin.Begin);
             }
         }
     }

--- a/src/Yarhl/IO/TextWriter.cs
+++ b/src/Yarhl/IO/TextWriter.cs
@@ -21,6 +21,7 @@ namespace Yarhl.IO
 {
     using System;
     using System.Globalization;
+    using System.IO;
     using System.Text;
 
     /// <summary>
@@ -42,7 +43,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to write to.</param>
         /// <remarks><para>The default encoding is UTF-8.</para></remarks>
-        public TextWriter(DataStream stream)
+        public TextWriter(Stream stream)
             : this(stream, Encoding.UTF8)
         {
         }
@@ -52,7 +53,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to read from.</param>
         /// <param name="encoding">Encoding to use.</param>
-        public TextWriter(DataStream stream, string encoding)
+        public TextWriter(Stream stream, string encoding)
             : this(stream, Encoding.GetEncoding(encoding))
         {
         }
@@ -62,7 +63,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <param name="stream">Stream to write to.</param>
         /// <param name="encoding">Encoding to use.</param>
-        public TextWriter(DataStream stream, Encoding encoding)
+        public TextWriter(Stream stream, Encoding encoding)
         {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
@@ -81,7 +82,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets the stream.
         /// </summary>
-        public DataStream Stream {
+        public Stream Stream {
             get;
             private set;
         }

--- a/src/Yarhl/Yarhl.csproj
+++ b/src/Yarhl/Yarhl.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <Description>Library to translation projects. It provides features for implementing file formats, converters and a virtual file system.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

As explained in #158, in order to improve the compatibility of Yarhl with other frameworks, it would be great if `DataStream` can be treated as a regular `Stream`, the standard base type for streams in .NET. Also, make other reader and writer class to work with it.

This PR obsolete some methods, these methods are marked with the `Obsolete` attribute and they are not guarantee to work (no unit test or code coverage). They can be removed in any future release.

`Stream` has a `CopyTo(Stream)` method but I've kept the `WriteTo(Stream)`. The reason is that `CopyTo` does not copy from the start but from the current position and it doesn't preserve this position. Also it doesn't detect well cases where the streams are disposed.

`BinaryFormat` keeps working only with `DataStream` as it facilitates the usage inside the Yarhl framework to make easier other substreams, `WriteTo` would affect `Node` too, but now this `DataStream` is a regular `Stream` too.

Also improving guards from several methods, especially `DataStream.WriteSegmentTo` and `DataReader.ReadBytes`.

### Breaking changes

- The property `Stream` of `DataReader`, `DataWriter`, `TextReader` and `TextWriter` now returns `Stream` instead of `DataStream`. This due to the fact that these classes now works entirely with `Stream`.
  - In order to use `DataStream` specific features like the property `EndOfStream` or methods like `WriteTo`, you could keep a reference to your original `DataReader`. If you know the reader/writer is working with a `DataStream` you could cast it.
  - Access to `EndOfStream` property from a reader could be replaced with `reader.Stream.Position >= reader.Stream.Length`.

- **`DataStream` does NOT throw `EndOfStreamException` when reading bytes.** This change is required to match the expected behavior of `Stream`.
  - `ReadByte` returns `-1` when it reaches the end.
  - `ReadBytes` reads as many bytes as possible given in the `count` argument. It will read nothing when it reaches the end. It returns how many bytes it has read (0 in end of stream).
  - **`DataReader` keeps the behavior and it WILL throw `EndOfStreamException` when reading any data type**, including `ReadByte` and `ReadBytes`.

- `DataStream.ReadByte` now returns `int` instead of `byte`. This is required to overload `Stream` function. It returns always byte values except when reaches the end that it returns -1.

- `IStream` now requires to implement the `Flush` method. `DataStream.Flush` will call it.

- Move `DataStream.Length` setter to its own method `SetLength(long)`. This is a required changed by `Stream`.

- Obsolete `SeekMode` and any method having this type as argument. Instead use the BCL type `System.IO.SeekOrigin`.

- `DataReader` and `DataWriter` now throw `NotSupportedException` when using an invalid endianness. Before it returned -1 or write in big endianness mode.

### Example

You can now using a `DataStream` instead with any other framework that works with `Stream`, like xdelta-sharp or compression libraries.

You can also use the classes `DataReader`, `DataWriter`, `TextReader` and `TextWriter` with regular `Stream` too.

This closes #158
