### PR TITLE
Fix behavior of DataStream.Seek when SeekOrigin is End

### DIFF
--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -618,6 +618,9 @@ namespace Yarhl.UnitTests.IO
             DataStream stream = new DataStream(baseStream, 0, 2, false);
             stream.Seek(0, SeekOrigin.End);
             Assert.AreEqual(2, stream.Position);
+            Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek(1, SeekOrigin.End));
+            stream.Seek(-2, SeekOrigin.End);
+            Assert.AreEqual(0, stream.Position);
             stream.Dispose();
         }
 
@@ -918,7 +921,7 @@ namespace Yarhl.UnitTests.IO
             baseStream.WriteByte(0xCA);
             baseStream.WriteByte(0xFE);
             DataStream stream = new DataStream(baseStream, 0, 2, false);
-            stream.Seek(1, SeekOrigin.End);
+            stream.Seek(-1, SeekOrigin.End);
             byte[] buffer = new byte[2];
             Assert.DoesNotThrow(() => stream.Read(buffer, 0, 2));
             Assert.AreEqual(2, stream.Position);

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -348,7 +348,7 @@ namespace Yarhl.IO
                     Position = offset;
                     break;
                 case SeekOrigin.End:
-                    Position = Length - offset;
+                    Position = Length + offset;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(origin));


### PR DESCRIPTION
### Description

**This is a breaking change**

The method `DataStream.Seek` didn't behave like `Stream.Seek` when using `SeekOrigin.End`. Now, a negative offset will move the stream position towards the beginning of the stream.

### Example

```csharp
stream.Seek(-2, SeekOrigin.End); // move the stream position to length - 2
```
