### PR TITLE
Rename TextReader and TextWriter to TextDataReader and TextDataWriter

### DIFF
--- a/docs/guides/Yarhl-nutshell.md
+++ b/docs/guides/Yarhl-nutshell.md
@@ -99,28 +99,28 @@ need to write padding bytes, then
 [`WritePadding`](<xref:Yarhl.IO.DataWriter.WritePadding(System.Byte,System.Int32)>)
 will be your friend.
 
-### TextReader and TextWriter
+### TextDataReader and TextDataWriter
 
 So far, `DataReader` and `DataWriter` have been very useful when you are dealing
 with a file that contains some integer fields for size or offset, arrays of
 bytes and maybe null-terminated strings. But, what about if you need to work
 with a file that only contains text and you are interested in reading line by
-line? In that case, you need [`TextReader`](xref:Yarhl.IO.TextReader) and
-[`TextWriter`](xref:Yarhl.IO.TextWriter).
+line? In that case, you need [`TextDataReader`](xref:Yarhl.IO.TextDataReader)
+and [`TextDataWriter`](xref:Yarhl.IO.TextDataWriter).
 
 #### New lines
 
-By default, `TextWriter` uses always (Windows too) the new line `\n`. It doesn't
-use `\r\n`. The reason is that most file formats uses `\n` and in some games
-having the `\r` may crash. It's sometimes difficult to notice that. If you want
-to use any other new line string (you can even use `<br/>`), you just need to
-change the [`NewLine`](xref:Yarhl.IO.TextWriter.NewLine) property.
+By default, `TextDataWriter` uses always (Windows too) the new line `\n`. It
+doesn't use `\r\n`. The reason is that most file formats uses `\n` and in some
+games having the `\r` may crash. It's sometimes difficult to notice that. If you
+want to use any other new line string (you can even use `<br/>`), you just need
+to change the [`NewLine`](xref:Yarhl.IO.TextDataWriter.NewLine) property.
 
-In the case of the `TextReader` the behavior is different. The default value for
-the [`NewLine`](xref:Yarhl.IO.TextReader.NewLine) property depends on the OS
-(Windows: `\r\n`, Unix: `\n`). In addition, we provided with an automatic
+In the case of the `TextDataReader` the behavior is different. The default value
+for the [`NewLine`](xref:Yarhl.IO.TextDataReader.NewLine) property depends on
+the OS (Windows: `\r\n`, Unix: `\n`). In addition, we provided with an automatic
 mechanism enabled by default:
-[`AutoNewLine`](xref:Yarhl.IO.TextReader.AutoNewLine*). If it's enabled, you
+[`AutoNewLine`](xref:Yarhl.IO.TextDataReader.AutoNewLine*). If it's enabled, you
 don't need to know the line ending in advance because we will stop at `\n` and
 remove the last `\r` if present. This is also useful if a file mix both line
 endings. And remember, by setting the `NewLine` property `AutoNewLine` is
@@ -148,13 +148,14 @@ stream that confirms the encoding of the file. For instance, when using UTF-16,
 the file will begin with the bytes `0xFEFF`. It also specifies if the encoding
 is little-ending or big-endian (needed for UTF-16).
 
-Our `TextReader` will skip the BOM (_if it's present_) at the beginning of the
-file. In the case of the `TextWriter`, the behavior is defined by the property
-[`AutoPreamble`](xref:Yarhl.IO.TextWriter.AutoPreamble) which is set to `false`
-by default (again, some games may see it as unexpected bytes). When enabled, the
-first write call will also write the BOM. You can also write it manually by
-calling [`WritePreamble()`](xref:Yarhl.IO.TextWriter.WritePreamble) (but
-remember, only if you are at the beginning of the stream).
+Our `TextDataReader` will skip the BOM (_if it's present_) at the beginning of
+the file. In the case of the `TextDataWriter`, the behavior is defined by the
+property [`AutoPreamble`](xref:Yarhl.IO.TextDataWriter.AutoPreamble) which is
+set to `false` by default (again, some games may see it as unexpected bytes).
+When enabled, the first write call will also write the BOM. You can also write
+it manually by calling
+[`WritePreamble()`](xref:Yarhl.IO.TextDataWriter.WritePreamble) (but remember,
+only if you are at the beginning of the stream).
 
 I know... I talk too much... Let's continue!
 
@@ -206,7 +207,7 @@ public void SaveFile(string path)
 ```csharp
 public void LoadFile(DataStream stream)
 {
-    var reader = new TextReader(stream, Encoding.Unicode);
+    var reader = new TextDataReader(stream, Encoding.Unicode);
 
     string firstLine = reader.ReadLine();
     char[] someChars = reader.Read(4);
@@ -219,7 +220,7 @@ public void LoadFile(DataStream stream)
 
 public void SaveFile(DataStream stream)
 {
-    var writer = new TextWriter(stream) {
+    var writer = new TextDataWriter(stream) {
         AutoPreamble = true,
     };
 

--- a/src/Yarhl.Media/Text/Binary2Po.cs
+++ b/src/Yarhl.Media/Text/Binary2Po.cs
@@ -39,7 +39,7 @@ namespace Yarhl.Media.Text
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            TextReader reader = new TextReader(source.Stream);
+            TextDataReader reader = new TextDataReader(source.Stream);
             Po po = new Po();
 
             // Read the header if any
@@ -60,7 +60,7 @@ namespace Yarhl.Media.Text
             return po;
         }
 
-        static PoEntry ReadEntry(TextReader reader)
+        static PoEntry ReadEntry(TextDataReader reader)
         {
             // Skip all the blank lines before the block of text
             string line = string.Empty;
@@ -86,7 +86,7 @@ namespace Yarhl.Media.Text
             return entry;
         }
 
-        static void ParseLine(TextReader reader, PoEntry entry, string line)
+        static void ParseLine(TextDataReader reader, PoEntry entry, string line)
         {
             string[] fields = line.Split(new[] { ' ' }, 2);
             if (fields.Length != 2)
@@ -207,7 +207,7 @@ namespace Yarhl.Media.Text
             }
         }
 
-        static string ReadMultiLineComment(TextReader reader, string line, string comment)
+        static string ReadMultiLineComment(TextDataReader reader, string line, string comment)
         {
             StringBuilder builder = new StringBuilder(line + "\n");
             while (reader.PeekToToken(" ") == comment) {
@@ -222,7 +222,7 @@ namespace Yarhl.Media.Text
             return result.Remove(result.Length - 1, 1).Replace("\n ", "\n");
         }
 
-        static string ReadMultiLineContent(TextReader reader, string currentLine)
+        static string ReadMultiLineContent(TextDataReader reader, string currentLine)
         {
             StringBuilder content = new StringBuilder(ParseMultiLine(currentLine));
 

--- a/src/Yarhl.Media/Text/Po2Binary.cs
+++ b/src/Yarhl.Media/Text/Po2Binary.cs
@@ -39,7 +39,7 @@ namespace Yarhl.Media.Text
                 throw new ArgumentNullException(nameof(source));
 
             BinaryFormat binary = new BinaryFormat();
-            TextWriter writer = new TextWriter(binary.Stream);
+            TextDataWriter writer = new TextDataWriter(binary.Stream);
 
             if (source.Header != null)
                 WriteHeader(source.Header, writer);
@@ -52,7 +52,7 @@ namespace Yarhl.Media.Text
             return binary;
         }
 
-        static void WriteHeader(PoHeader header, TextWriter writer)
+        static void WriteHeader(PoHeader header, TextDataWriter writer)
         {
             writer.WriteLine(@"msgid """"");
             writer.WriteLine(@"msgstr """"");
@@ -72,7 +72,7 @@ namespace Yarhl.Media.Text
                 writer.WriteLine(@"""X-{0}: {1}\n""", entry.Key, entry.Value);
         }
 
-        static void WriteEntry(PoEntry entry, TextWriter writer)
+        static void WriteEntry(PoEntry entry, TextDataWriter writer)
         {
             WriteIfNotEmpty(writer, "#  {0}", entry.TranslatorComment);
             WriteIfNotEmpty(writer, "#. {0}", entry.ExtractedComments);
@@ -93,7 +93,7 @@ namespace Yarhl.Media.Text
             WriteWrappedString(writer, entry.Translated);
         }
 
-        static void WriteIfNotEmpty(TextWriter writer, string format, string content)
+        static void WriteIfNotEmpty(TextDataWriter writer, string format, string content)
         {
             if (!string.IsNullOrEmpty(content)) {
                 var lines = content.Split('\n');
@@ -103,7 +103,7 @@ namespace Yarhl.Media.Text
             }
         }
 
-        static void WriteWrappedString(TextWriter writer, string content)
+        static void WriteWrappedString(TextDataWriter writer, string content)
         {
             int idx = 0;
             content = content.Replace("\n", "\\n");

--- a/src/Yarhl.UnitTests/IO/TextDataReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/TextDataReaderTests.cs
@@ -25,7 +25,7 @@ namespace Yarhl.UnitTests.IO
     using Yarhl.IO;
 
     [TestFixture]
-    public class TextReaderTests
+    public class TextDataReaderTests
     {
         DataStream stream;
 
@@ -44,7 +44,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void PropertyValuesWithConstructorOneArgument()
         {
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             Assert.AreSame(stream, reader.Stream);
             Assert.AreSame(Encoding.UTF8, reader.Encoding);
             Assert.AreEqual(Environment.NewLine, reader.NewLine);
@@ -54,7 +54,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void PropertyValuesWithConstructorEncoding()
         {
-            var reader = new TextReader(stream, Encoding.ASCII);
+            var reader = new TextDataReader(stream, Encoding.ASCII);
             Assert.AreSame(stream, reader.Stream);
             Assert.AreSame(Encoding.ASCII, reader.Encoding);
             Assert.AreEqual(Environment.NewLine, reader.NewLine);
@@ -64,7 +64,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void PropertyValuesWithConstructorEncodingName()
         {
-            var reader = new TextReader(stream, "utf-16");
+            var reader = new TextDataReader(stream, "utf-16");
             Assert.AreSame(stream, reader.Stream);
             Assert.AreSame(Encoding.Unicode, reader.Encoding);
             Assert.AreEqual(Environment.NewLine, reader.NewLine);
@@ -75,26 +75,26 @@ namespace Yarhl.UnitTests.IO
         public void CreateWithShiftJisEncoding()
         {
             // It will automatically register the encodings for .NET Core.
-            var reader = new TextReader(stream, "shift-jis");
+            var reader = new TextDataReader(stream, "shift-jis");
             Assert.That(reader.Encoding.CodePage, Is.EqualTo(932));
         }
 
         [Test]
         public void TestConstructorWithNullArguments()
         {
-            Assert.Throws<ArgumentNullException>(() => new TextReader(null));
+            Assert.Throws<ArgumentNullException>(() => new TextDataReader(null));
 
-            Assert.Throws<ArgumentNullException>(() => new TextReader(null, Encoding.ASCII));
-            Assert.Throws<ArgumentNullException>(() => new TextReader(stream, (Encoding)null));
+            Assert.Throws<ArgumentNullException>(() => new TextDataReader(null, Encoding.ASCII));
+            Assert.Throws<ArgumentNullException>(() => new TextDataReader(stream, (Encoding)null));
 
-            Assert.Throws<ArgumentNullException>(() => new TextReader(null, "ascii"));
-            Assert.Throws<ArgumentNullException>(() => new TextReader(stream, (string)null));
+            Assert.Throws<ArgumentNullException>(() => new TextDataReader(null, "ascii"));
+            Assert.Throws<ArgumentNullException>(() => new TextDataReader(stream, (string)null));
         }
 
         [Test]
         public void PropertyActuallyChangesValues()
         {
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             reader.NewLine = "a";
             Assert.AreEqual("a", reader.NewLine);
 
@@ -105,7 +105,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void AutoNewLineIsFalseAfterSettingNewLine()
         {
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             Assert.IsTrue(reader.AutoNewLine);
             reader.NewLine = "a";
             Assert.IsFalse(reader.AutoNewLine);
@@ -118,7 +118,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x30);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             Assert.AreEqual('a', reader.Read());
             Assert.AreEqual(1, stream.Position);
         }
@@ -130,7 +130,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             Assert.AreEqual('a', reader.Read());
             Assert.AreEqual(2, stream.Position);
         }
@@ -144,7 +144,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             Assert.AreEqual('a', reader.Read());
             Assert.AreEqual(4, stream.Position);
         }
@@ -152,7 +152,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadEndOfStreamThrowsException()
         {
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             Assert.Throws<System.IO.EndOfStreamException>(() => reader.Read());
         }
 
@@ -164,7 +164,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             var chars = reader.Read(2);
 
             Assert.AreEqual('1', chars[0]);
@@ -183,7 +183,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             var chars = reader.Read(2);
 
             Assert.AreEqual('1', chars[0]);
@@ -204,7 +204,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             var chars = reader.Read(2);
 
             Assert.AreEqual('1', chars[0]);
@@ -215,7 +215,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadArrayThrowsExceptionIfNegative()
         {
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             Assert.Throws<ArgumentOutOfRangeException>(() => reader.Read(-3));
         }
 
@@ -225,7 +225,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x31);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             Assert.Throws<System.IO.EndOfStreamException>(() => reader.Read(3));
         }
 
@@ -237,7 +237,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             string text = reader.ReadToToken("9");
 
             Assert.AreEqual("1", text);
@@ -251,7 +251,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x39);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             string text = string.Empty;
             Assert.DoesNotThrow(() => text = reader.ReadToToken("5"));
 
@@ -270,7 +270,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             var text = reader.ReadToToken("9");
 
             Assert.AreEqual("1", text);
@@ -290,7 +290,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             var text = reader.ReadToToken("9");
 
             Assert.AreEqual("1", text);
@@ -305,7 +305,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             string text = reader.ReadToToken("5.");
 
             Assert.AreEqual("195", text);
@@ -320,7 +320,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             string text = reader.ReadToToken("95");
 
             Assert.AreEqual("1", text);
@@ -340,7 +340,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             string text = reader.ReadToToken("95");
 
             Assert.AreEqual("1", text);
@@ -350,14 +350,14 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadToTokenWhenEOFReturnsNull()
         {
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             Assert.IsNull(reader.ReadToToken("3"));
         }
 
         [Test]
         public void ReadToNullOrEmptyToken()
         {
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             Assert.That(() => reader.ReadToToken(null), Throws.ArgumentNullException);
             Assert.That(() => reader.ReadToToken(string.Empty), Throws.ArgumentNullException);
         }
@@ -372,7 +372,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x38);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             string text = reader.ReadToToken("5");
 
             Assert.That(text, Is.EqualTo(new string('0', 150)));
@@ -394,7 +394,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0xe5);  // half encoded
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             string text = reader.ReadToToken("a");
 
             Assert.That(text, Is.EqualTo("01"));
@@ -411,7 +411,7 @@ namespace Yarhl.UnitTests.IO
             stream.Write(buffer, 0, buffer.Length);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             string text = reader.ReadToToken("a");
 
             Assert.That(text, Is.EqualTo("\uD801\uDC37"));
@@ -433,7 +433,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x30);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             string text = reader.ReadToToken("\x08");
 
             Assert.That(text, Is.EqualTo(new string('0', 127) + '漢'));
@@ -454,7 +454,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x30);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             string text = reader.ReadToToken("漢");
 
             Assert.That(text, Is.EqualTo(new string('0', 127)));
@@ -470,7 +470,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x31);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             reader.AutoNewLine = false;
             reader.NewLine = "\n";
             var line = reader.ReadLine();
@@ -494,7 +494,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             reader.AutoNewLine = false;
             reader.NewLine = "\n";
             var line = reader.ReadLine();
@@ -518,7 +518,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             reader.AutoNewLine = false;
             reader.NewLine = "\r\n";
             var line = reader.ReadLine();
@@ -540,7 +540,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x30);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             Assert.That(reader.ReadLine(), Is.EqualTo("51"));
             Assert.AreEqual(4, stream.Position);
 
@@ -564,7 +564,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte((byte)'0');
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             reader.NewLine = "<br/>";
             reader.AutoNewLine = false;
 
@@ -582,7 +582,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x39);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             var line = string.Empty;
             Assert.DoesNotThrow(() => line = reader.ReadLine());
             Assert.AreEqual("19", line);
@@ -592,7 +592,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadLineWhenEOFReturnsNull()
         {
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             Assert.IsNull(reader.ReadLine());
 
             reader.AutoNewLine = false;
@@ -606,7 +606,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             var text = reader.ReadToEnd();
 
             Assert.AreEqual("15", text);
@@ -622,7 +622,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             var text = reader.ReadToEnd();
 
             Assert.AreEqual("15", text);
@@ -640,7 +640,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             var text = reader.ReadToEnd();
 
             Assert.AreEqual("15", text);
@@ -654,7 +654,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 1;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             var text = reader.ReadToEnd();
 
             Assert.AreEqual("5", text);
@@ -664,7 +664,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ReadToEndIfEmpty()
         {
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             Assert.AreEqual(string.Empty, reader.ReadToEnd());
         }
 
@@ -675,7 +675,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x42);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             char ch = reader.Peek();
 
             Assert.AreEqual('A', ch);
@@ -689,7 +689,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             Assert.AreEqual('a', reader.Peek());
             Assert.AreEqual(0, stream.Position);
         }
@@ -703,7 +703,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x00);
             stream.Position = 0;
 
-            var reader = new TextReader(stream, Encoding.Unicode);
+            var reader = new TextDataReader(stream, Encoding.Unicode);
             Assert.AreEqual('a', reader.Peek());
             Assert.AreEqual(0, stream.Position);
         }
@@ -711,7 +711,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void PeekEndOfStreamThrowsException()
         {
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             Assert.Throws<System.IO.EndOfStreamException>(() => reader.Peek());
         }
 
@@ -723,7 +723,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             var chars = reader.Peek(2);
 
             Assert.AreEqual('1', chars[0]);
@@ -739,7 +739,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x35);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             string text = reader.PeekToToken("5");
 
             Assert.AreEqual("19", text);
@@ -756,7 +756,7 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0x31);
             stream.Position = 0;
 
-            var reader = new TextReader(stream);
+            var reader = new TextDataReader(stream);
             reader.NewLine = "\r\n";
             var line = reader.PeekLine();
 

--- a/src/Yarhl.UnitTests/IO/TextDataWriterTests.cs
+++ b/src/Yarhl.UnitTests/IO/TextDataWriterTests.cs
@@ -25,7 +25,7 @@ namespace Yarhl.UnitTests.IO
     using Yarhl.IO;
 
     [TestFixture]
-    public class TextWriterTests
+    public class TextDataWriterTests
     {
         DataStream stream;
 
@@ -44,7 +44,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void DefaultPropertyValues()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             Assert.AreSame(stream, writer.Stream);
             Assert.AreSame(Encoding.UTF8, writer.Encoding);
             Assert.IsFalse(writer.AutoPreamble);
@@ -54,21 +54,21 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void ConstructorWithEncoding()
         {
-            var writer = new TextWriter(stream, Encoding.ASCII);
+            var writer = new TextDataWriter(stream, Encoding.ASCII);
             Assert.AreSame(Encoding.ASCII, writer.Encoding);
         }
 
         [Test]
         public void ConstructorWithEncodingName()
         {
-            var writer = new TextWriter(stream, "ascii");
+            var writer = new TextDataWriter(stream, "ascii");
             Assert.AreSame(Encoding.ASCII, writer.Encoding);
         }
 
         [Test]
         public void CreateWithShiftJisEncoding()
         {
-            var writer = new TextWriter(stream, "shift-jis");
+            var writer = new TextDataWriter(stream, "shift-jis");
             Assert.That(writer.Encoding.CodePage, Is.EqualTo(932));
         }
 
@@ -76,23 +76,23 @@ namespace Yarhl.UnitTests.IO
         public void WrongArgsInConstructorThrowsException()
         {
             Assert.Throws<ArgumentNullException>(
-                () => new TextWriter(null));
+                () => new TextDataWriter(null));
 
             Assert.Throws<ArgumentNullException>(
-                () => new TextWriter(null, Encoding.ASCII));
+                () => new TextDataWriter(null, Encoding.ASCII));
             Assert.Throws<ArgumentNullException>(
-                () => new TextWriter(stream, (Encoding)null));
+                () => new TextDataWriter(stream, (Encoding)null));
 
             Assert.Throws<ArgumentNullException>(
-                () => new TextWriter(null, "ascii"));
+                () => new TextDataWriter(null, "ascii"));
             Assert.Throws<ArgumentNullException>(
-                () => new TextWriter(stream, (string)null));
+                () => new TextDataWriter(stream, (string)null));
         }
 
         [Test]
         public void PropertiesChangeValues()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             writer.NewLine = "a";
             Assert.AreEqual("a", writer.NewLine);
 
@@ -103,20 +103,20 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WritePreamble()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.WritePreamble();
             stream.Position = 0;
             Assert.That(stream.ReadByte(), Is.EqualTo(0xFF));
             Assert.That(stream.ReadByte(), Is.EqualTo(0xFE));
 
-            writer = new TextWriter(stream, Encoding.BigEndianUnicode);
+            writer = new TextDataWriter(stream, Encoding.BigEndianUnicode);
             stream.Position = 0;
             writer.WritePreamble();
             stream.Position = 0;
             Assert.That(stream.ReadByte(), Is.EqualTo(0xFE));
             Assert.That(stream.ReadByte(), Is.EqualTo(0xFF));
 
-            writer = new TextWriter(stream, Encoding.UTF8);
+            writer = new TextDataWriter(stream, Encoding.UTF8);
             stream.Position = 0;
             writer.WritePreamble();
             stream.Position = 0;
@@ -124,7 +124,7 @@ namespace Yarhl.UnitTests.IO
             Assert.That(stream.ReadByte(), Is.EqualTo(0xBB));
             Assert.That(stream.ReadByte(), Is.EqualTo(0xBF));
 
-            writer = new TextWriter(stream, Encoding.UTF32);
+            writer = new TextDataWriter(stream, Encoding.UTF32);
             stream.Position = 0;
             writer.WritePreamble();
             stream.Position = 0;
@@ -137,7 +137,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WritePreambleWithEncodingWithoutItDoesNotThrow()
         {
-            var writer = new TextWriter(stream, Encoding.ASCII);
+            var writer = new TextDataWriter(stream, Encoding.ASCII);
             Assert.That(() => writer.WritePreamble(), Throws.Nothing);
             Assert.That(stream.Length, Is.EqualTo(0));
         }
@@ -145,7 +145,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WritePreambleNotStartThrowsException()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             stream.WriteByte(0x00);
 
             Assert.That(
@@ -157,7 +157,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteChar()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             writer.AutoPreamble = false;
             writer.Write('c');
 
@@ -169,7 +169,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteCharWithEncoding()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = false;
             writer.Write('c');
 
@@ -182,7 +182,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteCharWithPreamble()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = true;
             writer.Write('c');
             writer.Write('a');
@@ -200,7 +200,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteCharArray()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             writer.AutoPreamble = false;
             writer.Write(new char[] { 'z', 'w' });
 
@@ -213,7 +213,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteCharArrayWithEncoding()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = false;
             writer.Write(new char[] { 'z', 'w' });
 
@@ -228,7 +228,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteCharArrayWithPreamble()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = true;
             writer.Write(new char[] { 'z', 'w' });
             writer.Write(new char[] { 'a' });
@@ -248,14 +248,14 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteNullCharArrayThrowsException()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             Assert.Throws<ArgumentNullException>(() => writer.Write((char[])null));
         }
 
         [Test]
         public void WriteString()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             writer.AutoPreamble = false;
             writer.Write("he");
 
@@ -268,7 +268,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteStringWithEncoding()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = false;
             writer.Write("he");
 
@@ -283,7 +283,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteStringWithPreamble()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = true;
             writer.Write("he");
             writer.Write("llo");
@@ -307,14 +307,14 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteNullStringThrowsException()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             Assert.Throws<ArgumentNullException>(() => writer.Write((string)null));
         }
 
         [Test]
         public void WriteStringFormat()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             writer.AutoPreamble = false;
             writer.Write("a{0}", 3);
 
@@ -327,7 +327,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteStringFormatEscaping()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             writer.AutoPreamble = false;
             writer.Write("a{{0}}", 3);
 
@@ -342,7 +342,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteStringFormatWithEncoding()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = false;
             writer.Write("a{0}", 3);
 
@@ -357,7 +357,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteStringFormatWithPreamble()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = true;
             writer.Write("a{0}", 3);
             writer.Write("b{0}", 0);
@@ -379,7 +379,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteNullStringFormatThrowsException()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             Assert.Throws<ArgumentNullException>(() => writer.Write(null, "a"));
             Assert.Throws<ArgumentNullException>(() => writer.Write("a", null));
         }
@@ -387,7 +387,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteStringFormatWithLessFormatsThrows()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             Assert.Throws<FormatException>(() => writer.Write("a{0}{1}", 3));
             Assert.Throws<FormatException>(() => writer.Write("a{1}", 3));
             Assert.Throws<FormatException>(() => writer.Write("a{0}", Array.Empty<object>()));
@@ -396,14 +396,14 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteStringFormatWithMoreArgsDoesNotThrow()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             Assert.DoesNotThrow(() => writer.Write("a{0}", 3, 4, 5));
         }
 
         [Test]
         public void WriteLineOnly()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             writer.AutoPreamble = false;
             writer.WriteLine();
 
@@ -415,7 +415,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineOnlyWithEncoding()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = false;
             writer.WriteLine();
 
@@ -428,7 +428,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineOnlyWithPreamble()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = true;
             writer.WriteLine();
             writer.WriteLine();
@@ -446,7 +446,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineOnlyWithNewLine()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             writer.AutoPreamble = false;
             writer.NewLine = "NL";
             writer.WriteLine();
@@ -460,7 +460,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineString()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             writer.AutoPreamble = false;
             writer.WriteLine("za");
 
@@ -474,7 +474,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineStringWithEncoding()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = false;
             writer.WriteLine("a");
 
@@ -489,7 +489,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineStringWithPreamble()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = true;
             writer.WriteLine("a");
             writer.WriteLine("b");
@@ -511,14 +511,14 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineNullStringThrowsException()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             Assert.Throws<ArgumentNullException>(() => writer.WriteLine(null));
         }
 
         [Test]
         public void WriteLineStringFormat()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             writer.AutoPreamble = false;
             writer.WriteLine("a{0}", 3);
 
@@ -532,7 +532,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineStringFormatEscaping()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             writer.AutoPreamble = false;
             writer.WriteLine("a{{0}}", 3);
 
@@ -548,7 +548,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineStringFormatWithEncoding()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = false;
             writer.WriteLine("a{0}", 3);
 
@@ -565,7 +565,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineStringFormatWithPreamble()
         {
-            var writer = new TextWriter(stream, Encoding.Unicode);
+            var writer = new TextDataWriter(stream, Encoding.Unicode);
             writer.AutoPreamble = true;
             writer.WriteLine("a{0}", 3);
             writer.WriteLine("b{0}", 0);
@@ -591,7 +591,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineNullStringFormatThrowsException()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             Assert.Throws<ArgumentNullException>(() => writer.WriteLine(null, "a"));
             Assert.Throws<ArgumentNullException>(() => writer.WriteLine("a", null));
         }
@@ -599,7 +599,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineStringFormatWithLessFormatsThrows()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             Assert.Throws<FormatException>(() => writer.WriteLine("a{0}{1}", 3));
             Assert.Throws<FormatException>(() => writer.WriteLine("a{1}", 3));
             Assert.Throws<FormatException>(() => writer.WriteLine("a{0}", Array.Empty<object>()));
@@ -608,7 +608,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void WriteLineStringFormatWithMoreArgsDoesNotThrow()
         {
-            var writer = new TextWriter(stream);
+            var writer = new TextDataWriter(stream);
             Assert.DoesNotThrow(() => writer.WriteLine("a{0}", 3, 4, 5));
         }
     }

--- a/src/Yarhl.UnitTests/Media/Text/Po2BinaryTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/Po2BinaryTests.cs
@@ -473,14 +473,14 @@ msgstr """"
         static void CompareText(BinaryFormat binary, string expected)
         {
             binary.Stream.Position = 0;
-            TextReader reader = new TextReader(binary.Stream);
+            TextDataReader reader = new TextDataReader(binary.Stream);
             Assert.AreEqual(expected, reader.ReadToEnd());
         }
 
         static Po ConvertStringToPo(string binary)
         {
             using BinaryFormat textFormat = new BinaryFormat();
-            new TextWriter(textFormat.Stream).Write(binary);
+            new TextDataWriter(textFormat.Stream).Write(binary);
             textFormat.Stream.Position = 0;
 
             return ConvertFormat.To<Po>(textFormat);

--- a/src/Yarhl/IO/TextDataReader.cs
+++ b/src/Yarhl/IO/TextDataReader.cs
@@ -26,14 +26,14 @@ namespace Yarhl.IO
     using System.Text;
 
     /// <summary>
-    /// Text reader for <see cref="DataStream" />.
+    /// Text reader for <see cref="Stream" />.
     /// </summary>
-    public class TextReader
+    public class TextDataReader
     {
         readonly DataReader reader;
         string newLine;
 
-        static TextReader()
+        static TextDataReader()
         {
             // Make sure that the shift-jis encoding is initialized in
             // .NET Core.
@@ -41,31 +41,31 @@ namespace Yarhl.IO
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TextReader"/> class.
+        /// Initializes a new instance of the <see cref="TextDataReader"/> class.
         /// </summary>
         /// <param name="stream">Stream to read from.</param>
         /// <remarks><para>The default encoding is UTF-8.</para></remarks>
-        public TextReader(Stream stream)
+        public TextDataReader(Stream stream)
             : this(stream, Encoding.UTF8)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TextReader"/> class.
+        /// Initializes a new instance of the <see cref="TextDataReader"/> class.
         /// </summary>
         /// <param name="stream">Stream to read from.</param>
         /// <param name="encoding">Encoding to use.</param>
-        public TextReader(Stream stream, string encoding)
+        public TextDataReader(Stream stream, string encoding)
             : this(stream, Encoding.GetEncoding(encoding))
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TextReader"/> class.
+        /// Initializes a new instance of the <see cref="TextDataReader"/> class.
         /// </summary>
         /// <param name="stream">Stream to read from.</param>
         /// <param name="encoding">Encoding to use.</param>
-        public TextReader(Stream stream, Encoding encoding)
+        public TextDataReader(Stream stream, Encoding encoding)
         {
             Stream = stream ?? throw new ArgumentNullException(nameof(stream));
             Encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));

--- a/src/Yarhl/IO/TextDataWriter.cs
+++ b/src/Yarhl/IO/TextDataWriter.cs
@@ -25,13 +25,13 @@ namespace Yarhl.IO
     using System.Text;
 
     /// <summary>
-    /// Text writer for <see cref="DataStream" />.
+    /// Text writer for <see cref="Stream" />.
     /// </summary>
-    public class TextWriter
+    public class TextDataWriter
     {
         readonly DataWriter writer;
 
-        static TextWriter()
+        static TextDataWriter()
         {
             // Make sure that the shift-jis encoding is initialized in
             // .NET Core.
@@ -39,31 +39,31 @@ namespace Yarhl.IO
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TextWriter"/> class.
+        /// Initializes a new instance of the <see cref="TextDataWriter"/> class.
         /// </summary>
         /// <param name="stream">Stream to write to.</param>
         /// <remarks><para>The default encoding is UTF-8.</para></remarks>
-        public TextWriter(Stream stream)
+        public TextDataWriter(Stream stream)
             : this(stream, Encoding.UTF8)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TextWriter"/> class.
+        /// Initializes a new instance of the <see cref="TextDataWriter"/> class.
         /// </summary>
         /// <param name="stream">Stream to read from.</param>
         /// <param name="encoding">Encoding to use.</param>
-        public TextWriter(Stream stream, string encoding)
+        public TextDataWriter(Stream stream, string encoding)
             : this(stream, Encoding.GetEncoding(encoding))
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TextWriter"/> class.
+        /// Initializes a new instance of the <see cref="TextDataWriter"/> class.
         /// </summary>
         /// <param name="stream">Stream to write to.</param>
         /// <param name="encoding">Encoding to use.</param>
-        public TextWriter(Stream stream, Encoding encoding)
+        public TextDataWriter(Stream stream, Encoding encoding)
         {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));


### PR DESCRIPTION
### Description

Rename `TextReader` and `TextWriter` to `TextDataReader` and `TextDataWriter`. This avoids name conflict with System.IO classes. Especially after the goal to be compatible with `System.IO` (#158).