### PR TITLE
🐛  Comparing stream to itself returns false

### DIFF
--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -1607,6 +1607,18 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void CompareSameStreams()
+        {
+            using var stream1 = new DataStream();
+            stream1.WriteByte(0xCA);
+            stream1.WriteByte(0xFE);
+            stream1.WriteByte(0x00);
+            stream1.WriteByte(0xFF);
+            DataStream stream2 = stream1;
+            Assert.IsTrue(stream1.Compare(stream2));
+        }
+
+        [Test]
         public void CompareTwoEqualStreams()
         {
             DataStream stream1 = new DataStream();

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -674,13 +674,19 @@ namespace Yarhl.IO
         /// <param name="otherStream">Stream to compare with.</param>
         public bool Compare(Stream otherStream)
         {
-            if (otherStream == null)
+            if (otherStream == null) {
                 throw new ArgumentNullException(nameof(otherStream));
+            }
 
             // We can't check if the other stream is disposed because Stream
             // doesn't provide the property, so we delay it to the Seek method.
-            if (Disposed)
+            if (Disposed) {
                 throw new ObjectDisposedException(nameof(DataStream));
+            }
+
+            if (this == otherStream) {
+                return true;
+            }
 
             long startPosition = Position;
             long otherStreamStartPosition = otherStream.Position;


### PR DESCRIPTION
`DataStream.Compare` with the same object was returning that the stream was not identical. We were not detecting that it's the same instance and trying to read twice from the same object.

This PR closes #189 

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] ~~Related documentation is updated~~
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- Compare method to itself returns true

## Follow-up work

None

## Example

```cs
using var stream1 = new DataStream();
stream1.WriteByte(0xCA);
DataStream stream2 = stream1;
Assert.IsTrue(stream1.Compare(stream2))
```
