### PR TITLE
Annotate API reference types for nullable awareness

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,4 +13,12 @@
         "editor.formatOnType": true
     },
     "prettier.proseWrap": "always",
+    "cSpell.words": [
+        "Conv",
+        "cref",
+        "Dependee",
+        "finalizer",
+        "msgctxt",
+        "Msgid"
+    ],
 }

--- a/src/Yarhl.Media/Text/Binary2Po.cs
+++ b/src/Yarhl.Media/Text/Binary2Po.cs
@@ -45,7 +45,7 @@ namespace Yarhl.Media.Text
             Po po = new Po();
 
             // Read the header if any
-            PoEntry entry = ReadEntry(reader);
+            PoEntry? entry = ReadEntry(reader);
             if (entry == null)
                 return po;
 
@@ -62,15 +62,15 @@ namespace Yarhl.Media.Text
             return po;
         }
 
-        static PoEntry ReadEntry(TextDataReader reader)
+        static PoEntry? ReadEntry(TextDataReader reader)
         {
             // Skip all the blank lines before the block of text
             string line = string.Empty;
-            while (reader.PeekLine()?.Trim().Length == 0)
+            while (!reader.Stream.EndOfStream && reader.PeekLine().Trim().Length == 0)
                 reader.ReadLine();
 
             // If nothing to read, EOF
-            if (reader.Stream.Position >= reader.Stream.Length)
+            if (reader.Stream.EndOfStream)
                 return null;
 
             PoEntry entry = new PoEntry();

--- a/src/Yarhl.Media/Text/Encodings/EscapeOutRangeEncoding.cs
+++ b/src/Yarhl.Media/Text/Encodings/EscapeOutRangeEncoding.cs
@@ -107,7 +107,7 @@ namespace Yarhl.Media.Text.Encodings
         /// <param name="charIndex">Index in the char array.</param>
         /// <param name="charCount">Number of chars to convert.</param>
         /// <param name="bytes">Output byte array.</param>
-        /// <param name="byteIndex">Indes in the byte array.</param>
+        /// <param name="byteIndex">Index in the byte array.</param>
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             if (chars == null)
@@ -206,7 +206,7 @@ namespace Yarhl.Media.Text.Encodings
             return true;
         }
 
-        static string UnescapeText(string text, ICollection<byte> symbols = null)
+        static string UnescapeText(string text, ICollection<byte>? symbols = null)
         {
             StringBuilder transformed = new StringBuilder(text);
             StringComparison culture = StringComparison.Ordinal;
@@ -265,7 +265,7 @@ namespace Yarhl.Media.Text.Encodings
         /// </summary>
         internal sealed class EscapeOutRangeDecoderFallbackBuffer : DecoderFallbackBuffer
         {
-            string replacement;
+            string replacement = string.Empty;
             int currentPos;
 
             /// <summary>

--- a/src/Yarhl.Media/Text/Encodings/EucJpEncoding.cs
+++ b/src/Yarhl.Media/Text/Encodings/EucJpEncoding.cs
@@ -103,7 +103,7 @@ namespace Yarhl.Media.Text.Encodings
         /// <param name="charIndex">Index in the char array.</param>
         /// <param name="charCount">Number of chars to convert.</param>
         /// <param name="bytes">Output byte array.</param>
-        /// <param name="byteIndex">Indes in the byte array.</param>
+        /// <param name="byteIndex">Index in the byte array.</param>
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             if (chars == null)
@@ -358,15 +358,13 @@ namespace Yarhl.Media.Text.Encodings
             {
                 Table table = new Table();
 
-                Stream stream = null;
+                Stream? stream = null;
                 try {
                     stream = Assembly.GetExecutingAssembly()
                         .GetManifestResourceStream(path);
 
                     using (var reader = new StreamReader(stream)) {
-#pragma warning disable IDISP003
                         stream = null;  // Avoid disposing twice
-#pragma warning restore IDISP003
 
                         while (!reader.EndOfStream) {
                             string line = reader.ReadLine();

--- a/src/Yarhl.Media/Text/Po.cs
+++ b/src/Yarhl.Media/Text/Po.cs
@@ -32,13 +32,13 @@ namespace Yarhl.Media.Text
         readonly IList<PoEntry> entries;
         readonly ReadOnlyCollection<PoEntry> readonlyEntries;
         readonly IDictionary<string, PoEntry> searchEntries;
-        PoHeader header;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Po"/> class.
         /// </summary>
         public Po()
         {
+            Header = new PoHeader();
             entries = new List<PoEntry>();
             readonlyEntries = new ReadOnlyCollection<PoEntry>(entries);
             searchEntries = new Dictionary<string, PoEntry>();
@@ -59,24 +59,8 @@ namespace Yarhl.Media.Text
         /// </summary>
         /// <value>The header.</value>
         public PoHeader Header {
-            get {
-                return header;
-            }
-
-            set {
-                if (value == null) {
-                    header = null;
-                } else {
-                    if (string.IsNullOrEmpty(value.ProjectIdVersion))
-                        throw new FormatException(nameof(value.ProjectIdVersion) + " is empty");
-                    if (string.IsNullOrEmpty(value.ReportMsgidBugsTo))
-                        throw new FormatException(nameof(value.ReportMsgidBugsTo) + " is empty");
-                    if (string.IsNullOrEmpty(value.Language))
-                        throw new FormatException(nameof(value.Language) + " is empty");
-
-                    header = value;
-                }
-            }
+            get;
+            set;
         }
 
         /// <summary>
@@ -125,7 +109,7 @@ namespace Yarhl.Media.Text
         /// <param name="original">Original text from the entry.</param>
         /// <param name="context">Context text from the entry.</param>
         /// <returns>The found entry or null if not found.</returns>
-        public PoEntry FindEntry(string original, string context = null)
+        public PoEntry? FindEntry(string original, string? context = null)
         {
             if (string.IsNullOrEmpty(original))
                 throw new ArgumentNullException(nameof(original));
@@ -137,10 +121,8 @@ namespace Yarhl.Media.Text
         /// <inheritdoc />
         public virtual object DeepClone()
         {
-            Po clone = new Po();
-            if (header != null) {
-                clone.header = new PoHeader(header);
-            }
+            var clonedHeader = new PoHeader(Header);
+            Po clone = new Po(clonedHeader);
 
             foreach (PoEntry entry in entries)
             {
@@ -155,7 +137,7 @@ namespace Yarhl.Media.Text
             return GetKey(entry.Original, entry.Context);
         }
 
-        static string GetKey(string original, string context)
+        static string GetKey(string original, string? context)
         {
             return original + "||" + (context ?? string.Empty);
         }
@@ -168,7 +150,7 @@ namespace Yarhl.Media.Text
                         "different translations.");
             }
 
-            if (newEntry.Reference != null)
+            if (!string.IsNullOrEmpty(newEntry.Reference))
                 current.Reference += "," + newEntry.Reference;
         }
     }

--- a/src/Yarhl.Media/Text/Po2Binary.cs
+++ b/src/Yarhl.Media/Text/Po2Binary.cs
@@ -31,8 +31,12 @@ namespace Yarhl.Media.Text
         /// <summary>
         /// Convert the specified PO into a Binary stream.
         /// </summary>
-        /// <returns>The converted stream.</returns>
         /// <param name="source">Source PO.</param>
+        /// <returns>The converted stream.</returns>
+        /// <remarks>
+        /// It writes the header only if <see cref="PoHeader.ProjectIdVersion"/>
+        /// is not empty.
+        /// </remarks>
         public BinaryFormat Convert(Po source)
         {
             if (source == null)
@@ -41,7 +45,7 @@ namespace Yarhl.Media.Text
             BinaryFormat binary = new BinaryFormat();
             TextDataWriter writer = new TextDataWriter(binary.Stream);
 
-            if (source.Header != null)
+            if (!string.IsNullOrEmpty(source.Header.ProjectIdVersion))
                 WriteHeader(source.Header, writer);
 
             foreach (var entry in source.Entries) {

--- a/src/Yarhl.Media/Text/PoEntry.cs
+++ b/src/Yarhl.Media/Text/PoEntry.cs
@@ -33,6 +33,13 @@ namespace Yarhl.Media.Text
         {
             Original = string.Empty;
             Translated = string.Empty;
+            Context = string.Empty;
+            TranslatorComment = string.Empty;
+            ExtractedComments = string.Empty;
+            Reference = string.Empty;
+            Flags = string.Empty;
+            PreviousContext = string.Empty;
+            PreviousOriginal = string.Empty;
         }
 
         /// <summary>
@@ -40,6 +47,7 @@ namespace Yarhl.Media.Text
         /// </summary>
         /// <param name="original">Original text to translate.</param>
         public PoEntry(string original)
+            : this()
         {
             Original = original;
             Translated = string.Empty;
@@ -69,7 +77,7 @@ namespace Yarhl.Media.Text
         /// Gets or sets the original content to translate.
         /// </summary>
         /// <remarks>
-        /// <para>Entris with the same original content will be merged.</para>
+        /// <para>Entries with the same original content will be merged.</para>
         /// </remarks>
         /// <value>The original content.</value>
         public string Original { get; set; }

--- a/src/Yarhl.Media/Text/PoHeader.cs
+++ b/src/Yarhl.Media/Text/PoHeader.cs
@@ -32,6 +32,14 @@ namespace Yarhl.Media.Text
         /// </summary>
         public PoHeader()
         {
+            ProjectIdVersion = string.Empty;
+            ReportMsgidBugsTo = string.Empty;
+            Language = string.Empty;
+            CreationDate = DateTime.Now.ToShortDateString();
+            RevisionDate = string.Empty;
+            LastTranslator = string.Empty;
+            LanguageTeam = string.Empty;
+            PluralForms = string.Empty;
             Extensions = new Dictionary<string, string>();
         }
 
@@ -47,7 +55,6 @@ namespace Yarhl.Media.Text
             ProjectIdVersion = id;
             ReportMsgidBugsTo = reporter;
             Language = lang;
-            CreationDate = DateTime.Now.ToShortDateString();
         }
 
         /// <summary>

--- a/src/Yarhl.Media/Yarhl.Media.csproj
+++ b/src/Yarhl.Media/Yarhl.Media.csproj
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <Description>Yarhl plugin with support of text converters.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Yarhl.UnitTests/IO/DataWriterTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataWriterTests.cs
@@ -1091,6 +1091,7 @@ namespace Yarhl.UnitTests.IO
             string nullValue = null;
             Assert.Throws<ArgumentNullException>(() => writer.WriteOfType(nullType, 1));
             Assert.Throws<ArgumentNullException>(() => writer.WriteOfType(typeof(string), nullValue));
+            Assert.Throws<ArgumentNullException>(() => writer.WriteOfType<string>(nullValue));
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/StreamFormat/StreamWrapperTests.cs
+++ b/src/Yarhl.UnitTests/IO/StreamFormat/StreamWrapperTests.cs
@@ -37,16 +37,6 @@ namespace Yarhl.UnitTests.IO.StreamFormat
         }
 
         [Test]
-        public void FeaturePropertiesDefaults()
-        {
-            using var wrapper = new StreamWrapperImpl();
-            Assert.That(wrapper.CanRead, Is.True);
-            Assert.That(wrapper.CanWrite, Is.True);
-            Assert.That(wrapper.CanSeek, Is.True);
-            Assert.That(wrapper.CanTimeout, Is.False);
-        }
-
-        [Test]
         public void FeaturePropertiesFromBaseStream()
         {
             var stream = new MemoryStream(new byte[2], writable: false);
@@ -278,10 +268,6 @@ namespace Yarhl.UnitTests.IO.StreamFormat
 
         private sealed class StreamWrapperImpl : StreamWrapper
         {
-            public StreamWrapperImpl()
-            {
-            }
-
             public StreamWrapperImpl(Stream stream)
                 : base(stream)
             {

--- a/src/Yarhl.UnitTests/IO/TextDataReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/TextDataReaderTests.cs
@@ -366,10 +366,12 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadToTokenWhenEOFReturnsNull()
+        public void ReadToTokenWhenEOFThrows()
         {
             var reader = new TextDataReader(stream);
-            Assert.IsNull(reader.ReadToToken("3"));
+            Assert.That(
+                () => reader.ReadToToken("3"),
+                Throws.InstanceOf<EndOfStreamException>());
         }
 
         [Test]
@@ -608,13 +610,17 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadLineWhenEOFReturnsNull()
+        public void ReadLineWhenEOFThrowsException()
         {
             var reader = new TextDataReader(stream);
-            Assert.IsNull(reader.ReadLine());
+            Assert.That(
+                () => reader.ReadLine(),
+                Throws.InstanceOf<EndOfStreamException>());
 
             reader.AutoNewLine = false;
-            Assert.IsNull(reader.ReadLine());
+            Assert.That(
+                () => reader.ReadLine(),
+                Throws.InstanceOf<EndOfStreamException>());
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/Media/Text/Po2BinaryTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/Po2BinaryTests.cs
@@ -254,7 +254,8 @@ msgstr ""translated""
             var newPo = ConvertStringToPo(text);
 
             CompareText(ConvertFormat.To<BinaryFormat>(testPo), text);
-            Assert.IsNull(newPo.Header);
+            Assert.That(newPo.Header, Is.Not.Null);
+            Assert.That(newPo.Header.ProjectIdVersion, Is.Empty);
             Assert.AreEqual(2, newPo.Entries.Count);
         }
 

--- a/src/Yarhl.UnitTests/Media/Text/PoEntryTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/PoEntryTests.cs
@@ -30,18 +30,18 @@ namespace Yarhl.UnitTests.Media.Text
         public void DefaultValues()
         {
             PoEntry entry = new PoEntry();
-            Assert.AreEqual(string.Empty, entry.Original);
-            Assert.AreEqual(string.Empty, entry.Translated);
-            Assert.IsNull(entry.Context);
-            Assert.IsNull(entry.TranslatorComment);
-            Assert.IsNull(entry.ExtractedComments);
-            Assert.IsNull(entry.Reference);
-            Assert.IsNull(entry.Flags);
-            Assert.IsNull(entry.PreviousContext);
-            Assert.IsNull(entry.PreviousOriginal);
+            Assert.That(entry.Original, Is.Empty);
+            Assert.That(entry.Translated, Is.Empty);
+            Assert.That(entry.Context, Is.Empty);
+            Assert.That(entry.TranslatorComment, Is.Empty);
+            Assert.That(entry.ExtractedComments, Is.Empty);
+            Assert.That(entry.Reference, Is.Empty);
+            Assert.That(entry.Flags, Is.Empty);
+            Assert.That(entry.PreviousContext, Is.Empty);
+            Assert.That(entry.PreviousOriginal, Is.Empty);
 
             entry = new PoEntry("original");
-            Assert.AreEqual("original", entry.Original);
+            Assert.That(entry.Original, Is.EqualTo("original"));
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/Media/Text/PoHeaderTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/PoHeaderTests.cs
@@ -30,21 +30,22 @@ namespace Yarhl.UnitTests.Media.Text
         public void DefaultValues()
         {
             var header = new PoHeader();
-            Assert.IsNull(header.ProjectIdVersion);
-            Assert.IsNull(header.ReportMsgidBugsTo);
+            Assert.That(header.ProjectIdVersion, Is.Empty);
+            Assert.That(header.ReportMsgidBugsTo, Is.Empty);
+            Assert.That(header.Language, Is.Empty);
 
             header = new PoHeader("myID", "yo", "es");
             Assert.AreEqual("myID", header.ProjectIdVersion);
             Assert.AreEqual("yo", header.ReportMsgidBugsTo);
             Assert.AreEqual(DateTime.Now.ToShortDateString(), header.CreationDate);
-            Assert.AreEqual(null, header.RevisionDate);
-            Assert.AreEqual(null, header.LastTranslator);
-            Assert.AreEqual(null, header.LanguageTeam);
+            Assert.That(header.RevisionDate, Is.Empty);
+            Assert.That(header.LastTranslator, Is.Empty);
+            Assert.That(header.LanguageTeam, Is.Empty);
             Assert.AreEqual("es", header.Language);
             Assert.AreEqual("1.0", PoHeader.MimeVersion);
             Assert.AreEqual("text/plain; charset=UTF-8", PoHeader.ContentType);
             Assert.AreEqual("8bit", PoHeader.ContentTransferEncoding);
-            Assert.AreEqual(null, header.PluralForms);
+            Assert.That(header.PluralForms, Is.Empty);
             Assert.IsNotNull(header.Extensions);
             Assert.IsEmpty(header.Extensions);
         }

--- a/src/Yarhl.UnitTests/Media/Text/PoTests.cs
+++ b/src/Yarhl.UnitTests/Media/Text/PoTests.cs
@@ -31,7 +31,7 @@ namespace Yarhl.UnitTests.Media.Text
         public void DefaultValues()
         {
             var po = new Po();
-            Assert.IsNull(po.Header);
+            Assert.That(po.Header, Is.Not.Null);
             Assert.IsEmpty(po.Entries);
         }
 
@@ -57,27 +57,6 @@ namespace Yarhl.UnitTests.Media.Text
         {
             var po = CreateDummyFormat();
             Assert.That(() => po.Header = null, Throws.Nothing);
-        }
-
-        [Test]
-        public void SetHeaderWithMissingFieldsThrowsException()
-        {
-            var po = CreateDummyFormat();
-            var header = new PoHeader();
-
-            var exception = Throws.InstanceOf<FormatException>()
-                .With.Message.EqualTo("ProjectIdVersion is empty");
-            Assert.That(() => po.Header = header, exception);
-
-            header.ProjectIdVersion = "id";
-            exception = Throws.InstanceOf<FormatException>()
-                .With.Message.EqualTo("ReportMsgidBugsTo is empty");
-            Assert.That(() => po.Header = header, exception);
-
-            header.ReportMsgidBugsTo = "yo";
-            exception = Throws.InstanceOf<FormatException>()
-                .With.Message.EqualTo("Language is empty");
-            Assert.That(() => po.Header = header, exception);
         }
 
         [Test]

--- a/src/Yarhl/FileFormat/ConverterMetadata.cs
+++ b/src/Yarhl/FileFormat/ConverterMetadata.cs
@@ -27,13 +27,26 @@ namespace Yarhl.FileFormat
     public class ConverterMetadata : IExportMetadata
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ConverterMetadata" /> class.
+        /// </summary>
+        public ConverterMetadata()
+        {
+            // MEF should always set these properties, so they won't be null.
+            // We set some initial values to ensure later they are not set to null.
+            Name = "<invalid>";
+            Type = typeof(ConverterMetadata);
+            InternalSources = Type.EmptyTypes;
+            InternalDestinations = Type.EmptyTypes;
+        }
+
+        /// <summary>
         /// Gets or sets the full name of the type. Shortcut of Type.FullName.
         /// </summary>
         /// <value>The full name of the type.</value>
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets the type of class implemeting the converter.
+        /// Gets or sets the type of class implementing the converter.
         /// </summary>
         /// <value>Type of the converter.</value>
         public Type Type { get; set; }
@@ -58,12 +71,8 @@ namespace Yarhl.FileFormat
         /// <returns>List of source types that can convert from.</returns>
         public Type[] GetSources()
         {
-            if (!(InternalSources is Type[] sourceList)) {
-                if (InternalSources != null) {
-                    sourceList = new[] { (Type)InternalSources };
-                } else {
-                    sourceList = Type.EmptyTypes;
-                }
+            if (InternalSources is not Type[] sourceList) {
+                sourceList = new[] { (Type)InternalSources };
             }
 
             return sourceList;
@@ -75,12 +84,8 @@ namespace Yarhl.FileFormat
         /// <returns>Destination types it can convert to.</returns>
         public Type[] GetDestinations()
         {
-            if (!(InternalDestinations is Type[] destList)) {
-                if (InternalDestinations != null) {
-                    destList = new[] { (Type)InternalDestinations };
-                } else {
-                    destList = Type.EmptyTypes;
-                }
+            if (InternalDestinations is not Type[] destList) {
+                destList = new[] { (Type)InternalDestinations };
             }
 
             return destList;
@@ -124,11 +129,11 @@ namespace Yarhl.FileFormat
                 throw new ArgumentNullException(nameof(dest));
 
             Type[] sources = GetSources();
-            Type[] dests = GetDestinations();
+            Type[] destinations = GetDestinations();
 
             for (int i = 0; i < sources.Length; i++) {
                 bool matchSource = sources[i].IsAssignableFrom(source);
-                bool matchDest = dest.IsAssignableFrom(dests[i]);
+                bool matchDest = dest.IsAssignableFrom(destinations[i]);
                 if (matchSource && matchDest) {
                     return true;
                 }

--- a/src/Yarhl/FileFormat/FormatMetadata.cs
+++ b/src/Yarhl/FileFormat/FormatMetadata.cs
@@ -27,6 +27,17 @@ namespace Yarhl.FileFormat
     public class FormatMetadata : IExportMetadata
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="FormatMetadata" /> class.
+        /// </summary>
+        public FormatMetadata()
+        {
+            // MEF should always set these properties, so they won't be null.
+            // We set some initial values to ensure later they are not set to null.
+            Name = "<invalid>";
+            Type = typeof(FormatMetadata);
+        }
+
+        /// <summary>
         /// Gets or sets the type full name. Shortcut of Type.FullName.
         /// </summary>
         /// <value>The full name of the type.</value>

--- a/src/Yarhl/FileSystem/NavigableNode.cs
+++ b/src/Yarhl/FileSystem/NavigableNode.cs
@@ -78,7 +78,10 @@ namespace Yarhl.FileSystem
         /// <summary>
         /// Gets the parent node.
         /// </summary>
-        public T Parent {
+        /// <returns>
+        /// The reference to the parent node or null if it doesn't have any parent.
+        /// </returns>
+        public T? Parent {
             get;
             private set;
         }
@@ -310,7 +313,7 @@ namespace Yarhl.FileSystem
 
         private bool IsDescendantOf(T node)
         {
-            T current = this.Parent;
+            T? current = this.Parent;
             while (current != null) {
                 if (current == node)
                     return true;

--- a/src/Yarhl/FileSystem/Navigator.cs
+++ b/src/Yarhl/FileSystem/Navigator.cs
@@ -41,7 +41,7 @@ namespace Yarhl.FileSystem
         /// considered to be a full path. Otherwise, it would be a relative
         /// path starting with the node in the argument.</para>
         /// </remarks>
-        public static T SearchNode<T>(T rootNode, string path)
+        public static T? SearchNode<T>(T rootNode, string path)
             where T : NavigableNode<T>
         {
             if (rootNode == null)

--- a/src/Yarhl/FileSystem/Node.cs
+++ b/src/Yarhl/FileSystem/Node.cs
@@ -65,7 +65,7 @@ namespace Yarhl.FileSystem
             if (node!.Format != null && !(node.Format is ICloneableFormat))
                 throw new InvalidOperationException("Format does not implement ICloneableFormat interface.");
 
-            ICloneableFormat newFormat = null;
+            ICloneableFormat? newFormat = null;
             if (node.Format != null) {
                 var oldFormat = node.Format as ICloneableFormat;
                 newFormat = (ICloneableFormat)oldFormat!.DeepClone();
@@ -83,7 +83,7 @@ namespace Yarhl.FileSystem
         /// Gets the current format of the node.
         /// </summary>
         /// <value>The current format.</value>
-        public IFormat Format {
+        public IFormat? Format {
             get;
             private set;
         }
@@ -94,7 +94,7 @@ namespace Yarhl.FileSystem
         /// <value>
         /// DataStream if the format is IBinary, null otherwise.
         /// </value>
-        public DataStream Stream {
+        public DataStream? Stream {
             get { return GetFormatAs<IBinary>()?.Stream; }
         }
 
@@ -114,7 +114,7 @@ namespace Yarhl.FileSystem
         /// </summary>
         /// <returns>The format casted to the type or null if not possible.</returns>
         /// <typeparam name="T">The format type.</typeparam>
-        public T GetFormatAs<T>()
+        public T? GetFormatAs<T>()
             where T : class, IFormat
         {
             if (Disposed)
@@ -139,7 +139,7 @@ namespace Yarhl.FileSystem
         /// If <see langword="true" /> the method will dispose the previous
         /// format.
         /// </param>
-        public void ChangeFormat(IFormat newFormat, bool disposePreviousFormat = true)
+        public void ChangeFormat(IFormat? newFormat, bool disposePreviousFormat = true)
         {
             if (Disposed)
                 throw new ObjectDisposedException(nameof(Node));
@@ -324,7 +324,7 @@ namespace Yarhl.FileSystem
         void AddContainerChildren()
         {
             RemoveChildren();
-            GetFormatAs<NodeContainerFormat>().MoveChildrenTo(this);
+            GetFormatAs<NodeContainerFormat>()?.MoveChildrenTo(this);
         }
 
         void CastAndChangeFormat(object newFormat)

--- a/src/Yarhl/FileSystem/NodeContainerFormat.cs
+++ b/src/Yarhl/FileSystem/NodeContainerFormat.cs
@@ -82,8 +82,8 @@ namespace Yarhl.FileSystem
                     Node child = Root.Children[i];
                     Node foundNode = newNode.Children.FirstOrDefault(node => node.Name == child.Name);
 
-                    if (foundNode != null && child.IsContainer) {
-                        child.GetFormatAs<NodeContainerFormat>()?.MoveChildrenTo(foundNode, true);
+                    if (foundNode != null && child.Format is NodeContainerFormat childFormat) {
+                        childFormat.MoveChildrenTo(foundNode, true);
                     } else {
                         Root.Remove(child);
                         newNode.Add(child);

--- a/src/Yarhl/FileSystem/NodeContainerFormat.cs
+++ b/src/Yarhl/FileSystem/NodeContainerFormat.cs
@@ -83,7 +83,7 @@ namespace Yarhl.FileSystem
                     Node foundNode = newNode.Children.FirstOrDefault(node => node.Name == child.Name);
 
                     if (foundNode != null && child.IsContainer) {
-                        child.GetFormatAs<NodeContainerFormat>().MoveChildrenTo(foundNode, true);
+                        child.GetFormatAs<NodeContainerFormat>()?.MoveChildrenTo(foundNode, true);
                     } else {
                         Root.Remove(child);
                         newNode.Add(child);

--- a/src/Yarhl/IO/DataReader.cs
+++ b/src/Yarhl/IO/DataReader.cs
@@ -249,7 +249,7 @@ namespace Yarhl.IO
         /// <param name="encoding">
         /// Encoding to use or <c>null</c> to use <see cref="DefaultEncoding" />.
         /// </param>
-        public char ReadChar(Encoding encoding = null)
+        public char ReadChar(Encoding? encoding = null)
         {
             return ReadChars(1, encoding)[0];
         }
@@ -268,7 +268,7 @@ namespace Yarhl.IO
         /// <param name="encoding">
         /// Encoding to use or <c>null</c> to use <see cref="DefaultEncoding" />.
         /// </param>
-        public char[] ReadChars(int count, Encoding encoding = null)
+        public char[] ReadChars(int count, Encoding? encoding = null)
         {
             if (encoding == null)
                 encoding = DefaultEncoding;
@@ -313,7 +313,7 @@ namespace Yarhl.IO
         /// <param name="encoding">
         /// Encoding to use or <c>null</c> to use <see cref="DefaultEncoding" />.
         /// </param>
-        public string ReadStringToToken(string token, Encoding encoding = null)
+        public string ReadStringToToken(string token, Encoding? encoding = null)
         {
             if (string.IsNullOrEmpty(token))
                 throw new ArgumentNullException(nameof(token));
@@ -376,7 +376,7 @@ namespace Yarhl.IO
         /// </summary>
         /// <returns>The string.</returns>
         /// <param name="encoding">Optional encoding to use.</param>
-        public string ReadString(Encoding encoding = null)
+        public string ReadString(Encoding? encoding = null)
         {
             return ReadStringToToken("\0", encoding);
         }
@@ -387,7 +387,7 @@ namespace Yarhl.IO
         /// <returns>The string.</returns>
         /// <param name="bytesCount">Size of the string in bytes.</param>
         /// <param name="encoding">Optional encoding to use.</param>
-        public string ReadString(int bytesCount, Encoding encoding = null)
+        public string ReadString(int bytesCount, Encoding? encoding = null)
         {
             if (encoding == null)
                 encoding = DefaultEncoding;
@@ -402,7 +402,7 @@ namespace Yarhl.IO
         /// <returns>The string.</returns>
         /// <param name="sizeType">Type of the size field.</param>
         /// <param name="encoding">Optional encoding to use.</param>
-        public string ReadString(Type sizeType, Encoding encoding = null)
+        public string ReadString(Type sizeType, Encoding? encoding = null)
         {
             if (encoding == null)
                 encoding = DefaultEncoding;
@@ -520,7 +520,7 @@ namespace Yarhl.IO
                     property.SetValue(obj, Enum.ToObject(property.PropertyType, value));
                 } else if (property.PropertyType == typeof(string) && Attribute.IsDefined(property, typeof(BinaryStringAttribute))) {
                     var attr = (BinaryStringAttribute)Attribute.GetCustomAttribute(property, typeof(BinaryStringAttribute));
-                    Encoding encoding = null;
+                    Encoding? encoding = null;
                     if (attr.CodePage != -1) {
                         encoding = Encoding.GetEncoding(attr.CodePage);
                     }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -49,9 +49,9 @@ namespace Yarhl.IO
         readonly bool canExpand;
         readonly bool hasOwnsership;
         readonly StreamInfo streamInfo;
+        readonly Stream baseStream;
 
         bool disposed;
-        Stream baseStream;
         long offset;
         long position;
         long length;
@@ -118,7 +118,7 @@ namespace Yarhl.IO
 
             if (stream is DataStream dataStream) {
                 ParentDataStream = dataStream;
-                BaseStream = dataStream.BaseStream;
+                baseStream = dataStream.BaseStream;
                 Offset = dataStream.Offset + offset;
 
                 if (transferOwnership && !dataStream.hasOwnsership) {
@@ -128,7 +128,7 @@ namespace Yarhl.IO
                 }
             } else {
                 ParentDataStream = null;
-                BaseStream = stream;
+                baseStream = stream;
                 Offset = offset;
             }
 
@@ -183,7 +183,7 @@ namespace Yarhl.IO
         /// Gets the parent DataStream only if this stream was initialized from
         /// a DataStream.
         /// </summary>
-        public DataStream ParentDataStream {
+        public DataStream? ParentDataStream {
             get;
             private set;
         }
@@ -193,7 +193,6 @@ namespace Yarhl.IO
         /// </summary>
         public Stream BaseStream {
             get => baseStream;
-            private set => baseStream = value;
         }
 
         /// <summary>

--- a/src/Yarhl/IO/DataWriter.cs
+++ b/src/Yarhl/IO/DataWriter.cs
@@ -210,7 +210,7 @@ namespace Yarhl.IO
         /// <remarks>
         /// <para>If the encoding is null, it will use the default encoding.</para>
         /// </remarks>
-        public void Write(char ch, Encoding encoding = null)
+        public void Write(char ch, Encoding? encoding = null)
         {
             if (encoding == null)
                 encoding = DefaultEncoding;
@@ -226,7 +226,7 @@ namespace Yarhl.IO
         /// <remarks>
         /// <para>If the encoding is null, it will use the default encoding.</para>
         /// </remarks>
-        public void Write(char[] chars, Encoding encoding = null)
+        public void Write(char[] chars, Encoding? encoding = null)
         {
             if (chars == null)
                 throw new ArgumentNullException(nameof(chars));
@@ -252,7 +252,7 @@ namespace Yarhl.IO
         public void Write(
                 string text,
                 bool nullTerminator = true,
-                Encoding encoding = null,
+                Encoding? encoding = null,
                 int maxSize = -1)
         {
             Write(text, nullTerminator ? "\0" : null, encoding, maxSize);
@@ -274,7 +274,7 @@ namespace Yarhl.IO
                 string text,
                 int fixedSize,
                 bool nullTerminator = true,
-                Encoding encoding = null)
+                Encoding? encoding = null)
         {
             Write(text, fixedSize, nullTerminator ? "\0" : null, encoding);
         }
@@ -296,7 +296,7 @@ namespace Yarhl.IO
                 string text,
                 Type sizeType,
                 bool nullTerminator = false,
-                Encoding encoding = null,
+                Encoding? encoding = null,
                 int maxSize = -1)
         {
             Write(text, sizeType, nullTerminator ? "\0" : null, encoding, maxSize);
@@ -317,8 +317,8 @@ namespace Yarhl.IO
         /// </remarks>
         public void Write(
                 string text,
-                string terminator,
-                Encoding encoding = null,
+                string? terminator,
+                Encoding? encoding = null,
                 int maxSize = -1)
         {
             if (text == null)
@@ -355,8 +355,8 @@ namespace Yarhl.IO
         public void Write(
                 string text,
                 int fixedSize,
-                string terminator,
-                Encoding encoding = null)
+                string? terminator,
+                Encoding? encoding = null)
         {
             if (text == null)
                 throw new ArgumentNullException(nameof(text));
@@ -395,8 +395,8 @@ namespace Yarhl.IO
         public void Write(
                 string text,
                 Type sizeType,
-                string terminator,
-                Encoding encoding = null,
+                string? terminator,
+                Encoding? encoding = null,
                 int maxSize = -1)
         {
             if (text == null)
@@ -499,6 +499,9 @@ namespace Yarhl.IO
         /// <typeparam name="T">The type of the value.</typeparam>
         public void WriteOfType<T>(T val)
         {
+            if (val == null)
+                throw new ArgumentNullException(nameof(val));
+
             WriteOfType(typeof(T), val);
         }
 
@@ -627,7 +630,7 @@ namespace Yarhl.IO
                     WriteOfType(attr.WriteAs, value);
                 } else if (property.PropertyType == typeof(string) && Attribute.IsDefined(property, typeof(BinaryStringAttribute))) {
                     var attr = (BinaryStringAttribute)Attribute.GetCustomAttribute(property, typeof(BinaryStringAttribute));
-                    Encoding encoding = null;
+                    Encoding? encoding = null;
                     if (attr.CodePage != -1) {
                         encoding = Encoding.GetEncoding(attr.CodePage);
                     }

--- a/src/Yarhl/IO/Serialization/Attributes/BinaryStringAttribute.cs
+++ b/src/Yarhl/IO/Serialization/Attributes/BinaryStringAttribute.cs
@@ -78,7 +78,7 @@ namespace Yarhl.IO.Serialization.Attributes
         /// Gets or sets the size value type.
         /// <remarks>Set to null if string doesn't have the length serialized.</remarks>
         /// </summary>
-        public Type SizeType {
+        public Type? SizeType {
             get;
             set;
         }

--- a/src/Yarhl/IO/StreamFormat/LazyFileStream.cs
+++ b/src/Yarhl/IO/StreamFormat/LazyFileStream.cs
@@ -40,6 +40,7 @@ namespace Yarhl.IO.StreamFormat
         /// <param name="path">Path to the file.</param>
         /// <param name="mode">Mode to open the file.</param>
         public LazyFileStream(string path, FileOpenMode mode)
+            : base(null!)
         {
             this.path = path;
             this.mode = mode;

--- a/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
+++ b/src/Yarhl/IO/StreamFormat/StreamWrapper.cs
@@ -31,13 +31,6 @@ namespace Yarhl.IO.StreamFormat
         /// <summary>
         /// Initializes a new instance of the <see cref="StreamWrapper" /> class.
         /// </summary>
-        protected StreamWrapper()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StreamWrapper" /> class.
-        /// </summary>
         /// <param name="stream">The stream to wrap.</param>
         protected StreamWrapper(Stream stream)
         {

--- a/src/Yarhl/IO/TextDataReader.cs
+++ b/src/Yarhl/IO/TextDataReader.cs
@@ -72,7 +72,7 @@ namespace Yarhl.IO
 
             Stream = stream as DataStream ?? new DataStream(stream, 0, stream.Length, false);
             Encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
-            NewLine = Environment.NewLine;
+            newLine = Environment.NewLine;
             AutoNewLine = true;
 
             reader = new DataReader(stream) {
@@ -152,16 +152,19 @@ namespace Yarhl.IO
         /// <summary>
         /// Reads a string until a string / token is found.
         /// </summary>
-        /// <returns>The read string.</returns>
         /// <param name="token">Token to find.</param>
+        /// <returns>The read string or null.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// If the stream position is at the end.
+        /// </exception>
         public string ReadToToken(string token)
         {
             if (string.IsNullOrEmpty(token))
                 throw new ArgumentNullException(nameof(token));
 
-            // If starting is EOF, then return null
+            // If starting is EOF, then throw exception.
             if (Stream.Position >= Stream.Length) {
-                return null;
+                throw new EndOfStreamException();
             }
 
             SkipPreamble();

--- a/src/Yarhl/PluginManager.cs
+++ b/src/Yarhl/PluginManager.cs
@@ -48,16 +48,16 @@ namespace Yarhl
         };
 
         static readonly object LockObj = new object();
-        static PluginManager singleInstance;
+        static PluginManager? singleInstance;
 
-        CompositionHost container;
+        readonly CompositionHost container;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PluginManager"/> class.
         /// </summary>
         PluginManager()
         {
-            InitializeContainer();
+            container = InitializeContainer();
         }
 
         /// <summary>
@@ -220,7 +220,7 @@ namespace Yarhl
                 .LoadAssemblies();
         }
 
-        void InitializeContainer()
+        static CompositionHost InitializeContainer()
         {
             var conventions = new ConventionBuilder();
             DefineFormatConventions(conventions);
@@ -247,7 +247,7 @@ namespace Yarhl
                 containerConfig.WithAssemblies(LoadAssemblies(pluginFiles));
             }
 
-            container = containerConfig.CreateContainer();
+            return containerConfig.CreateContainer();
         }
     }
 }

--- a/src/Yarhl/Yarhl.csproj
+++ b/src/Yarhl/Yarhl.csproj
@@ -4,7 +4,8 @@
   <PropertyGroup>
     <Description>Library to translation projects. It provides features for implementing file formats, converters and a virtual file system.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

Introduced with C# 8.0, we can annotate the code to specify if a reference-type variable can be null or not. Then, we can enable a new static analysis check that check for potential code paths that will de-reference a null pointer, throwing a `NullReferenceException`.
Annotating the API allows user to enable the feature as well and ensure a safe usage of the code. Fix all the related warnings

This is introducing the following breaking changes:
- `TextDataReader` will not return `null` string if it starts reading from the end already. It will throw `EndOfStreamException`.
- `Po` initializes an empty header.
- Properties of `PoHeader` are initialized to an empty string instead of null values, `CreationDate` is set to current time.
- The setter of `Po.Header` will not check if the header has some required non-empty properties.
- `Po2Binary` will write the PO header only if `ProjectIdVersion` is non-empty instead of checking if the `Header` property is null.

### Example

To enable the feature in any user project, just set `<Nullable>enable</Nullable>` in the csproj.
