### PR TITLE
Implement ICloneableFormat

### DIFF
--- a/src/Yarhl.Media/Text/Po.cs
+++ b/src/Yarhl.Media/Text/Po.cs
@@ -27,7 +27,7 @@ namespace Yarhl.Media.Text
     /// <summary>
     /// Portable Object format for translations.
     /// </summary>
-    public class Po : IFormat
+    public class Po : IFormat, ICloneable
     {
         readonly IList<PoEntry> entries;
         readonly ReadOnlyCollection<PoEntry> readonlyEntries;
@@ -132,6 +132,22 @@ namespace Yarhl.Media.Text
 
             string key = GetKey(original, context);
             return searchEntries.ContainsKey(key) ? searchEntries[key] : null;
+        }
+
+        /// <inheritdoc />
+        public object Clone()
+        {
+            Po clone = new Po();
+            if (header != null) {
+                clone.header = (PoHeader)header.Clone();
+            }
+
+            foreach (PoEntry entry in entries)
+            {
+                clone.Add((PoEntry)entry.Clone());
+            }
+
+            return clone;
         }
 
         static string GetKey(PoEntry entry)

--- a/src/Yarhl.Media/Text/Po.cs
+++ b/src/Yarhl.Media/Text/Po.cs
@@ -27,7 +27,7 @@ namespace Yarhl.Media.Text
     /// <summary>
     /// Portable Object format for translations.
     /// </summary>
-    public class Po : IFormat, ICloneable
+    public class Po : ICloneableFormat
     {
         readonly IList<PoEntry> entries;
         readonly ReadOnlyCollection<PoEntry> readonlyEntries;
@@ -135,16 +135,16 @@ namespace Yarhl.Media.Text
         }
 
         /// <inheritdoc />
-        public object Clone()
+        public virtual object DeepClone()
         {
             Po clone = new Po();
             if (header != null) {
-                clone.header = (PoHeader)header.Clone();
+                clone.header = new PoHeader(header);
             }
 
             foreach (PoEntry entry in entries)
             {
-                clone.Add((PoEntry)entry.Clone());
+                clone.Add(new PoEntry(entry));
             }
 
             return clone;

--- a/src/Yarhl.Media/Text/PoEntry.cs
+++ b/src/Yarhl.Media/Text/PoEntry.cs
@@ -19,10 +19,12 @@
 // SOFTWARE.
 namespace Yarhl.Media.Text
 {
+    using System;
+
     /// <summary>
     /// Entry in PO formats. Represents a translation unit.
     /// </summary>
-    public class PoEntry
+    public class PoEntry : ICloneable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PoEntry"/> class.
@@ -115,5 +117,8 @@ namespace Yarhl.Media.Text
         /// </summary>
         /// <value>The previous original content.</value>
         public string PreviousOriginal { get; set; }
+
+        /// <inheritdoc />
+        public object Clone() => this.MemberwiseClone();
     }
 }

--- a/src/Yarhl.Media/Text/PoEntry.cs
+++ b/src/Yarhl.Media/Text/PoEntry.cs
@@ -24,7 +24,7 @@ namespace Yarhl.Media.Text
     /// <summary>
     /// Entry in PO formats. Represents a translation unit.
     /// </summary>
-    public class PoEntry : ICloneable
+    public class PoEntry
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PoEntry"/> class.
@@ -43,6 +43,26 @@ namespace Yarhl.Media.Text
         {
             Original = original;
             Translated = string.Empty;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PoEntry"/> class.
+        /// </summary>
+        /// <param name="entry">The entry to copy.</param>
+        public PoEntry(PoEntry entry)
+        {
+            if (entry == null)
+                throw new ArgumentNullException(nameof(entry));
+
+            Original = entry.Original;
+            Translated = entry.Translated;
+            Context = entry.Context;
+            TranslatorComment = entry.TranslatorComment;
+            ExtractedComments = entry.ExtractedComments;
+            Reference = entry.Reference;
+            Flags = entry.Flags;
+            PreviousContext = entry.PreviousContext;
+            PreviousOriginal = entry.PreviousOriginal;
         }
 
         /// <summary>
@@ -117,8 +137,5 @@ namespace Yarhl.Media.Text
         /// </summary>
         /// <value>The previous original content.</value>
         public string PreviousOriginal { get; set; }
-
-        /// <inheritdoc />
-        public object Clone() => this.MemberwiseClone();
     }
 }

--- a/src/Yarhl.Media/Text/PoHeader.cs
+++ b/src/Yarhl.Media/Text/PoHeader.cs
@@ -25,7 +25,7 @@ namespace Yarhl.Media.Text
     /// <summary>
     /// Header for PO translation format.
     /// </summary>
-    public class PoHeader : ICloneable
+    public class PoHeader
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PoHeader"/> class.
@@ -48,6 +48,30 @@ namespace Yarhl.Media.Text
             ReportMsgidBugsTo = reporter;
             Language = lang;
             CreationDate = DateTime.Now.ToShortDateString();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PoHeader"/> class.
+        /// </summary>
+        /// <param name="header">The header to copy.</param>
+        public PoHeader(PoHeader header)
+            : this()
+        {
+            if (header == null)
+                throw new ArgumentNullException(nameof(header));
+
+            ProjectIdVersion = header.ProjectIdVersion;
+            ReportMsgidBugsTo = header.ReportMsgidBugsTo;
+            Language = header.Language;
+            CreationDate = header.CreationDate;
+            RevisionDate = header.RevisionDate;
+            LastTranslator = header.LastTranslator;
+            LanguageTeam = header.LanguageTeam;
+            PluralForms = header.PluralForms;
+            foreach (KeyValuePair<string, string> extension in header.Extensions)
+            {
+                Extensions[extension.Key] = extension.Value;
+            }
         }
 
         /// <summary>
@@ -121,18 +145,5 @@ namespace Yarhl.Media.Text
         /// </summary>
         /// <value>The dictionary for the metadata.</value>
         public IDictionary<string, string> Extensions { get; private set; }
-
-        /// <inheritdoc />
-        public object Clone()
-        {
-            PoHeader clone = (PoHeader)this.MemberwiseClone();
-            clone.Extensions = new Dictionary<string, string>();
-            foreach (KeyValuePair<string, string> extension in Extensions)
-            {
-                clone.Extensions[extension.Key] = extension.Value;
-            }
-
-            return clone;
-        }
     }
 }

--- a/src/Yarhl.Media/Text/PoHeader.cs
+++ b/src/Yarhl.Media/Text/PoHeader.cs
@@ -25,7 +25,7 @@ namespace Yarhl.Media.Text
     /// <summary>
     /// Header for PO translation format.
     /// </summary>
-    public class PoHeader
+    public class PoHeader : ICloneable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PoHeader"/> class.
@@ -121,5 +121,18 @@ namespace Yarhl.Media.Text
         /// </summary>
         /// <value>The dictionary for the metadata.</value>
         public IDictionary<string, string> Extensions { get; private set; }
+
+        /// <inheritdoc />
+        public object Clone()
+        {
+            PoHeader clone = (PoHeader)this.MemberwiseClone();
+            clone.Extensions = new Dictionary<string, string>();
+            foreach (KeyValuePair<string, string> extension in Extensions)
+            {
+                clone.Extensions[extension.Key] = extension.Value;
+            }
+
+            return clone;
+        }
     }
 }

--- a/src/Yarhl.UnitTests/FileSystem/NodeContainerFormatTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeContainerFormatTests.cs
@@ -196,7 +196,7 @@ namespace Yarhl.UnitTests.FileSystem
             format.Root.Add(child2);
             child1.Add(grandchild);
 
-            using NodeContainerFormat clone = (NodeContainerFormat)format.Clone();
+            using NodeContainerFormat clone = (NodeContainerFormat)format.DeepClone();
 
             Node child1Clone = clone.Root.Children["child1"];
             Node child2Clone = clone.Root.Children["child2"];

--- a/src/Yarhl.UnitTests/FileSystem/NodeContainerFormatTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeContainerFormatTests.cs
@@ -183,6 +183,31 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.That(folder3.Children.Count, Is.Zero);
         }
 
+        [Test]
+        public void Clone()
+        {
+            using NodeContainerFormat format = new NodeContainerFormat();
+
+            using Node child1 = NodeFactory.CreateContainer("child1");
+            using Node child2 = new Node("child2");
+            using Node grandchild = new Node("grandchild");
+
+            format.Root.Add(child1);
+            format.Root.Add(child2);
+            child1.Add(grandchild);
+
+            using NodeContainerFormat clone = (NodeContainerFormat)format.Clone();
+
+            Node child1Clone = clone.Root.Children["child1"];
+            Node child2Clone = clone.Root.Children["child2"];
+            Node grandchildClone = child1Clone.Children["grandchild"];
+
+            Assert.AreNotSame(format, clone);
+            Assert.AreNotSame(child1, child1Clone);
+            Assert.AreNotSame(child2, child2Clone);
+            Assert.AreNotSame(grandchild, grandchildClone);
+        }
+
         protected override NodeContainerFormat CreateDummyFormat()
         {
             return new NodeContainerFormat();

--- a/src/Yarhl.UnitTests/FileSystem/NodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeTests.cs
@@ -668,10 +668,16 @@ namespace Yarhl.UnitTests.FileSystem
         }
 
         [Test]
+        public void CloneNullNodeThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _ = new Node((Node)null));
+        }
+
+        [Test]
         public void NotCloneableFormatThrowsException()
         {
             using Node node = new Node("test", new StringFormatTest("3"));
-            Assert.Throws<InvalidOperationException>(() => _ = node.Clone());
+            Assert.Throws<InvalidOperationException>(() => _ = new Node(node));
         }
 
         [Test]
@@ -680,7 +686,7 @@ namespace Yarhl.UnitTests.FileSystem
             using Node node = NodeFactory.FromMemory("test");
             node.Tags["TestTag"] = 23;
 
-            using Node clone = (Node)node.Clone();
+            using Node clone = new Node(node);
 
             Assert.AreNotSame(node, clone);
             Assert.AreEqual(1, clone.Tags.Count);
@@ -691,7 +697,7 @@ namespace Yarhl.UnitTests.FileSystem
         public void CloneNullFormatNode()
         {
             using Node node = new Node("test");
-            using Node clone = (Node)node.Clone();
+            using Node clone = new Node(node);
 
             Assert.AreNotSame(node, clone);
             Assert.IsNull(clone.Format);

--- a/src/Yarhl.UnitTests/FileSystem/NodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeTests.cs
@@ -667,6 +667,36 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.DoesNotThrow(node.Dispose);
         }
 
+        [Test]
+        public void NotCloneableFormatThrowsException()
+        {
+            using Node node = new Node("test", new StringFormatTest("3"));
+            Assert.Throws<InvalidOperationException>(() => _ = node.Clone());
+        }
+
+        [Test]
+        public void CloneNodeHasTags()
+        {
+            using Node node = NodeFactory.FromMemory("test");
+            node.Tags["TestTag"] = 23;
+
+            using Node clone = (Node)node.Clone();
+
+            Assert.AreNotSame(node, clone);
+            Assert.AreEqual(1, clone.Tags.Count);
+            Assert.AreEqual(23, clone.Tags["TestTag"]);
+        }
+
+        [Test]
+        public void CloneNullFormatNode()
+        {
+            using Node node = new Node("test");
+            using Node clone = (Node)node.Clone();
+
+            Assert.AreNotSame(node, clone);
+            Assert.IsNull(clone.Format);
+        }
+
         [PartNotDiscoverable]
         public class PrivateConverter :
             IConverter<StringFormatTest, IntFormatTest>,

--- a/src/Yarhl.UnitTests/IO/BinaryFormatTests.cs
+++ b/src/Yarhl.UnitTests/IO/BinaryFormatTests.cs
@@ -187,7 +187,7 @@ namespace Yarhl.UnitTests.IO
             using DataStream stream = DataStreamFactory.FromArray(data, 0, data.Length);
             using BinaryFormat format = new BinaryFormat(stream);
 
-            using BinaryFormat clone = (BinaryFormat)format.Clone();
+            using BinaryFormat clone = (BinaryFormat)format.DeepClone();
 
             Assert.AreNotSame(format, clone);
             Assert.IsTrue(format.Stream.Compare(clone.Stream));

--- a/src/Yarhl.UnitTests/IO/BinaryFormatTests.cs
+++ b/src/Yarhl.UnitTests/IO/BinaryFormatTests.cs
@@ -180,6 +180,19 @@ namespace Yarhl.UnitTests.IO
             format.Dispose();
         }
 
+        [Test]
+        public void Clone()
+        {
+            byte[] data = { 0x01, 0x02, 0x03 };
+            using DataStream stream = DataStreamFactory.FromArray(data, 0, data.Length);
+            using BinaryFormat format = new BinaryFormat(stream);
+
+            using BinaryFormat clone = (BinaryFormat)format.Clone();
+
+            Assert.AreNotSame(format, clone);
+            Assert.IsTrue(format.Stream.Compare(clone.Stream));
+        }
+
         protected override BinaryFormat CreateDummyFormat()
         {
             using DataStream stream = new DataStream();

--- a/src/Yarhl.UnitTests/Media/Text/PoEntryTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/PoEntryTests.cs
@@ -19,6 +19,7 @@
 // SOFTWARE.
 namespace Yarhl.UnitTests.Media.Text
 {
+    using System;
     using NUnit.Framework;
     using Yarhl.Media.Text;
 
@@ -83,6 +84,12 @@ namespace Yarhl.UnitTests.Media.Text
         }
 
         [Test]
+        public void CloneNullThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _ = new PoEntry((PoEntry)null));
+        }
+
+        [Test]
         public void Clone()
         {
             PoEntry entry = new PoEntry {
@@ -97,7 +104,7 @@ namespace Yarhl.UnitTests.Media.Text
                 PreviousOriginal = "test8",
             };
 
-            PoEntry clone = (PoEntry)entry.Clone();
+            PoEntry clone = new PoEntry(entry);
 
             Assert.AreNotSame(entry, clone);
             Assert.AreEqual("test0", clone.Original);

--- a/src/Yarhl.UnitTests/Media/Text/PoEntryTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/PoEntryTests.cs
@@ -81,5 +81,34 @@ namespace Yarhl.UnitTests.Media.Text
             entry.Translated = "translated";
             Assert.That(entry.Text, Is.EqualTo(entry.Translated));
         }
+
+        [Test]
+        public void Clone()
+        {
+            PoEntry entry = new PoEntry {
+                Original = "test0",
+                Translated = "test1",
+                Context = "test2",
+                TranslatorComment = "test3",
+                ExtractedComments = "test4",
+                Reference = "test5",
+                Flags = "test6",
+                PreviousContext = "test7",
+                PreviousOriginal = "test8",
+            };
+
+            PoEntry clone = (PoEntry)entry.Clone();
+
+            Assert.AreNotSame(entry, clone);
+            Assert.AreEqual("test0", clone.Original);
+            Assert.AreEqual("test1", clone.Translated);
+            Assert.AreEqual("test2", clone.Context);
+            Assert.AreEqual("test3", clone.TranslatorComment);
+            Assert.AreEqual("test4", clone.ExtractedComments);
+            Assert.AreEqual("test5", clone.Reference);
+            Assert.AreEqual("test6", clone.Flags);
+            Assert.AreEqual("test7", clone.PreviousContext);
+            Assert.AreEqual("test8", clone.PreviousOriginal);
+        }
     }
 }

--- a/src/Yarhl.UnitTests/Media/Text/PoHeaderTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/PoHeaderTests.cs
@@ -76,6 +76,12 @@ namespace Yarhl.UnitTests.Media.Text
         }
 
         [Test]
+        public void CloneNullThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _ = new PoHeader(null));
+        }
+
+        [Test]
         public void Clone()
         {
             var header = new PoHeader("myID", "yo", "us") {
@@ -90,7 +96,7 @@ namespace Yarhl.UnitTests.Media.Text
             };
             header.Extensions["X-MyExt"] = "the value";
 
-            PoHeader clone = (PoHeader)header.Clone();
+            PoHeader clone = new PoHeader(header);
             Assert.AreNotSame(header, clone);
             Assert.AreEqual("test1", clone.ProjectIdVersion);
             Assert.AreEqual("test2", clone.ReportMsgidBugsTo);

--- a/src/Yarhl.UnitTests/Media/Text/PoHeaderTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/PoHeaderTests.cs
@@ -74,5 +74,33 @@ namespace Yarhl.UnitTests.Media.Text
             Assert.AreEqual("test8", header.PluralForms);
             Assert.That(header.Extensions["X-MyExt"], Is.EqualTo("the value"));
         }
+
+        [Test]
+        public void Clone()
+        {
+            var header = new PoHeader("myID", "yo", "us") {
+                ProjectIdVersion = "test1",
+                ReportMsgidBugsTo = "test2",
+                CreationDate = "test3",
+                RevisionDate = "test4",
+                LastTranslator = "test5",
+                LanguageTeam = "test6",
+                Language = "test7",
+                PluralForms = "test8",
+            };
+            header.Extensions["X-MyExt"] = "the value";
+
+            PoHeader clone = (PoHeader)header.Clone();
+            Assert.AreNotSame(header, clone);
+            Assert.AreEqual("test1", clone.ProjectIdVersion);
+            Assert.AreEqual("test2", clone.ReportMsgidBugsTo);
+            Assert.AreEqual("test3", clone.CreationDate);
+            Assert.AreEqual("test4", clone.RevisionDate);
+            Assert.AreEqual("test5", clone.LastTranslator);
+            Assert.AreEqual("test6", clone.LanguageTeam);
+            Assert.AreEqual("test7", clone.Language);
+            Assert.AreEqual("test8", clone.PluralForms);
+            Assert.That(clone.Extensions["X-MyExt"], Is.EqualTo("the value"));
+        }
     }
 }

--- a/src/Yarhl.UnitTests/Media/Text/PoTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/PoTests.cs
@@ -225,6 +225,20 @@ namespace Yarhl.UnitTests.Media.Text
             Assert.That(() => po.FindEntry(string.Empty), Throws.ArgumentNullException);
         }
 
+        [Test]
+        public void Clone()
+        {
+            var header = new PoHeader("id", "reporter", "lang");
+            var po = new Po(header);
+            po.Add(new PoEntry("t1"));
+            po.Add(new PoEntry("t2"));
+
+            var clone = (Po)po.Clone();
+
+            Assert.AreNotSame(po, clone);
+            Assert.AreEqual(2, clone.Entries.Count);
+        }
+
         protected override Po CreateDummyFormat()
         {
             return new Po();

--- a/src/Yarhl.UnitTests/Media/Text/PoTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/PoTests.cs
@@ -233,7 +233,7 @@ namespace Yarhl.UnitTests.Media.Text
             po.Add(new PoEntry("t1"));
             po.Add(new PoEntry("t2"));
 
-            var clone = (Po)po.Clone();
+            var clone = (Po)po.DeepClone();
 
             Assert.AreNotSame(po, clone);
             Assert.AreEqual(2, clone.Entries.Count);

--- a/src/Yarhl/FileFormat/ICloneableFormat.cs
+++ b/src/Yarhl/FileFormat/ICloneableFormat.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) 2019 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Yarhl.FileFormat
+{
+    /// <summary>
+    /// Cloneable format interface.
+    /// </summary>
+    public interface ICloneableFormat : IFormat
+    {
+        /// <summary>
+        /// Deep clones a format into a new object.
+        /// </summary>
+        /// <returns>The cloned format.</returns>
+        /// <remarks>
+        /// <para>A 'deep copy' must create the necessary copies, in the way that
+        /// any change in the original node (or any of it's member hierarchy) won't affect
+        /// the cloned node.</para>
+        /// </remarks>
+        object DeepClone();
+    }
+}

--- a/src/Yarhl/FileSystem/Node.cs
+++ b/src/Yarhl/FileSystem/Node.cs
@@ -27,7 +27,7 @@ namespace Yarhl.FileSystem
     /// <summary>
     /// Node in the FileSystem with an associated format.
     /// </summary>
-    public class Node : NavigableNode<Node>, ICloneable
+    public class Node : NavigableNode<Node>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Node"/> class.
@@ -47,6 +47,32 @@ namespace Yarhl.FileSystem
             : this(name)
         {
             ChangeFormat(initialFormat);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Node"/> class.
+        /// </summary>
+        /// <param name="node">The original node.</param>
+        /// <remarks><para>It makes a copy of the original node.
+        /// The original format is deep copied. See <see cref="ICloneableFormat"/> for details.</para></remarks>
+        public Node(Node node)
+            : this(node != null ? node.Name : string.Empty)
+        {
+            if (node!.Format != null && !(node.Format is ICloneableFormat))
+                throw new InvalidOperationException("Format does not implement ICloneableFormat interface.");
+
+            ICloneableFormat newFormat = null;
+            if (node.Format != null) {
+                var oldFormat = node.Format as ICloneableFormat;
+                newFormat = (ICloneableFormat)oldFormat!.DeepClone();
+            }
+
+            ChangeFormat(newFormat);
+
+            foreach (KeyValuePair<string, dynamic> tag in node.Tags)
+            {
+                Tags[tag.Key] = tag.Value;
+            }
         }
 
         /// <summary>
@@ -274,27 +300,6 @@ namespace Yarhl.FileSystem
 
             ChangeFormat(converter.Convert((TSrc)Format));
             return this;
-        }
-
-        /// <inheritdoc />
-        public object Clone()
-        {
-            if (Format != null && !(Format is ICloneable)) {
-                throw new InvalidOperationException("Format does not implement ICloneable interface.");
-            }
-
-            IFormat newFormat = null;
-            if (Format != null) {
-                newFormat = (IFormat)(Format as ICloneable).Clone();
-            }
-
-            var newNode = new Node(this.Name, newFormat);
-            foreach (KeyValuePair<string, dynamic> tag in Tags)
-            {
-                newNode.Tags[tag.Key] = tag.Value;
-            }
-
-            return newNode;
         }
 
         /// <summary>

--- a/src/Yarhl/FileSystem/Node.cs
+++ b/src/Yarhl/FileSystem/Node.cs
@@ -20,13 +20,14 @@
 namespace Yarhl.FileSystem
 {
     using System;
+    using System.Collections.Generic;
     using Yarhl.FileFormat;
     using Yarhl.IO;
 
     /// <summary>
     /// Node in the FileSystem with an associated format.
     /// </summary>
-    public class Node : NavigableNode<Node>
+    public class Node : NavigableNode<Node>, ICloneable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Node"/> class.
@@ -273,6 +274,27 @@ namespace Yarhl.FileSystem
 
             ChangeFormat(converter.Convert((TSrc)Format));
             return this;
+        }
+
+        /// <inheritdoc />
+        public object Clone()
+        {
+            if (Format != null && !(Format is ICloneable)) {
+                throw new InvalidOperationException("Format does not implement ICloneable interface.");
+            }
+
+            IFormat newFormat = null;
+            if (Format != null) {
+                newFormat = (IFormat)(Format as ICloneable).Clone();
+            }
+
+            var newNode = new Node(this.Name, newFormat);
+            foreach (KeyValuePair<string, dynamic> tag in Tags)
+            {
+                newNode.Tags[tag.Key] = tag.Value;
+            }
+
+            return newNode;
         }
 
         /// <summary>

--- a/src/Yarhl/FileSystem/Node.cs
+++ b/src/Yarhl/FileSystem/Node.cs
@@ -54,7 +54,11 @@ namespace Yarhl.FileSystem
         /// </summary>
         /// <param name="node">The original node.</param>
         /// <remarks><para>It makes a copy of the original node.
-        /// The original format is deep copied. See <see cref="ICloneableFormat"/> for details.</para></remarks>
+        /// The original format is deep copied. See <see cref="ICloneableFormat"/> for details.</para>
+        /// </remarks>
+        /// <remarks><para>If the node has children, it must be a <see cref="NodeContainerFormat"/> to clone them.
+        /// In other case, the format must implement <see cref="ICloneableFormat"/> and clone the children explicitly.
+        /// </para></remarks>
         public Node(Node node)
             : this(node != null ? node.Name : string.Empty)
         {

--- a/src/Yarhl/FileSystem/NodeContainerFormat.cs
+++ b/src/Yarhl/FileSystem/NodeContainerFormat.cs
@@ -26,7 +26,7 @@ namespace Yarhl.FileSystem
     /// <summary>
     /// Node container format for unpack / pack files.
     /// </summary>
-    public class NodeContainerFormat : IFormat, IDisposable, ICloneable
+    public class NodeContainerFormat : IDisposable, ICloneableFormat
     {
         bool manageRoot;
 
@@ -97,14 +97,14 @@ namespace Yarhl.FileSystem
         }
 
         /// <inheritdoc />
-        public object Clone()
+        public virtual object DeepClone()
         {
             var newFormat = new NodeContainerFormat();
 
             // Just copy the first generation children.
             // The rest will be copied recursively if necessary.
             foreach (Node node in Root.Children) {
-                var newNode = (Node)node.Clone();
+                var newNode = new Node(node);
                 newFormat.Root.Add(newNode);
             }
 

--- a/src/Yarhl/FileSystem/NodeContainerFormat.cs
+++ b/src/Yarhl/FileSystem/NodeContainerFormat.cs
@@ -26,7 +26,7 @@ namespace Yarhl.FileSystem
     /// <summary>
     /// Node container format for unpack / pack files.
     /// </summary>
-    public class NodeContainerFormat : IFormat, IDisposable
+    public class NodeContainerFormat : IFormat, IDisposable, ICloneable
     {
         bool manageRoot;
 
@@ -94,6 +94,21 @@ namespace Yarhl.FileSystem
             Root.RemoveChildren(false);
             Root = newNode;
             manageRoot = false;
+        }
+
+        /// <inheritdoc />
+        public object Clone()
+        {
+            var newFormat = new NodeContainerFormat();
+
+            // Just copy the first generation children.
+            // The rest will be copied recursively if necessary.
+            foreach (Node node in Root.Children) {
+                var newNode = (Node)node.Clone();
+                newFormat.Root.Add(newNode);
+            }
+
+            return newFormat;
         }
 
         /// <summary>

--- a/src/Yarhl/IO/BinaryFormat.cs
+++ b/src/Yarhl/IO/BinaryFormat.cs
@@ -21,11 +21,12 @@ namespace Yarhl.IO
 {
     using System;
     using System.IO;
+    using Yarhl.FileFormat;
 
     /// <summary>
     /// Binary format.
     /// </summary>
-    public class BinaryFormat : IBinary, IDisposable, ICloneable
+    public class BinaryFormat : IBinary, IDisposable, ICloneableFormat
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BinaryFormat"/> class.
@@ -94,7 +95,13 @@ namespace Yarhl.IO
         }
 
         /// <inheritdoc />
-        public object Clone() => new BinaryFormat(DataStreamFactory.FromStream(Stream, 0, Stream.Length));
+        public virtual object DeepClone()
+        {
+            DataStream newStream = DataStreamFactory.FromMemory();
+            Stream.WriteTo(newStream);
+
+            return new BinaryFormat(newStream);
+        }
 
         /// <summary>
         /// Releases all resource used by the <see cref="BinaryFormat"/> object.

--- a/src/Yarhl/IO/BinaryFormat.cs
+++ b/src/Yarhl/IO/BinaryFormat.cs
@@ -25,7 +25,7 @@ namespace Yarhl.IO
     /// <summary>
     /// Binary format.
     /// </summary>
-    public class BinaryFormat : IBinary, IDisposable
+    public class BinaryFormat : IBinary, IDisposable, ICloneable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BinaryFormat"/> class.
@@ -92,6 +92,9 @@ namespace Yarhl.IO
             get;
             private set;
         }
+
+        /// <inheritdoc />
+        public object Clone() => new BinaryFormat(DataStreamFactory.FromStream(Stream, 0, Stream.Length));
 
         /// <summary>
         /// Releases all resource used by the <see cref="BinaryFormat"/> object.

--- a/src/Yarhl/IO/BinaryFormat.cs
+++ b/src/Yarhl/IO/BinaryFormat.cs
@@ -94,7 +94,12 @@ namespace Yarhl.IO
             private set;
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Makes a copy of the format stream <strong>into memory</strong>
+        /// and returns a new <see cref="BinaryFormat"/> object.
+        /// </summary>
+        /// <remarks><para>The stream is copied into memory, so it is limited to 2GB size.</para></remarks>
+        /// <returns>The cloned <see cref="BinaryFormat"/>.</returns>
         public virtual object DeepClone()
         {
             DataStream newStream = DataStreamFactory.FromMemory();


### PR DESCRIPTION
### Description

In this PR, `BinaryFormat`, `NodeContainerFormat` and `Po` classes implement a `ICloneableFormat` interface, making easier to get duplicates.

Also, there is a new constructor in `Node` that accepts other node. It makes a new node with the same name and tags than the original node and a deep copy of its format.

### Example

```csharp
// Make a node copy
Node clone = new Node(original);

// Deep copy a BinaryFormat (or other ICloneableFormat)
BinaryFormat newFormat = (BinaryFormat)oldFormat.DeepClone();
```
