### PR TITLE
Fix NodeFactory.FromDirectory

### DIFF
--- a/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeFactoryTests.cs
@@ -158,6 +158,25 @@ namespace Yarhl.UnitTests.FileSystem
         }
 
         [Test]
+        public void CreateFromDirectoryWithNameAndFinalSlash()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDir);
+
+            string tempFile1 = Path.Combine(tempDir, Path.GetRandomFileName());
+            File.Create(tempFile1).Dispose();
+
+            Node node = NodeFactory.FromDirectory(tempDir + Path.DirectorySeparatorChar, "*", "MyTempNode");
+            Assert.AreEqual("MyTempNode", node.Name);
+            Assert.IsTrue(node.IsContainer);
+            Assert.AreEqual(1, node.Children.Count);
+            Assert.IsTrue(node.Children.Any(n => n.Name == Path.GetFileName(tempFile1)));
+
+            node.Dispose();
+            Directory.Delete(tempDir, true);
+        }
+
+        [Test]
         public void CreateFromDirectoryNull()
         {
             Assert.That(

--- a/src/Yarhl/FileSystem/NodeFactory.cs
+++ b/src/Yarhl/FileSystem/NodeFactory.cs
@@ -298,6 +298,10 @@ namespace Yarhl.FileSystem
             // This sanitizes the path and remove double slashes
             dirPath = Path.GetFullPath(dirPath);
 
+            if (dirPath[^1] == Path.DirectorySeparatorChar) {
+                dirPath = dirPath.Remove(dirPath.Length - 1);
+            }
+
             string[] fileList = Directory.GetFiles(dirPath, filter, options);
             return FromFileList(dirPath, nodeName, fileList, mode);
         }


### PR DESCRIPTION
### Description

Using `NodeFactory.FromDirectory` to create a node with filter and name when the path passed as argument ended with a `DirectorySeparatorChar`, inserted wrong names in children nodes.

I have added the code to remove the last separator in a similar way done in the other `FromDirectory` overloads.