### PR TITLE
🐛  WriteTo truncates output file

### DIFF
--- a/docs/articles/core/binary/datastream.md
+++ b/docs/articles/core/binary/datastream.md
@@ -94,6 +94,8 @@ internally maps to the .NET enumerations `FileMode` and `FileAccess` as follow:
 > hundreds of `DataStream` on different files ready without running out of
 > resources in the operative system.
 
+<!-- ignore warning -->
+
 > [!TIP]  
 > `FileOpenMode` is handy enumeration that covers most use cases. If you require
 > any other combination of `FileMode` and `FileAccess` you can create the
@@ -119,7 +121,9 @@ applies to the content that targets this `DataStream`, not the entire parent
 
 > [!NOTE]  
 > The method ignores the current position, it will always start writing from the
-> start to the end. It will **restore** the current position after comparing.
+> start to the end. It will **restore** the current position after writing. It
+> will also start **truncate** the output file. It will not append or preserve
+> any existing content.
 
 The path should point to the output file. If there is any directory that doesn't
 exist, it will create them first.

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -616,7 +616,7 @@ namespace Yarhl.IO
             }
 
             // We use FileStream so it creates a file even when the length is zero
-            using var segment = new FileStream(fileOut, FileMode.OpenOrCreate, FileAccess.Write);
+            using var segment = new FileStream(fileOut, FileMode.Create, FileAccess.Write);
             WriteSegmentTo(start, length, segment);
         }
 


### PR DESCRIPTION
`DataStream.WriteTo` now truncates the output file. Before if the file existed, it was opening and overwriting data. This could have caused unexpected results as the output file may have not contained exactly the same content as the source stream.

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- `WriteTo` truncates the file if exists

## Follow-up work

none

## Example

API doesn't change.
