### PR TITLE
:sparkles: Support opening nodes from Windows symlinks

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -4,6 +4,8 @@ Task("Define-Project")
     .Description("Fill specific project information")
     .Does<BuildInfo>(info =>
 {
+    info.CoverageTarget = 90; // can't be 100 due to platform-specific code paths
+
     info.AddLibraryProjects("Yarhl");
     info.AddLibraryProjects("Yarhl.Media");
     info.AddTestProjects("Yarhl.UnitTests");

--- a/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
@@ -622,8 +622,8 @@ namespace Yarhl.UnitTests.IO
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
                 using var p = Process.Start("cmd.exe", $"/C mklink {symlinkFile} {originalFile}");
-                Assert.That(p.ExitCode, Is.EqualTo(0));
                 p.WaitForExit();
+                Assert.That(p.ExitCode, Is.EqualTo(0));
             } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
                 using var p = Process.Start("ln", $"-s {originalFile} {symlinkFile}");
                 p.WaitForExit();

--- a/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SceneGate
+﻿// Copyright (c) 2019 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,9 @@
 namespace Yarhl.UnitTests.IO
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
+    using System.Runtime.InteropServices;
     using NUnit.Framework;
     using Yarhl.IO;
     using Yarhl.IO.StreamFormat;
@@ -413,7 +415,7 @@ namespace Yarhl.UnitTests.IO
             Assert.That(File.Exists(tempFile), Is.False);
             Assert.That(
                 () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Read),
-                Throws.Exception);
+                Throws.InstanceOf<FileNotFoundException>());
             Assert.That(
                 () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Write),
                 Throws.Nothing);
@@ -426,16 +428,16 @@ namespace Yarhl.UnitTests.IO
 
             Assert.That(
                 () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Read, 0, 0),
-                Throws.Exception);
+                Throws.InstanceOf<FileNotFoundException>());
             Assert.That(
                 () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Write, 0, 0),
-                Throws.Exception);
+                Throws.Nothing);
             Assert.That(
                 () => DataStreamFactory.FromFile(tempFile, FileOpenMode.ReadWrite, 0, 0),
-                Throws.Exception);
+                Throws.Nothing);
             Assert.That(
                 () => DataStreamFactory.FromFile(tempFile, FileOpenMode.Append, 0, 0),
-                Throws.Exception);
+                Throws.Nothing);
         }
 
         [Test]
@@ -564,6 +566,66 @@ namespace Yarhl.UnitTests.IO
                     DataStreamFactory.FromFile(tempFile, FileOpenMode.Read, 1, 2));
             } finally {
                 File.Delete(tempFile);
+            }
+        }
+
+        [Test]
+        public void CreateFromSymlinkPathRedirectsToTarget()
+        {
+            string originalFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            string symlinkFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Assert.That(File.Exists(originalFile), Is.False);
+            Assert.That(File.Exists(symlinkFile), Is.False);
+
+            try {
+                File.WriteAllBytes(originalFile, new byte[] { 0xCA, 0xFE, 0xBA, 0xBE });
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                    using var p = Process.Start("cmd.exe", $"/C mklink {symlinkFile} {originalFile}");
+                    p.WaitForExit();
+                } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+                    using var p = Process.Start("ln", $"-s {symlinkFile} {originalFile}");
+                    p.WaitForExit();
+                } else {
+                    Assert.Inconclusive("Unknown how to create symlinks for this platform");
+                }
+
+                using var symlinkStream = DataStreamFactory.FromFile(symlinkFile, FileOpenMode.Read);
+                Assert.That(symlinkStream.Length, Is.EqualTo(4));
+                Assert.That(symlinkStream.ReadByte(), Is.EqualTo(0xCA));
+            } finally {
+                File.Delete(symlinkFile);
+                File.Delete(originalFile);
+            }
+        }
+
+        [Test]
+        public void CreateFromSymlinkSectionPathRedirectsToTarget()
+        {
+            string originalFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            string symlinkFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Assert.That(File.Exists(originalFile), Is.False);
+            Assert.That(File.Exists(symlinkFile), Is.False);
+
+            try {
+                File.WriteAllBytes(originalFile, new byte[] { 0xCA, 0xFE, 0xBA, 0xBE });
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                    using var p = Process.Start("cmd.exe", $"/C mklink {symlinkFile} {originalFile}");
+                    p.WaitForExit();
+                } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+                    using var p = Process.Start("ln", $"-s {symlinkFile} {originalFile}");
+                    p.WaitForExit();
+                } else {
+                    Assert.Inconclusive("Unknown how to create symlinks for this platform");
+                }
+
+                using var symlinkStream = DataStreamFactory.FromFile(symlinkFile, FileOpenMode.Read, 2, 2);
+                Assert.That(symlinkStream.Length, Is.EqualTo(2));
+                Assert.That(symlinkStream.ReadByte(), Is.EqualTo(0xBA));
+            } finally {
+                File.Delete(symlinkFile);
+                File.Delete(originalFile);
             }
         }
     }

--- a/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamFactoryTests.cs
@@ -579,16 +579,10 @@ namespace Yarhl.UnitTests.IO
 
             try {
                 File.WriteAllBytes(originalFile, new byte[] { 0xCA, 0xFE, 0xBA, 0xBE });
+                Assert.That(File.Exists(originalFile), Is.True);
 
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                    using var p = Process.Start("cmd.exe", $"/C mklink {symlinkFile} {originalFile}");
-                    p.WaitForExit();
-                } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-                    using var p = Process.Start("ln", $"-s {symlinkFile} {originalFile}");
-                    p.WaitForExit();
-                } else {
-                    Assert.Inconclusive("Unknown how to create symlinks for this platform");
-                }
+                CreateSymlinkFile(originalFile, symlinkFile);
+                Assert.That(File.Exists(symlinkFile), Is.True);
 
                 using var symlinkStream = DataStreamFactory.FromFile(symlinkFile, FileOpenMode.Read);
                 Assert.That(symlinkStream.Length, Is.EqualTo(4));
@@ -604,21 +598,16 @@ namespace Yarhl.UnitTests.IO
         {
             string originalFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             string symlinkFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Console.WriteLine(originalFile);
             Assert.That(File.Exists(originalFile), Is.False);
             Assert.That(File.Exists(symlinkFile), Is.False);
 
             try {
                 File.WriteAllBytes(originalFile, new byte[] { 0xCA, 0xFE, 0xBA, 0xBE });
+                Assert.That(File.Exists(originalFile), Is.True);
 
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                    using var p = Process.Start("cmd.exe", $"/C mklink {symlinkFile} {originalFile}");
-                    p.WaitForExit();
-                } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-                    using var p = Process.Start("ln", $"-s {symlinkFile} {originalFile}");
-                    p.WaitForExit();
-                } else {
-                    Assert.Inconclusive("Unknown how to create symlinks for this platform");
-                }
+                CreateSymlinkFile(originalFile, symlinkFile);
+                Assert.That(File.Exists(symlinkFile), Is.True);
 
                 using var symlinkStream = DataStreamFactory.FromFile(symlinkFile, FileOpenMode.Read, 2, 2);
                 Assert.That(symlinkStream.Length, Is.EqualTo(2));
@@ -626,6 +615,21 @@ namespace Yarhl.UnitTests.IO
             } finally {
                 File.Delete(symlinkFile);
                 File.Delete(originalFile);
+            }
+        }
+
+        private void CreateSymlinkFile(string originalFile, string symlinkFile)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                using var p = Process.Start("cmd.exe", $"/C mklink {symlinkFile} {originalFile}");
+                Assert.That(p.ExitCode, Is.EqualTo(0));
+                p.WaitForExit();
+            } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+                using var p = Process.Start("ln", $"-s {originalFile} {symlinkFile}");
+                p.WaitForExit();
+                Assert.That(p.ExitCode, Is.EqualTo(0));
+            } else {
+                Assert.Inconclusive("Unknown how to create symlinks for this platform");
             }
         }
     }

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -212,6 +212,10 @@ namespace Yarhl.FileSystem
         /// <param name="filePath">File path.</param>
         /// <param name="nodeName">Node name.</param>
         /// <param name="mode">The mode to open the file.</param>
+        /// <remarks>
+        /// <para>Add the tag "FileInfo" with the file info status at the time it's created.</para>
+        /// <para>In the case of Windows Symlinks, it will be the status of the link file, not the target.</para>
+        /// </remarks>
         [SuppressMessage(
             "Reliability",
             "CA2000:Dispose objects before losing scope",

--- a/src/Yarhl/IO/DataStreamFactory.cs
+++ b/src/Yarhl/IO/DataStreamFactory.cs
@@ -172,7 +172,7 @@ namespace Yarhl.IO
             if (string.IsNullOrEmpty(path))
                 throw new ArgumentNullException(nameof(path));
             if (mode == FileOpenMode.Read && !File.Exists(path)) {
-                throw new FileNotFoundException(nameof(path));
+                throw new FileNotFoundException("File to read does not exist: " + path, path);
             }
 
             var info = new FileInfo(path);

--- a/src/Yarhl/IO/StreamFormat/LazyFileStream.cs
+++ b/src/Yarhl/IO/StreamFormat/LazyFileStream.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SceneGate
+﻿// Copyright (c) 2019 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -47,8 +47,16 @@ namespace Yarhl.IO.StreamFormat
 
             // Before the stream is initialized, we can get the
             // length so we can report it without opening the file.
+            // If it's a windows symlink, get the length by opening the stream.
+            // Otherwise we would need P/Invoke calls.
+            // .NET does the redirection of the symlink in FileStream automatically.
             var info = new FileInfo(path);
-            initialLength = info.Exists ? info.Length : 0;
+            if (info.Exists && info.Attributes.HasFlag(FileAttributes.ReparsePoint)) {
+                using var tempStream = new FileStream(path, FileMode.Open);
+                initialLength = tempStream.Length;
+            } else {
+                initialLength = info.Exists ? info.Length : 0;
+            }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
### Description

Support opening a node from a symbolic link file, redirecting to the target instead of opening the symlink itself.
This is a feature provided by `FileStream` of .NET 6, but it requires some small adjustments in the behavior of `LazyFileStream`.
Also fix an issue where opening a non-existing file for writing was throwing an exception.

### Example

1. Create a symbolic link with

```bash
mklink link.nds original.nds
```

2. Open it like a regular file

```csharp
var node = NodeFactory.FromFile("link.nds"); // this is opening original.nds
```

It can be very useful to link to test files without copying them in each repo.