### PR TITLE
Use DataStream type in Stream properties for readers and writers and explicitly set CanTimeout to false

### DIFF
--- a/src/Yarhl.UnitTests/IO/DataReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataReaderTests.cs
@@ -67,6 +67,29 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void ConstructorGuards()
+        {
+            Assert.That(() => new DataReader(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void EntityDoesNotOwnStream()
+        {
+            using var dataStream = new DataStream();
+            using var commonStream = new MemoryStream();
+            int initialCount = DataStream.ActiveStreams;
+
+            var myReader = new DataReader(dataStream);
+            Assert.That(myReader.Stream, Is.SameAs(dataStream));
+            Assert.That(DataStream.ActiveStreams, Is.EqualTo(initialCount));
+
+            myReader = new DataReader(commonStream);
+            Assert.That(myReader.Stream.BaseStream, Is.SameAs(commonStream));
+            Assert.That(DataStream.ActiveStreams, Is.EqualTo(initialCount));
+            Assert.That(myReader.Stream.InternalInfo.NumInstances, Is.EqualTo(0));
+        }
+
+        [Test]
         public void EndiannessProperty()
         {
             Assert.AreEqual(EndiannessMode.LittleEndian, reader.Endianness);

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1884,6 +1884,18 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void CannotTimeOutButDoesNotThrowException()
+        {
+            // Important to prevent exceptions in reflection UI controls
+            using var stream = new DataStream();
+            Assert.That(stream.CanTimeout, Is.False);
+            Assert.That(stream.ReadTimeout, Is.EqualTo(-1));
+            Assert.That(stream.WriteTimeout, Is.EqualTo(-1));
+            Assert.That(() => stream.ReadTimeout = 300, Throws.InstanceOf<InvalidOperationException>());
+            Assert.That(() => stream.WriteTimeout = 300, Throws.InstanceOf<InvalidOperationException>());
+        }
+
+        [Test]
         public void TestStreamFlushGuards()
         {
             var stream = new DataStream();

--- a/src/Yarhl.UnitTests/IO/DataWriterTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataWriterTests.cs
@@ -20,6 +20,7 @@
 namespace Yarhl.UnitTests.IO
 {
     using System;
+    using System.IO;
     using System.Linq;
     using System.Text;
     using NUnit.Framework;
@@ -42,6 +43,29 @@ namespace Yarhl.UnitTests.IO
             using DataStream stream = new DataStream();
             DataWriter writer = new DataWriter(stream);
             Assert.AreSame(stream, writer.Stream);
+        }
+
+        [Test]
+        public void ConstructorGuards()
+        {
+            Assert.That(() => new DataWriter(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void EntityDoesNotOwnStream()
+        {
+            using var dataStream = new DataStream();
+            using var commonStream = new MemoryStream();
+            int initialCount = DataStream.ActiveStreams;
+
+            var myWriter = new DataWriter(dataStream);
+            Assert.That(myWriter.Stream, Is.SameAs(dataStream));
+            Assert.That(DataStream.ActiveStreams, Is.EqualTo(initialCount));
+
+            myWriter = new DataWriter(commonStream);
+            Assert.That(myWriter.Stream.BaseStream, Is.SameAs(commonStream));
+            Assert.That(DataStream.ActiveStreams, Is.EqualTo(initialCount));
+            Assert.That(myWriter.Stream.InternalInfo.NumInstances, Is.EqualTo(0));
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/TextDataReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/TextDataReaderTests.cs
@@ -20,6 +20,7 @@
 namespace Yarhl.UnitTests.IO
 {
     using System;
+    using System.IO;
     using System.Text;
     using NUnit.Framework;
     using Yarhl.IO;
@@ -89,6 +90,23 @@ namespace Yarhl.UnitTests.IO
 
             Assert.Throws<ArgumentNullException>(() => new TextDataReader(null, "ascii"));
             Assert.Throws<ArgumentNullException>(() => new TextDataReader(stream, (string)null));
+        }
+
+        [Test]
+        public void EntityDoesNotOwnStream()
+        {
+            using var dataStream = new DataStream();
+            using var commonStream = new MemoryStream();
+            int initialCount = DataStream.ActiveStreams;
+
+            var myReader = new TextDataReader(dataStream);
+            Assert.That(myReader.Stream, Is.SameAs(dataStream));
+            Assert.That(DataStream.ActiveStreams, Is.EqualTo(initialCount));
+
+            myReader = new TextDataReader(commonStream);
+            Assert.That(myReader.Stream.BaseStream, Is.SameAs(commonStream));
+            Assert.That(DataStream.ActiveStreams, Is.EqualTo(initialCount));
+            Assert.That(myReader.Stream.InternalInfo.NumInstances, Is.EqualTo(0));
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/TextDataWriterTests.cs
+++ b/src/Yarhl.UnitTests/IO/TextDataWriterTests.cs
@@ -20,6 +20,7 @@
 namespace Yarhl.UnitTests.IO
 {
     using System;
+    using System.IO;
     using System.Text;
     using NUnit.Framework;
     using Yarhl.IO;
@@ -87,6 +88,23 @@ namespace Yarhl.UnitTests.IO
                 () => new TextDataWriter(null, "ascii"));
             Assert.Throws<ArgumentNullException>(
                 () => new TextDataWriter(stream, (string)null));
+        }
+
+        [Test]
+        public void EntityDoesNotOwnStream()
+        {
+            using var dataStream = new DataStream();
+            using var commonStream = new MemoryStream();
+            int initialCount = DataStream.ActiveStreams;
+
+            var myWriter = new TextDataWriter(dataStream);
+            Assert.That(myWriter.Stream, Is.SameAs(dataStream));
+            Assert.That(DataStream.ActiveStreams, Is.EqualTo(initialCount));
+
+            myWriter = new TextDataWriter(commonStream);
+            Assert.That(myWriter.Stream.BaseStream, Is.SameAs(commonStream));
+            Assert.That(DataStream.ActiveStreams, Is.EqualTo(initialCount));
+            Assert.That(myWriter.Stream.InternalInfo.NumInstances, Is.EqualTo(0));
         }
 
         [Test]

--- a/src/Yarhl/IO/DataReader.cs
+++ b/src/Yarhl/IO/DataReader.cs
@@ -50,7 +50,10 @@ namespace Yarhl.IO
         /// </remarks>
         public DataReader(Stream stream)
         {
-            Stream = stream;
+            if (stream is null)
+                throw new ArgumentNullException(nameof(stream));
+
+            Stream = stream as DataStream ?? new DataStream(stream, 0, stream.Length, false);
             Endianness = EndiannessMode.LittleEndian;
             DefaultEncoding = new UTF8Encoding(false, true);
         }
@@ -58,7 +61,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets the stream.
         /// </summary>
-        public Stream Stream {
+        public DataStream Stream {
             get;
             private set;
         }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -232,6 +232,27 @@ namespace Yarhl.IO
         }
 
         /// <summary>
+        /// Gets a value indicating whether the current stream support timeouts.
+        /// </summary>
+        public override bool CanTimeout => false;
+
+        /// <summary>
+        /// Gets or sets an invalid value as read time is not supported.
+        /// </summary>
+        public override int ReadTimeout {
+            get => -1;
+            set => throw new InvalidOperationException("Read timeout is not supported");
+        }
+
+        /// <summary>
+        /// Gets or sets an invalid value as write time is not supported.
+        /// </summary>
+        public override int WriteTimeout {
+            get => -1;
+            set => throw new InvalidOperationException("Write timeout is not supported");
+        }
+
+        /// <summary>
         /// Gets the internal stream information for testing pourpose only.
         /// </summary>
         internal StreamInfo InternalInfo {

--- a/src/Yarhl/IO/DataWriter.cs
+++ b/src/Yarhl/IO/DataWriter.cs
@@ -49,7 +49,10 @@ namespace Yarhl.IO
         /// </remarks>
         public DataWriter(Stream stream)
         {
-            Stream = stream;
+            if (stream is null)
+                throw new ArgumentNullException(nameof(stream));
+
+            Stream = stream as DataStream ?? new DataStream(stream, 0, stream.Length, false);
             Endianness = EndiannessMode.LittleEndian;
             DefaultEncoding = Encoding.UTF8;
         }
@@ -58,7 +61,7 @@ namespace Yarhl.IO
         /// Gets the stream.
         /// </summary>
         /// <value>The stream.</value>
-        public Stream Stream {
+        public DataStream Stream {
             get;
             private set;
         }

--- a/src/Yarhl/IO/TextDataReader.cs
+++ b/src/Yarhl/IO/TextDataReader.cs
@@ -67,7 +67,10 @@ namespace Yarhl.IO
         /// <param name="encoding">Encoding to use.</param>
         public TextDataReader(Stream stream, Encoding encoding)
         {
-            Stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            if (stream is null)
+                throw new ArgumentNullException(nameof(stream));
+
+            Stream = stream as DataStream ?? new DataStream(stream, 0, stream.Length, false);
             Encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
             NewLine = Environment.NewLine;
             AutoNewLine = true;
@@ -80,7 +83,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets the stream.
         /// </summary>
-        public Stream Stream {
+        public DataStream Stream {
             get;
             private set;
         }

--- a/src/Yarhl/IO/TextDataWriter.cs
+++ b/src/Yarhl/IO/TextDataWriter.cs
@@ -70,7 +70,7 @@ namespace Yarhl.IO
             if (encoding == null)
                 throw new ArgumentNullException(nameof(encoding));
 
-            Stream = stream;
+            Stream = stream as DataStream ?? new DataStream(stream, 0, stream.Length, false);
             Encoding = encoding;
             NewLine = "\n";
             AutoPreamble = false;
@@ -82,7 +82,7 @@ namespace Yarhl.IO
         /// <summary>
         /// Gets the stream.
         /// </summary>
-        public Stream Stream {
+        public DataStream Stream {
             get;
             private set;
         }


### PR DESCRIPTION
### Description

Get again all the advantages of `DataStream` from the properties of `DataReader`, `DataWriter`, `TextDataReader` and `TextDataWriter`.
This reduces the amount of breaking changes introduced by this release.

Also set `CanTimeout` to `false` and return invalid values for `ReadTimeout` and `WriterTimeout`. The default implementation is to throw an exception and that make almost impossible to use some reflection in the type. For instance in debuggers or in UI controls that display automatically the value of the properties.

### Example

```csharp
using var stream = new DataStream();
var reader = new DataReader(stream);
reader.Stream.PushPosition();
```