### PR TITLE
:books: Fixed a small error in the Docs

### DIFF
--- a/docs/guides/Yarhl-nutshell.md
+++ b/docs/guides/Yarhl-nutshell.md
@@ -566,7 +566,7 @@ times the format of our node until it's the one we want.
 
 ```csharp
 var node = NodeFactory.FromFile(path);
-node.TransformTo<MenuSentences>;
+node.TransformTo<MenuSentences>();
 
 // Now node.Format is MenuSentences
 ```


### PR DESCRIPTION
Updated 'Yarhl in a nutshell' doc. TransformTo needs parenthesis. 
