### PR TITLE
✨  ChangeFormat fluent style returning itself

### DIFF
--- a/src/Yarhl.UnitTests/FileSystem/NodeTests.cs
+++ b/src/Yarhl.UnitTests/FileSystem/NodeTests.cs
@@ -137,9 +137,10 @@ public partial class NodeTests
         var dummyFormat1 = new StringFormat("3");
         var dummyFormat2 = new IntFormat(4);
         using var node = new Node("mytest", dummyFormat1);
-        node.ChangeFormat(dummyFormat2);
+        Node output = node.ChangeFormat(dummyFormat2);
         Assert.AreNotSame(node.Format, dummyFormat1);
         Assert.AreSame(node.Format, dummyFormat2);
+        Assert.AreSame(node, output);
     }
 
     [Test]

--- a/src/Yarhl/FileSystem/Node.cs
+++ b/src/Yarhl/FileSystem/Node.cs
@@ -124,6 +124,7 @@ namespace Yarhl.FileSystem
         /// <summary>
         /// Change the format of the current node.
         /// </summary>
+        /// <returns>This node.</returns>
         /// <remarks>
         /// <para>If the previous format was a container, this method will
         /// remove the children of the node.
@@ -137,14 +138,14 @@ namespace Yarhl.FileSystem
         /// If <see langword="true" /> the method will dispose the previous
         /// format.
         /// </param>
-        public void ChangeFormat(IFormat? newFormat, bool disposePreviousFormat = true)
+        public Node ChangeFormat(IFormat? newFormat, bool disposePreviousFormat = true)
         {
             if (Disposed) {
                 throw new ObjectDisposedException(nameof(Node));
             }
 
             if (newFormat == Format) {
-                return;
+                return this;
             }
 
             // If it was a container, clean children
@@ -162,6 +163,8 @@ namespace Yarhl.FileSystem
             if (IsContainer) {
                 AddContainerChildren();
             }
+
+            return this;
         }
 
         /// <summary>


### PR DESCRIPTION
Return the same node when calling `ChangeFormat` to allow method chaining.

This PR closes #196

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] ~~Related documentation is updated~~
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- ChangeFormat returns the same node

## Follow-up work

Further improvements will continue in #195 with an overload to import files.

## Example

```csharp
using var node = new Node("node")
    .ChangeFormat(binFormat)
    .TransformWith<Binary2Po>();
```
