### PR TITLE
✨  Implement node renaming

### DIFF
--- a/docs/articles/core/virtual-file-system/nodes.md
+++ b/docs/articles/core/virtual-file-system/nodes.md
@@ -51,6 +51,20 @@ To access to a child use its index, `Children[3]`, or its name,
 > You can find more ways to iterate or navigate nodes across a hierarchy in the
 > [`Navigator`](xref:Yarhl.FileSystem.Navigator) class.
 
+### Path
+
+The [`Path`](xref:Yarhl.FileSystem.NavigableNode`1.Path) property provides the
+full route to the node. It contains the name of all its parent from the root
+node to the node. It does include the node name.
+
+The path separator is constant for every OS. It's defined in
+[`NodeSystem.PathSeparator`](xref:Yarhl.FileSystem.NodeSystem.PathSeparator).
+
+> [!WARNING]  
+> Nodes may change their name. If a _parent_ node change its name, the path of
+> all its children will change as well. Be careful storing the path, for
+> instance as a key, as it may change.
+
 ### Add or remove
 
 It's possible to add or remove children from its parent node. Use the method

--- a/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NavigableNodeTests.cs
@@ -45,6 +45,10 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.That(
                 () => new DummyNavigable(string.Empty),
                 Throws.TypeOf<ArgumentNullException>());
+
+            using var node = new DummyNavigable("name");
+            Assert.That(() => node.Name = null, Throws.ArgumentNullException);
+            Assert.That(() => node.Name = string.Empty, Throws.ArgumentNullException);
         }
 
         [Test]
@@ -55,6 +59,9 @@ namespace Yarhl.UnitTests.FileSystem
             Assert.That(
                 ex.Message,
                 Contains.Substring("Name contains invalid characters"));
+
+            using var node = new DummyNavigable("name");
+            Assert.That(() => node.Name = "MyT/est", Throws.ArgumentException);
         }
 
         [Test]
@@ -62,6 +69,20 @@ namespace Yarhl.UnitTests.FileSystem
         {
             using var node = new DummyNavigable("MyNameTest");
             Assert.AreEqual("MyNameTest", node.Name);
+
+            node.Name = "MyNewName";
+            Assert.That(node.Name, Is.EqualTo("MyNewName"));
+        }
+
+        [Test]
+        public void RenamingWithParentChildMatchThrows()
+        {
+            using var parent = new DummyNavigable("parent");
+            using var node1 = new DummyNavigable("node1");
+            parent.Add(node1);
+            parent.Add(new DummyNavigable("node2"));
+
+            Assert.That(() => node1.Name = "node2", Throws.ArgumentException);
         }
 
         [Test]
@@ -80,6 +101,22 @@ namespace Yarhl.UnitTests.FileSystem
 
             Assert.AreEqual("/MyParent/MyChild", node.Path);
             Assert.AreEqual("/MyParent", parentNode.Path);
+        }
+
+        [Test]
+        public void RenamingChangesPath()
+        {
+            using var parent = new DummyNavigable("parent");
+            using var node = new DummyNavigable("node1");
+            parent.Add(node);
+
+            Assert.That(node.Path, Is.EqualTo("/parent/node1"));
+
+            parent.Name = "root";
+            Assert.That(node.Path, Is.EqualTo("/root/node1"));
+
+            node.Name = "child";
+            Assert.That(node.Path, Is.EqualTo("/root/child"));
         }
 
         [Test]


### PR DESCRIPTION
Implement a setter to the `Name` property of nodes, so we can change their names.
Added a note to the `Path` property as it may change in parent affecting children. It shouldn't be stored as keys in dictionaries for instance.

This PR closes #193

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- The name of a node can change

## Follow-up work

None

## Example

```
using node = new Node("node1");
node.Name = "node2";
```
