### PR TITLE
Update build system to build and test for .NET 6

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/dotnet:6.0
 # Install Mono (for DocFX)
 RUN apt install -y apt-transport-https dirmngr gnupg ca-certificates \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb https://download.mono-project.com/repo/debian stable-buster main" >> tee /etc/apt/sources.list.d/mono-official-stable.list \
+    && echo "deb https://download.mono-project.com/repo/debian stable-buster main" >> /etc/apt/sources.list.d/mono-official-stable.list \
     && apt update \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt install -y mono-devel

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:5.0
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:6.0
 
 # Install .NET Core 3.1
 RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
@@ -8,7 +8,7 @@ RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-p
     && apt-get update \
     && apt-get install -y aspnetcore-runtime-3.1
 
-# Install Mono (soon won't be necessary (.NET 6?))
+# Install Mono
 RUN apt install -y gnupg ca-certificates \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
     && echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" >> /etc/apt/sources.list.d/mono-official-stable.list \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,17 +1,9 @@
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:6.0
 
-# Install .NET Core 3.1
-RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-    && dpkg -i packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install -y apt-transport-https \
-    && apt-get update \
-    && apt-get install -y aspnetcore-runtime-3.1
-
-# Install Mono
-RUN apt install -y gnupg ca-certificates \
+# Install Mono (for DocFX)
+RUN apt install -y apt-transport-https dirmngr gnupg ca-certificates \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" >> /etc/apt/sources.list.d/mono-official-stable.list \
+    && echo "deb https://download.mono-project.com/repo/debian stable-buster main" >> tee /etc/apt/sources.list.d/mono-official-stable.list \
     && apt update \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt install -y mono-devel

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Dev (Ubuntu - .NET 6, 3.1 and Mono)",
+    "name": "Dev (.NET 6 and Mono)",
     "build": {
         "dockerfile": "Dockerfile",
     },
@@ -18,7 +18,7 @@
 
     "remoteUser": "vscode",
 
-    // Required for Podman (Docker alternative)
+    // PODMAN ONLY. You may need to remove this line for Docker.
     // SELinux issues: https://github.com/containers/podman/issues/3683
     "runArgs": [ "--security-opt", "label=disable", "--userns=keep-id" ],
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,7 @@
 {
-    "name": "Dev (Ubuntu - .NET 5, 3.1 and Mono)",
+    "name": "Dev (Ubuntu - .NET 6, 3.1 and Mono)",
     "build": {
         "dockerfile": "Dockerfile",
-    },
-
-    "settings": {
-        "terminal.integrated.shell.linux": "/bin/bash"
     },
 
     "extensions": [

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -12,7 +12,6 @@ on:
 
 env:
   NET_SDK: '6.0.100'
-  NET31_SDK: '3.1.415'
 
 jobs:
   build_main:
@@ -28,10 +27,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.NET_SDK }}
-      - name: "Setup .NET Core 3.1 for Cake dependencies"
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.NET31_SDK }}
 
       - name: "Install build tools"
         run: dotnet tool restore
@@ -77,10 +72,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.NET_SDK }}
-      - name: "Setup .NET Core 3.1 for Cake dependencies"
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.NET31_SDK }}
 
       - name: "Install build tools"
         run: dotnet tool restore
@@ -115,10 +106,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.NET_SDK }}
-      - name: "Setup .NET Core 3.1 for Cake dependencies"
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.NET31_SDK }}
 
       - name: "Install build tools"
         run: dotnet tool restore

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -11,8 +11,8 @@ on:
     tags: [ "v*" ]
 
 env:
-  NET_SDK: '5.0.402'
-  NET31_SDK: '3.1.414'
+  NET_SDK: '6.0.100'
+  NET31_SDK: '3.1.415'
 
 jobs:
   build_main:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "Cake: Run Build for release",
-            "program": "${workspaceFolder}/src/Yarhl.PerformanceTests/bin/Release/net5.0/Yarhl.PerformanceTests.dll",
+            "program": "${workspaceFolder}/src/Yarhl.PerformanceTests/bin/Release/net6.0/Yarhl.PerformanceTests.dll",
             "args": [ "auto" ],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ provide an small snippet of code that reproduces the issue. Try to provide also
 the following information:
 
 - OS: Linux / Windows / Mac OS
-- Runtime: .NET Framework, Mono, .NET Core, .NET 5
+- Runtime: .NET Framework, Mono, .NET 6
 - Version of Yarhl
 - Stacktrace if any
 - What's happening and what you expect to happen

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ Stable releases are available from nuget.org:
 The libraries target .NET Standard 2.0. The tests (so the library) runs with the
 supported runtimes:
 
-- .NET 5.0
-- .NET Core 3.1
+- .NET 6.0
 - .NET Framework 4.8 or Mono (latest on CI)
 
 Preview releases can be found in this
@@ -53,9 +52,8 @@ your solution (.sln) file with the following content:
 
 ## Build
 
-The project requires to build .NET 5.0 SDK, .NET Core 3.1 runtime and .NET
-Framework 4.8 or latest Mono. If you open the project with VS Code and you did
-install the
+The project requires to build .NET 6.0 SDK and .NET Framework 4.8 or latest
+Mono. If you open the project with VS Code and you did install the
 [VS Code Remote Containers](https://code.visualstudio.com/docs/remote/containers)
 extension, you can have an already pre-configured development environment with
 Docker or Podman.

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#load "nuget:?package=PleOps.Cake&version=0.5.1"
+#load "nuget:?package=PleOps.Cake&version=0.6.1"
 
 Task("Define-Project")
     .Description("Fill specific project information")

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,7 @@
         <Copyright>Copyright (C) 2019 SceneGate</Copyright>
 
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <NoWarn>NETSDK1179</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -13,6 +14,7 @@
         <RepositoryUrl>https://github.com/SceneGate/Yarhl</RepositoryUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageTags>translation;localization;romhacking;fan-translation</PackageTags>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <!-- Deterministic and source link -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,7 +17,7 @@
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 
         <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.31.0.39249" />
-        <PackageVersion Include="Roslynator.Analyzers" Version="3.2.2" />
+        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.32.0.39516" />
+        <PackageVersion Include="Roslynator.Analyzers" Version="3.3.0" />
     </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,23 +1,23 @@
 <Project>
     <!-- Centralize dependency management -->
     <ItemGroup>
-        <PackageVersion Include="System.Composition" Version="5.0.1" />
-        <PackageVersion Include="System.Text.Encoding.CodePages" Version="5.0.0" />
+        <PackageVersion Include="System.Composition" Version="6.0.0" />
+        <PackageVersion Include="System.Text.Encoding.CodePages" Version="6.0.0" />
         <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
         <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
 
         <PackageVersion Include="NUnit" Version="3.13.2" />
-        <PackageVersion Include="NUnit3TestAdapter" Version="4.0.0" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
+        <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
         <PackageVersion Include="coverlet.collector" Version="3.1.0" />
         <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
         <PackageVersion Include="Moq" Version="4.16.1" />
 
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 
         <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.30.0.37606" />
+        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.31.0.39249" />
         <PackageVersion Include="Roslynator.Analyzers" Version="3.2.2" />
     </ItemGroup>
 </Project>

--- a/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
+++ b/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Description>Plugin integration tests for Yarhl.</Description>
-    <TargetFrameworks>netcoreapp3.1;net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
+++ b/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Description>Plugin integration tests for Yarhl.</Description>
-    <TargetFrameworks>netcoreapp3.1;net48;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Yarhl.PerformanceTests/Yarhl.PerformanceTests.csproj
+++ b/src/Yarhl.PerformanceTests/Yarhl.PerformanceTests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>Performance tests for Yarhl.</Description>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
+++ b/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Description>Yarhl unit tests.</Description>
-    <TargetFrameworks>netcoreapp3.1;net48;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48;net6.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
+++ b/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Description>Yarhl unit tests.</Description>
-    <TargetFrameworks>netcoreapp3.1;net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/src/Yarhl/Yarhl.csproj
+++ b/src/Yarhl/Yarhl.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <None Include="../../docs/images/favicon-128.png" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
-    <None Include="../../README.md" Pack="true" PackagePath="README.md" Visible="false" />
+    <None Include="../../README.md" Pack="true" PackagePath="$(PackageReadmeFile)" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

Update the build system to use the .NET 6 SDK to build and to run the unit tests against .NET 6 and .NET Framework only.
As .NET 6 is an LTS release, Yarhl will stop supporting .NET Core 3.1 and .NET 5. However, as it targets .NET Standard 2.0, it should be compatible in those runtimes.
