### PR TITLE
Stream overloads in BinaryFormat and NodeFactory and fix threading issue

### DIFF
--- a/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
@@ -53,6 +53,19 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void CreateFromStreamWithDataStreamReuseIStream()
+        {
+            using var stream = new MemoryStream();
+            var dataStream1 = DataStreamFactory.FromStream(stream);
+            var dataStream2 = DataStreamFactory.FromStream(dataStream1);
+
+            Assert.That(dataStream1.BaseStream, Is.SameAs(dataStream2.BaseStream));
+
+            // Especially important check for thread-safety
+            Assert.That(dataStream1.BaseStream.LockObj, Is.SameAs(dataStream2.BaseStream.LockObj));
+        }
+
+        [Test]
         public void CreateFromStreamThrowIfInvalidArgument()
         {
             Assert.That(
@@ -105,6 +118,20 @@ namespace Yarhl.UnitTests.IO
 
             dataStream.Dispose();
             Assert.That(() => stream.ReadByte(), Throws.InstanceOf<ObjectDisposedException>());
+        }
+
+        [Test]
+        public void CreateFromSubStreamWithDataStreamReuseIStream()
+        {
+            using var stream = new MemoryStream();
+            stream.Write(new byte[] { 1, 2, 3, 4 }, 0, 4);
+            var dataStream1 = DataStreamFactory.FromStream(stream, 1, 2);
+            var dataStream2 = DataStreamFactory.FromStream(dataStream1, 1, 1);
+
+            Assert.That(dataStream1.BaseStream, Is.SameAs(dataStream2.BaseStream));
+
+            // Especially important check for thread-safety
+            Assert.That(dataStream1.BaseStream.LockObj, Is.SameAs(dataStream2.BaseStream.LockObj));
         }
 
         [Test]
@@ -166,6 +193,20 @@ namespace Yarhl.UnitTests.IO
             dataStream.Dispose();
             Assert.That(() => stream.ReadByte(), Throws.Nothing);
             stream.Dispose();
+        }
+
+        [Test]
+        public void CreateFromSubStreamKeepingOwnershipWithDataStreamReuseIStream()
+        {
+            using var stream = new MemoryStream();
+            stream.Write(new byte[] { 1, 2, 3, 4 }, 0, 4);
+            var dataStream1 = DataStreamFactory.FromStreamKeepingOwnership(stream, 1, 2);
+            var dataStream2 = DataStreamFactory.FromStreamKeepingOwnership(dataStream1, 1, 1);
+
+            Assert.That(dataStream1.BaseStream, Is.SameAs(dataStream2.BaseStream));
+
+            // Especially important check for thread-safety
+            Assert.That(dataStream1.BaseStream.LockObj, Is.SameAs(dataStream2.BaseStream.LockObj));
         }
 
         [Test]

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -105,6 +105,13 @@ namespace Yarhl.FileSystem
         /// The offset in the source stream where the node starts.
         /// </param>
         /// <param name="length">The length of the data in the node.</param>
+        /// <remarks>
+        /// <para>This format creates an internal <see cref="DataStream" /> from the
+        /// provided stream. It will take over the ownership of the stream
+        /// argument, you should not dispose this argument, unless you are
+        /// providing a <see cref="DataStream" /> in which case it is safe and
+        /// recommended to dispose it.</para>
+        /// </remarks>
         /// <returns>The new node.</returns>
         [SuppressMessage(
             "Reliability",
@@ -112,7 +119,7 @@ namespace Yarhl.FileSystem
             Justification = "Ownserhip dispose transferred")]
         public static Node FromSubstream(
             string name,
-            DataStream source,
+            Stream source,
             long offset,
             long length)
         {

--- a/src/Yarhl/IO/BinaryFormat.cs
+++ b/src/Yarhl/IO/BinaryFormat.cs
@@ -20,6 +20,7 @@
 namespace Yarhl.IO
 {
     using System;
+    using System.IO;
 
     /// <summary>
     /// Binary format.
@@ -38,28 +39,32 @@ namespace Yarhl.IO
         /// <summary>
         /// Initializes a new instance of the <see cref="BinaryFormat"/> class.
         /// </summary>
-        /// <remarks>
-        /// <para>This format creates a substream from the provided stream.</para>
-        /// </remarks>
-        /// <param name="stream">Binary stream.</param>
-        public BinaryFormat(DataStream stream)
+        /// <param name="stream">
+        /// Stream to wrap as a format. It takes over the ownership of the stream.
+        /// You must not dispose it.
+        /// </param>
+        public BinaryFormat(Stream stream)
         {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
 
-            Stream = stream;
+            Stream = stream as DataStream ?? DataStreamFactory.FromStream(stream);
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BinaryFormat"/> class.
         /// </summary>
         /// <remarks>
-        /// <para>This format creates a substream from the provided stream.</para>
+        /// <para>This format creates an internal <see cref="DataStream" /> from the
+        /// provided stream. It will take over the ownership of the stream
+        /// argument, you should not dispose this argument, unless you are
+        /// providing a <see cref="DataStream" /> in which case it is safe and
+        /// recommended to dispose it.</para>
         /// </remarks>
         /// <param name="stream">Binary stream.</param>
         /// <param name="offset">Offset from the DataStream start.</param>
         /// <param name="length">Length of the substream.</param>
-        public BinaryFormat(DataStream stream, long offset, long length)
+        public BinaryFormat(Stream stream, long offset, long length)
         {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
@@ -68,7 +73,7 @@ namespace Yarhl.IO
             if (length < 0 || offset + length > stream.Length)
                 throw new ArgumentOutOfRangeException(nameof(length));
 
-            Stream = new DataStream(stream, offset, length);
+            Stream = DataStreamFactory.FromStream(stream, offset, length);
         }
 
         /// <summary>

--- a/src/Yarhl/IO/DataStreamFactory.cs
+++ b/src/Yarhl/IO/DataStreamFactory.cs
@@ -32,11 +32,19 @@ namespace Yarhl.IO
         /// Creates a new <see cref="DataStream"/> from a <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The stream to use as a base.</param>
+        /// <remarks>
+        /// <p>The dispose ownership is transferred to the new DataStream.</p>
+        /// </remarks>
         /// <returns>A new <see cref="DataStream"/>.</returns>
         public static DataStream FromStream(Stream stream)
         {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
+
+            // Required check so we lock in the same base stream lock.
+            if (stream is DataStream dataStream) {
+                return new DataStream(dataStream, 0, dataStream.Length);
+            }
 
             var baseStream = new StreamWrapper(stream);
             return new DataStream(baseStream);
@@ -67,6 +75,11 @@ namespace Yarhl.IO
             if (length < 0 || offset + length > stream.Length)
                 throw new ArgumentOutOfRangeException(nameof(length));
 
+            // Required check so we lock in the same base stream lock.
+            if (stream is DataStream dataStream) {
+                return new DataStream(dataStream, offset, length);
+            }
+
             var baseStream = new StreamWrapper(stream);
             return new DataStream(baseStream, offset, length, true);
         }
@@ -92,6 +105,11 @@ namespace Yarhl.IO
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (length < 0 || offset + length > stream.Length)
                 throw new ArgumentOutOfRangeException(nameof(length));
+
+            // Required check so we lock in the same base stream lock.
+            if (stream is DataStream dataStream) {
+                return new DataStream(dataStream, offset, length);
+            }
 
             var baseStream = new StreamWrapper(stream);
             return new DataStream(baseStream, offset, length, false);


### PR DESCRIPTION
### Description

Add a signature support in the constructor of `BinaryFormat` and in the `NodeFactory`, so migration and compatibility with other frameworks is better.

Also fix a potential threading issue as we were creating another `StreamWrapper` when passing `DataStream` as a regular `Stream`, so the locker object was different.

### Example

Now you can use regular `Stream` to create a `BinaryFormat` and a `Node`.

Related issue #158
+semver: minor