### PR TITLE
Advanced filter in FromDirectory

### DIFF
--- a/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
@@ -302,6 +302,29 @@ namespace Yarhl.UnitTests.FileSystem
         public void CreateFromNullDirectory()
         {
             Assert.Throws<ArgumentNullException>(() => NodeFactory.FromDirectory(null));
+
+            Assert.Throws<ArgumentNullException>(() => NodeFactory.FromDirectory(string.Empty));
+
+            Assert.Throws<ArgumentNullException>(() => NodeFactory.FromDirectory(null, "*", "name"));
+
+            Assert.Throws<ArgumentNullException>(() => NodeFactory.FromDirectory(string.Empty, "*", "name"));
+        }
+
+        [Test]
+        public void CreateFromDirectoryAndNullFilter()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDir);
+
+            Assert.Throws<ArgumentNullException>(() => NodeFactory.FromDirectory(tempDir, (string)null));
+
+            Assert.Throws<ArgumentNullException>(() => NodeFactory.FromDirectory(tempDir, string.Empty));
+
+            Assert.Throws<ArgumentNullException>(() => NodeFactory.FromDirectory(tempDir, (string)null, "name"));
+
+            Assert.Throws<ArgumentNullException>(() => NodeFactory.FromDirectory(tempDir, string.Empty, "name"));
+
+            Directory.Delete(tempDir, true);
         }
 
         [Test]
@@ -656,6 +679,18 @@ namespace Yarhl.UnitTests.FileSystem
         }
 
         [Test]
+        public void CreateFromDirectoryAdvancedFilterAndEmptyFilter()
+        {
+            Assert.That(
+                () => NodeFactory.FromDirectory("dir", (Func<string, bool>)null),
+                Throws.ArgumentNullException);
+
+            Assert.That(
+                () => NodeFactory.FromDirectory("dir", (Func<string, bool>)null, "name"),
+                Throws.ArgumentNullException);
+        }
+
+        [Test]
         public void CreateFromDirectoryAdvancedFilterAndEmptyName()
         {
             Assert.That(
@@ -680,8 +715,15 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.IsTrue(node.IsContainer);
             Assert.AreEqual(1, node.Children.Count);
             Assert.IsTrue(node.Children.Any(n => n.Name == Path.GetFileName(tempFile1)));
-
             node.Dispose();
+
+            node = NodeFactory.FromDirectory(tempDir + Path.DirectorySeparatorChar, _ => true, "name");
+            Assert.AreEqual("name", node.Name);
+            Assert.IsTrue(node.IsContainer);
+            Assert.AreEqual(1, node.Children.Count);
+            Assert.IsTrue(node.Children.Any(n => n.Name == Path.GetFileName(tempFile1)));
+            node.Dispose();
+
             Directory.Delete(tempDir, true);
         }
 

--- a/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
@@ -647,6 +647,23 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.That(
                 () => NodeFactory.FromDirectory(string.Empty, _ => true),
                 Throws.ArgumentNullException);
+            Assert.That(
+                () => NodeFactory.FromDirectory(null, _ => true, "name"),
+                Throws.ArgumentNullException);
+            Assert.That(
+                () => NodeFactory.FromDirectory(string.Empty, _ => true, "name"),
+                Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void CreateFromDirectoryAdvancedFilterAndEmptyName()
+        {
+            Assert.That(
+                () => NodeFactory.FromDirectory("dir", _ => true, null),
+                Throws.ArgumentNullException);
+            Assert.That(
+                () => NodeFactory.FromDirectory("dir", _ => true, string.Empty),
+                Throws.ArgumentNullException);
         }
 
         [Test]

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -276,6 +276,12 @@ namespace Yarhl.FileSystem
             bool subDirectories = false,
             FileOpenMode mode = FileOpenMode.ReadWrite)
         {
+            if (string.IsNullOrEmpty(dirPath))
+                throw new ArgumentNullException(nameof(dirPath));
+
+            if (string.IsNullOrEmpty(nodeName))
+                throw new ArgumentNullException(nameof(nodeName));
+
             SearchOption options = subDirectories ?
                 SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
 

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -247,8 +247,12 @@ namespace Yarhl.FileSystem
             if (string.IsNullOrEmpty(dirPath))
                 throw new ArgumentNullException(nameof(dirPath));
 
-            if (dirPath[dirPath.Length - 1] == Path.DirectorySeparatorChar)
+            if (filter == null)
+                throw new ArgumentNullException(nameof(filter));
+
+            if (dirPath[dirPath.Length - 1] == Path.DirectorySeparatorChar) {
                 dirPath = dirPath.Remove(dirPath.Length - 1);
+            }
 
             string dirName = Path.GetFileName(dirPath);
             return FromDirectory(dirPath, filter, dirName, false, mode);
@@ -278,6 +282,9 @@ namespace Yarhl.FileSystem
         {
             if (string.IsNullOrEmpty(dirPath))
                 throw new ArgumentNullException(nameof(dirPath));
+
+            if (filter == null)
+                throw new ArgumentNullException(nameof(filter));
 
             if (string.IsNullOrEmpty(nodeName))
                 throw new ArgumentNullException(nameof(nodeName));

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -323,8 +323,9 @@ namespace Yarhl.FileSystem
             }
 
             foreach (Node node in Navigator.IterateNodes(folder)) {
-                if (!node.IsContainer || node.Tags.ContainsKey("DirectoryInfo"))
+                if (!node.IsContainer || node.Tags.ContainsKey("DirectoryInfo")) {
                     continue;
+                }
 
                 int rootPathLength = $"{NodeSystem.PathSeparator}{nodeName}".Length;
                 string nodePath = Path.GetFullPath(string.Concat(dirPath, node.Path.Substring(rootPathLength)));

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -187,8 +187,12 @@ namespace Yarhl.FileSystem
             if (string.IsNullOrEmpty(dirPath))
                 throw new ArgumentNullException(nameof(dirPath));
 
-            if (dirPath[dirPath.Length - 1] == Path.DirectorySeparatorChar)
+            // This sanitizes the path and remove double slashes
+            dirPath = Path.GetFullPath(dirPath);
+
+            if (dirPath[dirPath.Length - 1] == Path.DirectorySeparatorChar) {
                 dirPath = dirPath.Remove(dirPath.Length - 1);
+            }
 
             string dirName = Path.GetFileName(dirPath);
             return FromDirectory(dirPath, filter, dirName, false, mode);
@@ -250,6 +254,9 @@ namespace Yarhl.FileSystem
             if (filter == null)
                 throw new ArgumentNullException(nameof(filter));
 
+            // This sanitizes the path and remove double slashes
+            dirPath = Path.GetFullPath(dirPath);
+
             if (dirPath[dirPath.Length - 1] == Path.DirectorySeparatorChar) {
                 dirPath = dirPath.Remove(dirPath.Length - 1);
             }
@@ -294,6 +301,10 @@ namespace Yarhl.FileSystem
 
             // This sanitizes the path and remove double slashes
             dirPath = Path.GetFullPath(dirPath);
+
+            if (dirPath[dirPath.Length - 1] == Path.DirectorySeparatorChar) {
+                dirPath = dirPath.Remove(dirPath.Length - 1);
+            }
 
             string[] allFiles = Directory.GetFiles(dirPath, "*", options);
             string[] fileList = Array.FindAll(allFiles, x => filter(x));


### PR DESCRIPTION
### Description

This PR allows using a `Func` to define the filter in `NodeFactory.FromDirectory` methods.

This way, the users can define more precisely the files to add to the container.

On the other side, this method will be slower than wildcard filters because it first enumerates all files and, later, filters them.

### Example

Get files using a regular expression:

```csharp
Node node = NodeFactory.FromDirectory(tempDir, x => Regex.IsMatch(x, @"file\d\.(txt|bin)$"));
```
