### PR TITLE
Fix Binary2Po converter not reading from the beginning of the stream

### DIFF
--- a/src/Yarhl.Media/Text/Binary2Po.cs
+++ b/src/Yarhl.Media/Text/Binary2Po.cs
@@ -39,6 +39,8 @@ namespace Yarhl.Media.Text
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
+            source.Stream.Position = 0;
+
             TextDataReader reader = new TextDataReader(source.Stream);
             Po po = new Po();
 

--- a/src/Yarhl.UnitTests/Media/Text/Po2BinaryTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/Po2BinaryTests.cs
@@ -470,6 +470,25 @@ msgstr """"
             Assert.AreEqual(testPo.Entries[0].Reference, newPo.Entries[0].Reference);
         }
 
+        [Test]
+        public void StreamNotAtOrigin()
+        {
+            var header = new PoHeader("testId", "reporter", "es");
+            var po = new Po(header);
+            var entry = new PoEntry("Test") { Translated = "Prueba" };
+            po.Add(entry);
+
+            BinaryFormat poBinary = ConvertFormat.To<BinaryFormat>(po);
+
+            Assert.AreNotEqual(0, poBinary.Stream.Position);
+
+            Po result = ConvertFormat.To<Po>(poBinary);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Entries.Count);
+            Assert.AreEqual(po.Entries[0].Original, result.Entries[0].Original);
+        }
+
         static void CompareText(BinaryFormat binary, string expected)
         {
             binary.Stream.Position = 0;


### PR DESCRIPTION
### Description

Binary2Po doesn't check the stream position, so the conversion might fail even if the binary is a valid Po but the stream position is not 0.

This PR moves the stream position to the beginning before the conversion.

### Example

The PR doen't change the way the converter is used.