### PR TITLE
:racehorse: Improve memory consumption of DataStream.WriteTo

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,6 +6,7 @@
         <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
         <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
+        <PackageVersion Include="System.Buffers" Version="4.5.1" />
 
         <PackageVersion Include="NUnit" Version="3.13.2" />
         <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/src/Yarhl/Yarhl.csproj
+++ b/src/Yarhl/Yarhl.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="System.Composition" />
     <PackageReference Include="System.Runtime.Loader" />
     <PackageReference Include="System.Text.Encoding.CodePages"/>
+    <PackageReference Include="System.Buffers" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description

Consecutive calls to `DataStream.WriteTo` were allocating arrays upto 70 KB each time. When the number of calls is big, this could cause an unnecessary performance issues, especially impacting the memory.
For instance, in Ekona generating some ROMs with a lot of files, due to the `WriteTo` we required 256 MB in the RAM.
Now, we reuse arrays between calls with the library `System.Buffers`. The memory was reduced to 70 MB in the same test.

### Example

Internal improvement, API is the same.