### PR TITLE
Deprecate .NET Framework

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (console)",
+            "name": ".NET Launch (console)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "Cake: Run Build for release",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,51 +5,52 @@ Thanks for taking the time to contribute! :sparkles:
 In this document you will find all the information you need to make sure that
 Yarhl continues to be the high-quality product we want to be!
 
-## Reporting issues
+## Reporting features and issues
 
 ### Issues
 
 When reporting a problem, be as specific as possible. Ideally, you should
-provide an small snippet of code that reproduces the issue. Try to provide also
-the following information:
-
-- OS: Linux / Windows / Mac OS
-- Runtime: version of .NET
-- Version of Yarhl
-- Stacktrace if any
-- What's happening and what you expect to happen
+provide an small snippet of code that reproduces the issue. Please fill the
+default template so we can have all the required information to address the
+issue.
 
 ### Features
 
+Features are requested and handled as GitHub _issues_.
+
 If you want to ask for a new feature, first make sure it hasn't been reported
 yet by using the search box in the issue tab. Make sure that the feature aligns
-with the direction of the project. **Do not ask for tools for games or
-translations**. This is an abstract library for all kind of converter programs.
+with the direction of the project.
+
+**Do not ask for tools for games or translations**. This is an abstract library
+for all kind of converter programs.
 
 ## Pull Request
 
-Before starting a pull request, create an issue requesting the feature you would
-like to see and implement. If you are fixing a bug, create also an issue to be
-able to track the problem. State that you would like to work on that. The team
-will reply to the issue as soon as possible, discussing the proposal if needed.
-This guarantee that later on the Pull Request we don't reject the proposal
-without having a discussion first and we don't waste time.
+Before starting a pull request, create an issue
+[requesting the feature](#features) you would like to see and implement. If you
+are fixing a bug, create also an issue to be able to track the problem.
+
+In the issue/feature request specify that that you would like to work on that.
+The team will reply as soon as possible to discuss the proposal. This guarantee
+that in any later Pull Request we don't reject the proposal without having a
+discussion first and we don't waste your lovely time.
 
 In general, the process to create a pull request is:
 
 1. Create an issue describing the bug or feature and state you would like to
    work on that.
 2. The team will cheer you and/or discuss with you the issue.
-3. Fork the project.
+3. Fork the project (if not done already).
 4. Clone your forked project and create a git branch.
 5. Make the necessary code changes in as many commits as you want. The commit
    message should follow this convention:
 
-```plain
-:emoji: Short description #IssueID
+   ```plain
+   :emoji: Short description #IssueID
 
-Long description if needed.
-```
+   Long description if needed.
+   ```
 
 6. Create a pull request. After reviewing your changes and making any new
    commits if needed, the team will approve and merge it.
@@ -58,6 +59,9 @@ For a complete list of emoji description see
 [this repository](https://github.com/slashsBin/styleguide-git-commit-message#suggested-emojis).
 
 ## Code Guidelines
+
+The project includes a `.editorconfig` file that ensures the code style is
+consistent. It should be supported in any common IDE.
 
 We follow the following standard guidelines with custom changes:
 
@@ -105,12 +109,9 @@ We focus on code-quality to make ours and others life easier. For that reason:
 - :heavy_check_mark: **DO** write documentation for any public type and field.
 - :heavy_check_mark: **DO** write a test for all the possible code branches of
   your methods. Use a TDD approach.
-- :heavy_check_mark: **DO** seek for 100% test coverage.
+- :heavy_check_mark: **DO** seek for test coverage.
 - :heavy_check_mark: **DO** seek for compiler warning free code.
-- :heavy_check_mark: **DO** check the code with StyleCop for style issues.
-- :heavy_check_mark: **DO** check the code with Gendarme for design issues.
-- :heavy_check_mark: **DO** review the results of SonarQube in the Pull Request.
-- :heavy_check_mark: **DO** make sure the CI pass.
+- :heavy_check_mark: **DO** make sure the CI build pass.
 
 ### Style Guidelines
 
@@ -130,8 +131,9 @@ We focus on code-quality to make ours and others life easier. For that reason:
 
 #### Line length
 
-- :heavy_check_mark: **DO** use a limit of 80 columns. If you need to wrap, move
-  to the next line with one extra indentation level.
+- :heavy_check_mark: **DO** use a limit of 120 characters per line (recommended
+  80). If you need to wrap, move to the next line with one extra indentation
+  level.
 - :heavy_check_mark: **DO** put all the arguments in a new line if they don't
   fit.
 - :heavy_check_mark: **DO** use local variables to make small conditions.
@@ -157,7 +159,8 @@ void Method(
 
 #### Layout
 
-- :heavy_check_mark: **DO** define a type (class / struct / enum) per file.
+- :heavy_check_mark: **DO** define each type (class / struct / enum / record) in
+  a different file.
 - :heavy_check_mark: **DO** separate methods and properties with new lines.
 - :heavy_check_mark: **DO** place the elements in this order: private fields,
   constructors, properties, methods, nested types. Place first static fields and
@@ -169,13 +172,6 @@ void Method(
 - :x: **DO NOT** use space before opening parenthesis calling methods or
   indexers, between the parenthesis and the arguments or between the generic
   types.
-
-```csharp
-Method ( a );
-array [ 10 ];
-var list = new List <int> ();
-```
-
 - :heavy_check_mark: **DO** use the following convention:
 
 ```csharp
@@ -242,7 +238,12 @@ for (int i = 0; i < 2; i++) {
   checking.
 
 ```csharp
-if (a) {
+if (a is null)
+    throw new ArgumentNullException(nameof(a));
+if (b is null)
+    throw new ArgumentNullException(nameof(b));
+
+if (a.Color == Colors.Blue) {
     Code();
 }
 ```
@@ -277,6 +278,11 @@ public int Property {
 
 ```csharp
 void EmptyMethod()
+{
+}
+
+MyConstructor(int a)
+    : base(a)
 {
 }
 ```
@@ -317,31 +323,25 @@ public int Text {
 - :heavy_check_mark: **DO** put the license in the file header with this format:
 
 ```csharp
-//
-// <FileName>.cs
-//
-// Author:
-//       <AuthorName> <email@example.com>
-//
-// Copyright (c) <Year> <AuthorName>
-//
+// Copyright (c) <year> <author or team>
+
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 ```
 
 ### Naming
@@ -351,7 +351,7 @@ public int Text {
 ```csharp
 void Method(string myArgument)
 
-class MyClass
+public class MyClass
 {
     string myString;
     int veryImportantValue;
@@ -368,7 +368,7 @@ class MyClass
   same name.
 
 ```csharp
-class Foo
+public class Foo
 {
     int bar;
 
@@ -423,15 +423,7 @@ var dict = new Dictionary<string, int> {
 };
 ```
 
-### Redundant visibility
-
-- :x: **DO NOT** use the `private` keyword to indicate internal fields since
-  it's already the default visibility.
-
 ### Usings
-
-- :heavy_check_mark: **DO** put the `using` inside the namespace.
-- :heavy_check_mark: **DO** include all the namespaces you are using.
 
 - :heavy_check_mark: **DO** use the `using` statement for `IDisposable` types.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ provide an small snippet of code that reproduces the issue. Try to provide also
 the following information:
 
 - OS: Linux / Windows / Mac OS
-- Runtime: .NET Framework, Mono, .NET 6
+- Runtime: version of .NET
 - Version of Yarhl
 - Stacktrace if any
 - What's happening and what you expect to happen

--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ Stable releases are available from nuget.org:
 - [Yarhl](https://www.nuget.org/packages/Yarhl)
 - [Yarhl.Media](https://www.nuget.org/packages/Yarhl.Media)
 
-The libraries target .NET Standard 2.0. The tests (so the library) runs with the
-supported runtimes:
-
-- .NET 6.0
-- .NET Framework 4.8 or Mono (latest on CI)
+The libraries only support the latest version of .NET and its LTS (.NET 6).
 
 Preview releases can be found in this
 [Azure DevOps package repository](https://dev.azure.com/SceneGate/SceneGate/_packaging?_a=feed&feed=SceneGate-Preview).

--- a/build.cake
+++ b/build.cake
@@ -18,7 +18,7 @@ Task("Prepare-IntegrationTests")
     .Does<BuildInfo>(info =>
 {
     // Copy a good and bad plugin to test the assembly load logic
-    string pluginPath = $"src/Yarhl.Media/bin/{info.Configuration}/netstandard2.0/Yarhl.Media.dll";
+    string pluginPath = $"src/Yarhl.Media/bin/{info.Configuration}/net6.0/Yarhl.Media.dll";
     string badPluginPath = info.SolutionFile; // this isn't a DLL for sure :D
 
     string outputBasePath = $"src/Yarhl.IntegrationTests/bin/{info.Configuration}";

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -4,8 +4,8 @@
         "src": [
           {
             "files": [
-              "Yarhl/Yarhl.csproj",
-              "Yarhl.Media/Yarhl.Media.csproj"
+              "Yarhl/bin/**/Yarhl.dll",
+              "Yarhl.Media/bin/**/Yarhl.Media.dll"
             ],
             "src": "../src"
           }

--- a/docs/guides/Yarhl-nutshell.md
+++ b/docs/guides/Yarhl-nutshell.md
@@ -61,7 +61,7 @@ several positions.
   position and move.
 - [`PopPosition`](xref:Yarhl.IO.DataStream.PopPosition): restore the last saved
   position.
-- [`RunInPosition`](<xref:Yarhl.IO.DataStream.RunInPosition(System.Action,System.Int64,Yarhl.IO.SeekMode)>):
+- [`RunInPosition`](<xref:Yarhl.IO.DataStream.RunInPosition(System.Action,System.Int64,System.IO.SeekOrigin)>):
   push, run the lambda expression and pop again.
 
 #### Read and Write

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,16 +8,16 @@
         <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
 
         <PackageVersion Include="NUnit" Version="3.13.2" />
-        <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
-        <PackageVersion Include="coverlet.collector" Version="3.1.0" />
+        <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
+        <PackageVersion Include="coverlet.collector" Version="3.1.2" />
         <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
         <PackageVersion Include="Moq" Version="4.16.1" />
 
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 
         <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.32.0.39516" />
-        <PackageVersion Include="Roslynator.Analyzers" Version="3.3.0" />
+        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.36.0.43782" />
+        <PackageVersion Include="Roslynator.Analyzers" Version="4.0.2" />
     </ItemGroup>
 </Project>

--- a/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
+++ b/src/Yarhl.IntegrationTests/Yarhl.IntegrationTests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Description>Plugin integration tests for Yarhl.</Description>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Yarhl.Media/Text/Encodings/EucJpEncoding.cs
+++ b/src/Yarhl.Media/Text/Encodings/EucJpEncoding.cs
@@ -32,10 +32,10 @@ namespace Yarhl.Media.Text.Encodings
     public sealed class EucJpEncoding : Encoding
     {
         static readonly Table TableJis212 =
-            Table.FromResource("Yarhl.Media.Text.Encodings.index-jis0212.txt");
+            Table.FromResource($"{typeof(EucJpEncoding).Namespace}.index-jis0212.txt");
 
         static readonly Table TableJis208 =
-            Table.FromResource("Yarhl.Media.Text.Encodings.index-jis0208.txt");
+            Table.FromResource($"{typeof(EucJpEncoding).Namespace}.index-jis0208.txt");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EucJpEncoding"/> class.
@@ -362,11 +362,12 @@ namespace Yarhl.Media.Text.Encodings
 
                 Stream? stream = null;
                 try {
+                    // Cannot be null as this is a private call with known files
+                    // If the files are not included in the build, tests will fail.
+                    #pragma warning disable SA1009 // False positive due to nullable
                     stream = Assembly.GetExecutingAssembly()
-                        .GetManifestResourceStream(path);
-                    if (stream is null) {
-                        throw new InvalidOperationException($"Resource does not exist: {path}");
-                    }
+                        .GetManifestResourceStream(path)!;
+                    #pragma warning restore SA1009
 
                     using (var reader = new StreamReader(stream)) {
                         stream = null;  // Avoid disposing twice

--- a/src/Yarhl.Media/Text/Encodings/EucJpEncoding.cs
+++ b/src/Yarhl.Media/Text/Encodings/EucJpEncoding.cs
@@ -231,7 +231,7 @@ namespace Yarhl.Media.Text.Encodings
             // 1
             while (stream.Position < stream.Length) {
                 byte[] buffer = new byte[4];
-                stream.Read(buffer, 0, 4);
+                _ = stream.Read(buffer, 0, 4);
                 int codePoint = BitConverter.ToInt32(buffer, 0);
 
                 // 6
@@ -272,13 +272,15 @@ namespace Yarhl.Media.Text.Encodings
         {
             var fallback = EncoderFallback.CreateFallbackBuffer();
             string ch = char.ConvertFromUtf32(codePoint);
-            if (ch.Length == 1)
-                fallback.Fallback(ch[0], 0);
-            else
-                fallback.Fallback(ch[0], ch[1], 0);
+            if (ch.Length == 1) {
+                _ = fallback.Fallback(ch[0], 0);
+            } else {
+                _ = fallback.Fallback(ch[0], ch[1], 0);
+            }
 
-            while (fallback.Remaining > 0)
+            while (fallback.Remaining > 0) {
                 encodedByte(stream, (byte)fallback.GetNextChar());
+            }
         }
 
         /// <summary>
@@ -362,12 +364,15 @@ namespace Yarhl.Media.Text.Encodings
                 try {
                     stream = Assembly.GetExecutingAssembly()
                         .GetManifestResourceStream(path);
+                    if (stream is null) {
+                        throw new InvalidOperationException($"Resource does not exist: {path}");
+                    }
 
                     using (var reader = new StreamReader(stream)) {
                         stream = null;  // Avoid disposing twice
 
                         while (!reader.EndOfStream) {
-                            string line = reader.ReadLine();
+                            string? line = reader.ReadLine();
                             if (string.IsNullOrWhiteSpace(line))
                                 continue;
                             if (line[0] == '#')
@@ -378,7 +383,7 @@ namespace Yarhl.Media.Text.Encodings
                             string indexText = fields[0].TrimStart(' ');
                             int index = System.Convert.ToInt32(indexText, 10);
 
-                            string codeText = fields[1].Substring(2);
+                            string codeText = fields[1][2..];
                             int codePoint = System.Convert.ToInt32(codeText, 16);
 
                             table.Index2CodePoint[index] = codePoint;

--- a/src/Yarhl.Media/Text/ReplacerEntry.cs
+++ b/src/Yarhl.Media/Text/ReplacerEntry.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SceneGate
+﻿// Copyright (c) 2019 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -96,9 +96,9 @@ namespace Yarhl.Media.Text
         /// true if the specified object is equal to the current object;
         /// otherwise, false.
         /// </returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            if (!(obj is ReplacerEntry otherEntry)) {
+            if (obj is not ReplacerEntry otherEntry) {
                 return false;
             }
 

--- a/src/Yarhl.Media/Yarhl.Media.csproj
+++ b/src/Yarhl.Media/Yarhl.Media.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Description>Yarhl plugin with support of text converters.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Yarhl.UnitTests/IO/DataReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataReaderTests.cs
@@ -25,7 +25,6 @@ namespace Yarhl.UnitTests.IO
     using System.Text;
     using NUnit.Framework;
     using Yarhl.IO;
-    using Yarhl.IO.Serialization;
     using Yarhl.IO.Serialization.Attributes;
 
     [TestFixture]
@@ -1176,6 +1175,17 @@ namespace Yarhl.UnitTests.IO
             Assert.AreEqual(1, obj.Int24Value);
         }
 
+        [Test]
+        public void ReflectionReadingDoesNotSupportNullable()
+        {
+            stream.Write(new byte[4], 0, 4);
+            stream.Position = 0;
+
+            Assert.That(
+                () => reader.Read<ObjectWithNullable>(),
+                Throws.InstanceOf<FormatException>());
+        }
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Microsoft.Performance",
             "CA1812:Class never instantiated",
@@ -1459,6 +1469,12 @@ namespace Yarhl.UnitTests.IO
         {
             [BinaryInt24]
             public int Int24Value { get; set; }
+        }
+
+        [Yarhl.IO.Serialization.Attributes.Serializable]
+        private class ObjectWithNullable
+        {
+            public int? NullValue { get; set; }
         }
     }
 }

--- a/src/Yarhl.UnitTests/IO/TextDataReaderTests.cs
+++ b/src/Yarhl.UnitTests/IO/TextDataReaderTests.cs
@@ -75,7 +75,7 @@ namespace Yarhl.UnitTests.IO
         [Test]
         public void CreateWithShiftJisEncoding()
         {
-            // It will automatically register the encodings for .NET Core.
+            // It will automatically register the encodings.
             var reader = new TextDataReader(stream, "shift-jis");
             Assert.That(reader.Encoding.CodePage, Is.EqualTo(932));
         }

--- a/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
+++ b/src/Yarhl.UnitTests/Yarhl.UnitTests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Description>Yarhl unit tests.</Description>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/src/Yarhl/AssemblyUtils.cs
+++ b/src/Yarhl/AssemblyUtils.cs
@@ -26,83 +26,22 @@ namespace Yarhl
     using System.Runtime.Loader;
 
     /// <summary>
-    /// Utilities to work with Assemblies in different frameworks.
+    /// Utilities to work with Assemblies.
     /// </summary>
     static class AssemblyUtils
     {
         /// <summary>
-        /// Load assemblies in different .NET implementations.
+        /// Load assemblies.
         /// </summary>
         /// <param name="paths">List of assemblies to load.</param>
         /// <returns>The assemblies.</returns>
         public static IEnumerable<Assembly> LoadAssemblies(this IEnumerable<string> paths)
-        {
-            if (IsNetFramework()) {
-                return LoadAssembliesNetFramework(paths);
-            }
-
-            return LoadAssembliesNetCore(paths);
-        }
-
-        /// <summary>
-        /// Detect if the application is running with the .NET Framework runtime.
-        /// </summary>
-        /// <returns>
-        /// A value indicating whether the current runtime is
-        /// .NET Framework or not.
-        /// </returns>
-        static bool IsNetFramework()
-        {
-            string framework = RuntimeInformation.FrameworkDescription;
-            return framework.StartsWith(".NET Framework", StringComparison.Ordinal) ||
-                framework.StartsWith("Mono", StringComparison.Ordinal);
-        }
-
-        /// <summary>
-        /// Load assemblies from .NET Core.
-        /// </summary>
-        /// <remarks>
-        /// <para>In .NET Core for some bugs / features we can't use the method
-        /// Assembly.LoadFile because two identical types can return false in
-        /// an equality. For that reason we need to load the assemblies with
-        /// the AssemblyLoadContext which is only available in .NET Core.</para>
-        /// </remarks>
-        /// <param name="paths">List of assemblies paths.</param>
-        /// <returns>The load assemblies.</returns>
-        static IEnumerable<Assembly> LoadAssembliesNetCore(
-            IEnumerable<string> paths)
         {
             List<Assembly> assemblies = new List<Assembly>();
             foreach (string path in paths) {
                 try {
                     Assembly assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
                     assemblies.Add(assembly);
-                } catch (BadImageFormatException) {
-                    // Bad IL. Skip.
-                }
-            }
-
-            return assemblies;
-        }
-
-        /// <summary>
-        /// Load assemblies from .NET Framework.
-        /// </summary>
-        /// <param name="paths">List of assemblies paths.</param>
-        /// <returns>The load assemblies.</returns>
-        static IEnumerable<Assembly> LoadAssembliesNetFramework(
-            IEnumerable<string> paths)
-        {
-            List<Assembly> assemblies = new List<Assembly>();
-            foreach (string path in paths) {
-                try {
-                    // We try to avoid the non-recommended load from file methods.
-                    // Instead we get the full assembly name.
-                    // In the future we could realize assembly validations with
-                    // public keys, name or version.
-                    AssemblyName libName = AssemblyName.GetAssemblyName(path);
-                    Assembly library = Assembly.Load(libName);
-                    assemblies.Add(library);
                 } catch (BadImageFormatException) {
                     // Bad IL. Skip.
                 }

--- a/src/Yarhl/FileSystem/NavigableNode.cs
+++ b/src/Yarhl/FileSystem/NavigableNode.cs
@@ -60,7 +60,6 @@ namespace Yarhl.FileSystem
         /// </summary>
         public string Name {
             get;
-            private set;
         }
 
         /// <summary>
@@ -69,11 +68,7 @@ namespace Yarhl.FileSystem
         /// <remarks>
         /// <para>It includes the names of all the parent nodes and this node.</para>
         /// </remarks>
-        public string Path {
-            get {
-                return (Parent?.Path ?? string.Empty) + NodeSystem.PathSeparator + Name;
-            }
-        }
+        public string Path => (Parent?.Path ?? string.Empty) + NodeSystem.PathSeparator + Name;
 
         /// <summary>
         /// Gets the parent node.
@@ -96,7 +91,6 @@ namespace Yarhl.FileSystem
         /// </summary>
         public IDictionary<string, dynamic> Tags {
             get;
-            private set;
         }
 
         /// <summary>
@@ -129,7 +123,7 @@ namespace Yarhl.FileSystem
                 throw new ArgumentException("Cannot add one parent as child", nameof(node));
 
             // Update the children of the parent
-            node.Parent?.Remove(node);
+            _ = node.Parent?.Remove(node);
 
             // Update the parent of the child
             node.Parent = (T)this;
@@ -326,10 +320,10 @@ namespace Yarhl.FileSystem
 
         private sealed class DefaultNavigableNodeComparer : IComparer<T>
         {
-            public int Compare(T x, T y)
+            public int Compare(T? x, T? y)
             {
                 // x and y cannot be null because Add methods don't allow null parameters.
-                return string.Compare(x.Name, y.Name, StringComparison.CurrentCulture);
+                return string.Compare(x!.Name, y!.Name, StringComparison.CurrentCulture);
             }
         }
     }

--- a/src/Yarhl/FileSystem/NavigableNodeCollection.cs
+++ b/src/Yarhl/FileSystem/NavigableNodeCollection.cs
@@ -46,8 +46,6 @@ namespace Yarhl.FileSystem
         /// </summary>
         /// <param name="name">Node name.</param>
         /// <returns>The node with the same name or null if not found.</returns>
-        public T this[string name] {
-            get { return this.FirstOrDefault((node) => node.Name == name); }
-        }
+        public T? this[string name] => this.FirstOrDefault(node => node?.Name == name);
     }
 }

--- a/src/Yarhl/FileSystem/Navigator.cs
+++ b/src/Yarhl/FileSystem/Navigator.cs
@@ -65,7 +65,7 @@ namespace Yarhl.FileSystem
                 new[] { NodeSystem.PathSeparator },
                 StringSplitOptions.RemoveEmptyEntries);
 
-            T currentNode = rootNode;
+            T? currentNode = rootNode;
             foreach (string segment in paths) {
                 currentNode = currentNode.Children[segment];
                 if (currentNode == null) {

--- a/src/Yarhl/FileSystem/Node.cs
+++ b/src/Yarhl/FileSystem/Node.cs
@@ -62,7 +62,7 @@ namespace Yarhl.FileSystem
         public Node(Node node)
             : this(node != null ? node.Name : string.Empty)
         {
-            if (node!.Format != null && !(node.Format is ICloneableFormat))
+            if (node!.Format != null && node.Format is not ICloneableFormat)
                 throw new InvalidOperationException("Format does not implement ICloneableFormat interface.");
 
             ICloneableFormat? newFormat = null;
@@ -94,9 +94,7 @@ namespace Yarhl.FileSystem
         /// <value>
         /// DataStream if the format is IBinary, null otherwise.
         /// </value>
-        public DataStream? Stream {
-            get { return GetFormatAs<IBinary>()?.Stream; }
-        }
+        public DataStream? Stream => GetFormatAs<IBinary>()?.Stream;
 
         /// <summary>
         /// Gets a value indicating whether the format is a container of nodes.
@@ -105,9 +103,7 @@ namespace Yarhl.FileSystem
         /// <see langword="true"/> if the format is a container; otherwise,
         /// <see langword="false"/>.
         /// </value>
-        public bool IsContainer {
-            get { return Format is NodeContainerFormat; }
-        }
+        public bool IsContainer => Format is NodeContainerFormat;
 
         /// <summary>
         /// Gets the format as the specified type.
@@ -250,7 +246,7 @@ namespace Yarhl.FileSystem
                     "Cannot transform a node without format");
             }
 
-            var result = ConvertFormat.With<TConv, TParam>(param, Format);
+            object result = ConvertFormat.With<TConv, TParam>(param, Format);
             CastAndChangeFormat(result);
 
             return this;

--- a/src/Yarhl/FileSystem/NodeContainerFormat.cs
+++ b/src/Yarhl/FileSystem/NodeContainerFormat.cs
@@ -80,12 +80,12 @@ namespace Yarhl.FileSystem
             } else {
                 for (int i = Root.Children.Count - 1; i >= 0; i--) {
                     Node child = Root.Children[i];
-                    Node foundNode = newNode.Children.FirstOrDefault(node => node.Name == child.Name);
+                    Node? foundNode = newNode.Children.FirstOrDefault(node => node.Name == child.Name);
 
                     if (foundNode != null && child.Format is NodeContainerFormat childFormat) {
                         childFormat.MoveChildrenTo(foundNode, true);
                     } else {
-                        Root.Remove(child);
+                        _ = Root.Remove(child);
                         newNode.Add(child);
                     }
                 }

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -71,8 +71,8 @@ namespace Yarhl.FileSystem
 
             Node currentNode = root;
             foreach (string name in parentNames) {
-                Node subParent = currentNode.Children[name];
-                if (subParent == null) {
+                Node? subParent = currentNode.Children[name];
+                if (subParent is null) {
                     subParent = CreateContainer(name);
                     currentNode.Add(subParent);
                 }
@@ -249,7 +249,7 @@ namespace Yarhl.FileSystem
             // This sanitizes the path and remove double slashes
             dirPath = Path.GetFullPath(dirPath);
 
-            if (dirPath[dirPath.Length - 1] == Path.DirectorySeparatorChar) {
+            if (dirPath[^1] == Path.DirectorySeparatorChar) {
                 dirPath = dirPath.Remove(dirPath.Length - 1);
             }
 
@@ -316,7 +316,7 @@ namespace Yarhl.FileSystem
             // This sanitizes the path and remove double slashes
             dirPath = Path.GetFullPath(dirPath);
 
-            if (dirPath[dirPath.Length - 1] == Path.DirectorySeparatorChar) {
+            if (dirPath[^1] == Path.DirectorySeparatorChar) {
                 dirPath = dirPath.Remove(dirPath.Length - 1);
             }
 
@@ -361,7 +361,7 @@ namespace Yarhl.FileSystem
             // This sanitizes the path and remove double slashes
             dirPath = Path.GetFullPath(dirPath);
 
-            if (dirPath[dirPath.Length - 1] == Path.DirectorySeparatorChar) {
+            if (dirPath[^1] == Path.DirectorySeparatorChar) {
                 dirPath = dirPath.Remove(dirPath.Length - 1);
             }
 
@@ -376,8 +376,8 @@ namespace Yarhl.FileSystem
             folder.Tags["DirectoryInfo"] = new DirectoryInfo(dirPath);
 
             foreach (string filePath in fileList) {
-                string relParent = Path.GetDirectoryName(filePath)
-                                       .Replace(dirPath, string.Empty);
+                string relParent = Path.GetDirectoryName(filePath)?
+                                       .Replace(dirPath, string.Empty) ?? string.Empty;
                 CreateContainersForChild(folder, relParent, FromFile(filePath, mode));
             }
 
@@ -387,7 +387,7 @@ namespace Yarhl.FileSystem
                 }
 
                 int rootPathLength = $"{NodeSystem.PathSeparator}{nodeName}".Length;
-                string nodePath = Path.GetFullPath(string.Concat(dirPath, node.Path.Substring(rootPathLength)));
+                string nodePath = Path.GetFullPath(string.Concat(dirPath, node.Path[rootPathLength..]));
                 node.Tags["DirectoryInfo"] = new DirectoryInfo(nodePath);
             }
 

--- a/src/Yarhl/IO/DataReader.cs
+++ b/src/Yarhl/IO/DataReader.cs
@@ -35,8 +35,7 @@ namespace Yarhl.IO
     {
         static DataReader()
         {
-            // Make sure that the shift-jis encoding is initialized in
-            // .NET Core.
+            // Make sure that the shift-jis encoding is initialized.
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         }
 

--- a/src/Yarhl/IO/DataReader.cs
+++ b/src/Yarhl/IO/DataReader.cs
@@ -485,12 +485,12 @@ namespace Yarhl.IO
 
         dynamic ReadUsingReflection(Type type)
         {
-            object? obj = Activator.CreateInstance(type);
-
-            // Return null for Nullable<T>
-            if (obj is null) {
-                throw new InvalidOperationException("Nullable types are not supported");
-            }
+            // It returns null for Nullable<T>, but as that is a class and
+            // it won't have the serializable attribute, it will throw an
+            // unsupported exception before. So this can't be null at this point.
+            #pragma warning disable SA1009 // False positive
+            object obj = Activator.CreateInstance(type)!;
+            #pragma warning restore SA1009
 
             PropertyInfo[] properties = type.GetProperties(
                 BindingFlags.DeclaredOnly |

--- a/src/Yarhl/IO/DataReader.cs
+++ b/src/Yarhl/IO/DataReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SceneGate
+﻿// Copyright (c) 2019 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -231,7 +231,7 @@ namespace Yarhl.IO
                 throw new EndOfStreamException();
 
             byte[] buffer = new byte[count];
-            Stream.Read(buffer, 0, count);
+            _ = Stream.Read(buffer, 0, count);
             return buffer;
         }
 
@@ -299,7 +299,7 @@ namespace Yarhl.IO
             // takes to get them and decode again with the original fallbacks
             int exactBytes = encoding.GetByteCount(charArray, 0, count);
             charArray = encoding.GetChars(buffer, 0, exactBytes);
-            Stream.Seek(startPos + exactBytes, SeekOrigin.Begin);
+            _ = Stream.Seek(startPos + exactBytes, SeekOrigin.Begin);
 
             return charArray;
         }
@@ -360,12 +360,12 @@ namespace Yarhl.IO
             // Get the final string and the number exact of bytes to seek
             int endPos = matchIndex + token.Length;
             int exactBytes = encoding.GetByteCount(text.ToCharArray(0, endPos));
-            Stream.Seek(startPos + exactBytes, SeekOrigin.Begin);
+            _ = Stream.Seek(startPos + exactBytes, SeekOrigin.Begin);
 
             // Now we know the number of bytes, decode again with the original
             // encoding so it can apply its original decoder fallback.
             text = encoding.GetString(textBuffer.ToArray(), 0, exactBytes);
-            text = text.Substring(0, text.Length - token.Length);
+            text = text[..^token.Length];
 
             return text;
         }
@@ -415,6 +415,7 @@ namespace Yarhl.IO
         /// Reads a field by type.
         /// </summary>
         /// <returns>The field.</returns>
+        /// <remarks>Nullable types are not supported.</remarks>
         /// <param name="type">Type of the field.</param>
         public dynamic ReadByType(Type type)
         {
@@ -478,13 +479,19 @@ namespace Yarhl.IO
 
             long remainingBytes = Stream.Position.Pad(padding) - Stream.Position;
             if (remainingBytes > 0) {
-                Stream.Seek(remainingBytes, SeekOrigin.Current);
+                _ = Stream.Seek(remainingBytes, SeekOrigin.Current);
             }
         }
 
         dynamic ReadUsingReflection(Type type)
         {
-            object obj = Activator.CreateInstance(type);
+            object? obj = Activator.CreateInstance(type);
+
+            // Return null for Nullable<T>
+            if (obj is null) {
+                throw new InvalidOperationException("Nullable types are not supported");
+            }
+
             PropertyInfo[] properties = type.GetProperties(
                 BindingFlags.DeclaredOnly |
                 BindingFlags.Public |
@@ -499,14 +506,14 @@ namespace Yarhl.IO
                 EndiannessMode currentEndianness = Endianness;
                 bool forceEndianness = Attribute.IsDefined(property, typeof(BinaryForceEndiannessAttribute));
                 if (forceEndianness) {
-                    var attr = (BinaryForceEndiannessAttribute)Attribute.GetCustomAttribute(property, typeof(BinaryForceEndiannessAttribute));
-                    Endianness = attr.Mode;
+                    var attr = Attribute.GetCustomAttribute(property, typeof(BinaryForceEndiannessAttribute)) as BinaryForceEndiannessAttribute;
+                    Endianness = attr!.Mode;
                 }
 
                 if (property.PropertyType == typeof(bool) && Attribute.IsDefined(property, typeof(BinaryBooleanAttribute))) {
                     // booleans can only be read if they have the attribute.
-                    var attr = (BinaryBooleanAttribute)Attribute.GetCustomAttribute(property, typeof(BinaryBooleanAttribute));
-                    dynamic value = ReadByType(attr.ReadAs);
+                    var attr = Attribute.GetCustomAttribute(property, typeof(BinaryBooleanAttribute)) as BinaryBooleanAttribute;
+                    dynamic value = ReadByType(attr!.ReadAs);
                     property.SetValue(obj, value == (dynamic)attr.TrueValue);
                 } else if (property.PropertyType == typeof(int) && Attribute.IsDefined(property, typeof(BinaryInt24Attribute))) {
                     // read the number as int24.
@@ -514,13 +521,13 @@ namespace Yarhl.IO
                     property.SetValue(obj, value);
                 } else if (property.PropertyType.IsEnum && Attribute.IsDefined(property, typeof(BinaryEnumAttribute))) {
                     // enums can only be read if they have the attribute.
-                    var attr = (BinaryEnumAttribute)Attribute.GetCustomAttribute(property, typeof(BinaryEnumAttribute));
-                    dynamic value = ReadByType(attr.ReadAs);
+                    var attr = Attribute.GetCustomAttribute(property, typeof(BinaryEnumAttribute)) as BinaryEnumAttribute;
+                    dynamic value = ReadByType(attr!.ReadAs);
                     property.SetValue(obj, Enum.ToObject(property.PropertyType, value));
                 } else if (property.PropertyType == typeof(string) && Attribute.IsDefined(property, typeof(BinaryStringAttribute))) {
-                    var attr = (BinaryStringAttribute)Attribute.GetCustomAttribute(property, typeof(BinaryStringAttribute));
+                    var attr = Attribute.GetCustomAttribute(property, typeof(BinaryStringAttribute)) as BinaryStringAttribute;
                     Encoding? encoding = null;
-                    if (attr.CodePage != -1) {
+                    if (attr!.CodePage != -1) {
                         encoding = Encoding.GetEncoding(attr.CodePage);
                     }
 

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SceneGate
+﻿// Copyright (c) 2019 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -89,7 +89,7 @@ namespace Yarhl.IO
         /// <param name="length">Length of this substream.</param>
         [SuppressMessage("", "S1125: remove unnecessary boolean", Justification = "Readability")]
         public DataStream(Stream stream, long offset, long length)
-            : this(stream, offset, length, (stream is DataStream dataStream) ? dataStream.hasOwnsership : true)
+            : this(stream, offset, length, (stream is not DataStream dataStream) || dataStream.hasOwnsership)
         {
         }
 
@@ -315,13 +315,13 @@ namespace Yarhl.IO
 
             switch (mode) {
                 case SeekMode.Current:
-                    Seek(shift, SeekOrigin.Current);
+                    _ = Seek(shift, SeekOrigin.Current);
                     break;
                 case SeekMode.Start:
-                    Seek(shift, SeekOrigin.Begin);
+                    _ = Seek(shift, SeekOrigin.Begin);
                     break;
                 case SeekMode.End:
-                    Seek(shift, SeekOrigin.End);
+                    _ = Seek(shift, SeekOrigin.End);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(mode));
@@ -383,7 +383,7 @@ namespace Yarhl.IO
                 throw new ObjectDisposedException(nameof(DataStream));
 
             positionStack.Push(Position);
-            Seek(shift, mode);
+            _ = Seek(shift, mode);
         }
 
         /// <summary>
@@ -685,9 +685,9 @@ namespace Yarhl.IO
 
             // Parent dir can be empty if we just specified the file name.
             // In that case, the folder (cwd) already exists.
-            string parentDir = Path.GetDirectoryName(fileOut);
+            string? parentDir = Path.GetDirectoryName(fileOut);
             if (!string.IsNullOrEmpty(parentDir)) {
-                Directory.CreateDirectory(parentDir);
+                _ = Directory.CreateDirectory(parentDir);
             }
 
             // We use FileStream so it creates a file even when the length is zero
@@ -756,8 +756,8 @@ namespace Yarhl.IO
 
             long startPosition = Position;
             long otherStreamStartPosition = otherStream.Position;
-            Seek(0, SeekOrigin.Begin);
-            otherStream.Seek(0, SeekOrigin.Begin);
+            _ = Seek(0, SeekOrigin.Begin);
+            _ = otherStream.Seek(0, SeekOrigin.Begin);
 
             if (Length != otherStream.Length) {
                 return false;
@@ -771,7 +771,7 @@ namespace Yarhl.IO
             while (!EndOfStream && result) {
                 // As we have checked the length before, we assume we read the same
                 int loopLength = Read(buffer1, 0, buffer1.Length);
-                otherStream.Read(buffer2, 0, buffer2.Length);
+                _ = otherStream.Read(buffer2, 0, buffer2.Length);
 
                 for (int i = 0; i < loopLength && result; i++) {
                     if (buffer1[i] != buffer2[i]) {
@@ -780,8 +780,8 @@ namespace Yarhl.IO
                 }
             }
 
-            Seek(startPosition, SeekOrigin.Begin);
-            otherStream.Seek(otherStreamStartPosition, SeekOrigin.Begin);
+            _ = Seek(startPosition, SeekOrigin.Begin);
+            _ = otherStream.Seek(otherStreamStartPosition, SeekOrigin.Begin);
 
             return result;
         }
@@ -809,7 +809,7 @@ namespace Yarhl.IO
                 info => {
                     if (info.NumInstances == 0) {
                         BaseStream.Dispose();
-                        Instances.TryRemove(BaseStream, out _);
+                        _ = Instances.TryRemove(BaseStream, out _);
                     }
                 });
         }
@@ -823,7 +823,7 @@ namespace Yarhl.IO
                 read = buffer.Length;
             }
 
-            stream.Read(buffer, 0, read);
+            _ = stream.Read(buffer, 0, read);
             return read;
         }
 

--- a/src/Yarhl/IO/DataWriter.cs
+++ b/src/Yarhl/IO/DataWriter.cs
@@ -34,8 +34,7 @@ namespace Yarhl.IO
     {
         static DataWriter()
         {
-            // Make sure that the shift-jis encoding is initialized in
-            // .NET Core.
+            // Make sure that the shift-jis encoding is initialized.
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         }
 

--- a/src/Yarhl/IO/TextDataReader.cs
+++ b/src/Yarhl/IO/TextDataReader.cs
@@ -35,8 +35,7 @@ namespace Yarhl.IO
 
         static TextDataReader()
         {
-            // Make sure that the shift-jis encoding is initialized in
-            // .NET Core.
+            // Make sure that the shift-jis encoding is initialized.
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         }
 

--- a/src/Yarhl/IO/TextDataWriter.cs
+++ b/src/Yarhl/IO/TextDataWriter.cs
@@ -33,8 +33,7 @@ namespace Yarhl.IO
 
         static TextDataWriter()
         {
-            // Make sure that the shift-jis encoding is initialized in
-            // .NET Core.
+            // Make sure that the shift-jis encoding is initialized.
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         }
 

--- a/src/Yarhl/Yarhl.csproj
+++ b/src/Yarhl/Yarhl.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Description>Library to translation projects. It provides features for implementing file formats, converters and a virtual file system.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
### Description

Maintaining .NET Framework started to take more time than its potential benefits. .NET 6 is an LTS release, stable and plenty of known frameworks already are supported. We can make cross-platform UI, web and more.
Deprecating .NET Framework will allow to start making use the `Span<>` for efficient API (IO, Encodings, ...) and the new behavior of `FileStream` with symbolic link support.
It allows to use more C# features, including full support of nullable as required for this PR.