### PR TITLE
Implement factories to create DataStreams and Nodes from array and standard streams

### DIFF
--- a/src/Yarhl.Media/Yarhl.Media.csproj
+++ b/src/Yarhl.Media/Yarhl.Media.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <None Include="../../docs/images/favicon-128.png" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
+    <None Include="../../README.md" Pack="true" PackagePath="README.md" Visible="false" />
 
     <EmbeddedResource Include="Text\Encodings\index-jis0208.txt" />
     <EmbeddedResource Include="Text\Encodings\index-jis0212.txt" />

--- a/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
@@ -530,6 +530,73 @@ namespace Yarhl.UnitTests.FileSystem
         }
 
         [Test]
+        public void CreateFromArray()
+        {
+            byte[] data = new byte[] { 1, 2 };
+            using var node = NodeFactory.FromArray("node", data);
+            Assert.That(node, Is.Not.Null);
+            Assert.That(node.Name, Is.EqualTo("node"));
+            Assert.That(node.Format, Is.TypeOf<BinaryFormat>());
+            Assert.That(node.Stream.Length, Is.EqualTo(2));
+            Assert.That(node.Stream.ReadByte(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void CreateFromArrayGuards()
+        {
+            byte[] data = new byte[1];
+            Assert.That(() => NodeFactory.FromArray(null, data), Throws.ArgumentNullException);
+            Assert.That(() => NodeFactory.FromArray(string.Empty, data), Throws.ArgumentNullException);
+            Assert.That(() => NodeFactory.FromArray("node", null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void CreateFromSubArray()
+        {
+            byte[] data = new byte[] { 1, 2, 3 };
+            using var node = NodeFactory.FromArray("node", data, 1, 1);
+            Assert.That(node, Is.Not.Null);
+            Assert.That(node.Name, Is.EqualTo("node"));
+            Assert.That(node.Format, Is.TypeOf<BinaryFormat>());
+            Assert.That(node.Stream.Position, Is.EqualTo(0));
+            Assert.That(node.Stream.Length, Is.EqualTo(1));
+            Assert.That(node.Stream.ReadByte(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void CreateFromSubArrayGuards()
+        {
+            byte[] data = new byte[3];
+            Assert.That(() => NodeFactory.FromArray(null, data, 1, 2), Throws.ArgumentNullException);
+            Assert.That(() => NodeFactory.FromArray(string.Empty, data, 1, 2), Throws.ArgumentNullException);
+            Assert.That(() => NodeFactory.FromArray("node", data, -1, 2), Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(() => NodeFactory.FromArray("node", data, 3, 2), Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(() => NodeFactory.FromArray("node", data, 1, 4), Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(() => NodeFactory.FromArray("node", data, 1, -1), Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(() => NodeFactory.FromArray("node", null, 0, 0), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void CreateFromStream()
+        {
+            using var stream = new DataStream();
+            using var node = NodeFactory.FromStream("node", stream);
+            Assert.That(node, Is.Not.Null);
+            Assert.That(node.Name, Is.EqualTo("node"));
+            Assert.That(node.Format, Is.TypeOf<BinaryFormat>());
+            Assert.That(node.Stream.BaseStream, Is.SameAs(stream.BaseStream));
+        }
+
+        [Test]
+        public void CreateFromStreamGuards()
+        {
+            using var stream = new DataStream();
+            Assert.That(() => NodeFactory.FromStream(null, stream), Throws.ArgumentNullException);
+            Assert.That(() => NodeFactory.FromStream(string.Empty, stream), Throws.ArgumentNullException);
+            Assert.That(() => NodeFactory.FromStream("node", null), Throws.ArgumentNullException);
+        }
+
+        [Test]
         public void CreateFromSubstream()
         {
             using DataStream main = new DataStream();

--- a/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
@@ -239,6 +239,23 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void CreateFromArray()
+        {
+            byte[] data = new byte[] { 0x01, 0x02 };
+            using var stream = DataStreamFactory.FromArray(data);
+            Assert.That(stream.Position, Is.EqualTo(0));
+            Assert.That(stream.Length, Is.EqualTo(2));
+            Assert.That(stream.ReadByte(), Is.EqualTo(0x01));
+            Assert.That(stream.ReadByte(), Is.EqualTo(0x02));
+        }
+
+        [Test]
+        public void CreateFromArrayGuards()
+        {
+            Assert.That(() => DataStreamFactory.FromArray(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
         public void CreateFromArrayReadsArray()
         {
             byte[] data = new byte[] { 0x01, 0x2, 0x3 };

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -98,6 +98,65 @@ namespace Yarhl.FileSystem
         }
 
         /// <summary>
+        /// Creates a Node with a binary format containing the array.
+        /// </summary>
+        /// <param name="name">The name of the node.</param>
+        /// <param name="data">The data for the binary format.</param>
+        /// <returns>The new node.</returns>
+        /// <exception cref="ArgumentNullException">The name is null or empty, the data is null.</exception>
+        public static Node FromArray(string name, byte[] data)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentNullException(nameof(name));
+            if (data is null)
+                throw new ArgumentNullException(nameof(data));
+
+            var format = new BinaryFormat(DataStreamFactory.FromArray(data));
+            return new Node(name, format);
+        }
+
+        /// <summary>
+        /// Creates a Node with a binary format containing a part of the array.
+        /// </summary>
+        /// <param name="name">The name of the node.</param>
+        /// <param name="data">The data for the binary format.</param>
+        /// <param name="offset">The offset to start the data of the node.</param>
+        /// <param name="length">The number of bytes for the node's data.</param>
+        /// <returns>The new node.</returns>
+        /// <exception cref="ArgumentNullException">The name is null or empty, the data is null.</exception>
+        public static Node FromArray(string name, byte[] data, int offset, int length)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentNullException(nameof(name));
+            if (data is null)
+                throw new ArgumentNullException(nameof(data));
+
+            var format = new BinaryFormat(DataStreamFactory.FromArray(data, offset, length));
+            return new Node(name, format);
+        }
+
+        /// <summary>
+        /// Creates a Node from a stream.
+        /// </summary>
+        /// <param name="name">The name of the node.</param>
+        /// <param name="stream">The binary stream.</param>
+        /// <remarks>
+        /// <para>It will take over the ownership of the stream
+        /// argument, you should not dispose this stream argument.</para>
+        /// </remarks>
+        /// <returns>The new node.</returns>
+        public static Node FromStream(string name, Stream stream)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentNullException(nameof(name));
+            if (stream is null)
+                throw new ArgumentNullException(nameof(stream));
+
+            var binary = new BinaryFormat(stream);
+            return new Node(name, binary);
+        }
+
+        /// <summary>
         /// Creates a Node from a part of a stream.
         /// </summary>
         /// <param name="name">The name of the node.</param>
@@ -110,8 +169,8 @@ namespace Yarhl.FileSystem
         /// <para>This format creates an internal <see cref="DataStream" /> from the
         /// provided stream. It will take over the ownership of the stream
         /// argument, you should not dispose this argument, unless you are
-        /// providing a <see cref="DataStream" /> in which case it is safe and
-        /// recommended to dispose it.</para>
+        /// providing a <see cref="DataStream" /> that we won't take over in case
+        /// you want to create more substreams.</para>
         /// </remarks>
         /// <returns>The new node.</returns>
         [SuppressMessage(

--- a/src/Yarhl/IO/BinaryFormat.cs
+++ b/src/Yarhl/IO/BinaryFormat.cs
@@ -59,8 +59,8 @@ namespace Yarhl.IO
         /// <para>This format creates an internal <see cref="DataStream" /> from the
         /// provided stream. It will take over the ownership of the stream
         /// argument, you should not dispose this argument, unless you are
-        /// providing a <see cref="DataStream" /> in which case it is safe and
-        /// recommended to dispose it.</para>
+        /// providing a <see cref="DataStream" /> that we won't take over in case
+        /// you want to create more substreams.</para>
         /// </remarks>
         /// <param name="stream">Binary stream.</param>
         /// <param name="offset">Offset from the DataStream start.</param>

--- a/src/Yarhl/IO/DataStreamFactory.cs
+++ b/src/Yarhl/IO/DataStreamFactory.cs
@@ -111,6 +111,19 @@ namespace Yarhl.IO
         /// Creates a new <see cref="DataStream"/> from an array of data.
         /// </summary>
         /// <param name="data">The array of data to use in the stream.</param>
+        /// <returns>A new <see cref="DataStream"/>.</returns>
+        public static DataStream FromArray(byte[] data)
+        {
+            if (data is null)
+                throw new ArgumentNullException(nameof(data));
+
+            return FromArray(data, 0, data.Length);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="DataStream"/> from an array of data.
+        /// </summary>
+        /// <param name="data">The array of data to use in the stream.</param>
         /// <param name="offset">Offset in the array of data.</param>
         /// <param name="length">Length of the new stream.</param>
         /// <returns>A new <see cref="DataStream"/>.</returns>

--- a/src/Yarhl/Yarhl.csproj
+++ b/src/Yarhl/Yarhl.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <None Include="../../docs/images/favicon-128.png" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
+    <None Include="../../README.md" Pack="true" PackagePath="README.md" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

Implement API in the `NodeFactory` and `DataStreamFactory` to create objects from _arrays_ and _streams_.
Also include the README in the NuGets for visibility in nuget.org.

### Example

```csharp
byte[] myData = new byte[] { 1, 2, 3 };

using var stream = DataStreamFactory.FromArray(myData);

using var node1 = NodeFactory.FromArray("node1", myData);
using var node2 = NodeFactory.FromArray("node2", myData, 1, 2);

var commonStream = new MemoryStream();
using var node3 = NodeFactory.FromStream("node3", commonStream);
```