### PR TITLE
✨  Implement slice for DataStream

### DIFF
--- a/docs/articles/core/binary/datastream.md
+++ b/docs/articles/core/binary/datastream.md
@@ -38,6 +38,14 @@ Another use case is reading a binary format with sections. By creating a
 modular and safe. It would prevent reading data outside the range of the
 section.
 
+We can create a _sub-stream_ from the `DataStream` constructor:
+
+[!code-csharp[SubStreamConstructor](./../../../../src/Yarhl.Examples/IO/DataStreamExamples.cs?name=SubStreamConstructor)]
+
+or from the `Slice` API:
+
+[!code-csharp[SubStreamConstructor](./../../../../src/Yarhl.Examples/IO/DataStreamExamples.cs?name=SubStreamSlice)]
+
 ## Factory
 
 The constructors of `DataStream` takes a `Stream` with optional offset and

--- a/src/Yarhl.Examples/IO/DataStreamExamples.cs
+++ b/src/Yarhl.Examples/IO/DataStreamExamples.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2023 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Yarhl.Examples.IO;
+
+using Yarhl.IO;
+
+public static class DataStreamExamples
+{
+    public static void CreateSubStreamConstructor()
+    {
+        #region SubStreamConstructor
+        var baseStream = new FileStream("container.bin", FileMode.Open);
+        using var file1Stream = new DataStream(baseStream, 0x100, 0x2C0);
+        using var file2Stream = new DataStream(baseStream, 0x3C0, 0x80);
+        #endregion
+    }
+
+    public static void CreateSubStreamSlice()
+    {
+        #region SubStreamSlice
+        DataStream containerStream = DataStreamFactory.FromFile("container.bin", FileOpenMode.Read);
+        using DataStream file1Stream = containerStream.Slice(0x100, 0x2C0);
+        using DataStream file2Stream = containerStream.Slice(0x3C0, 0x80);
+        using DataStream lastFileStream = containerStream.Slice(0x8400);
+        #endregion
+    }
+}

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -23,10 +23,8 @@ namespace Yarhl.UnitTests.IO
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Threading.Tasks;
-    using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
     using Moq;
     using NUnit.Framework;
-    using NUnit.Framework.Internal;
     using Yarhl.FileFormat;
     using Yarhl.IO;
     using Yarhl.IO.StreamFormat;

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -974,12 +974,21 @@ namespace Yarhl.UnitTests.IO
             stream.WriteByte(0xCA);
             stream.WriteByte(0xFE);
 
+            DataStream testSlice = stream.Slice(2);
             Assert.That(
-                () => stream.Slice(2),
+                () => testSlice,
                 Throws.Nothing);
+            Assert.AreEqual(0, testSlice.Position);
+            Assert.AreEqual(2, testSlice.Offset);
+            Assert.AreEqual(stream.Length - testSlice.Offset, testSlice.Length);
+
+            testSlice = stream.Slice(2, 2);
             Assert.That(
-                () => stream.Slice(2, 2),
+                () => testSlice,
                 Throws.Nothing);
+            Assert.AreEqual(0, testSlice.Position);
+            Assert.AreEqual(2, testSlice.Offset);
+            Assert.AreEqual(2, testSlice.Length);
             Assert.That(
                 () => stream.Slice(10),
                 Throws.Exception);

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -23,8 +23,10 @@ namespace Yarhl.UnitTests.IO
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Threading.Tasks;
+    using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
     using Moq;
     using NUnit.Framework;
+    using NUnit.Framework.Internal;
     using Yarhl.FileFormat;
     using Yarhl.IO;
     using Yarhl.IO.StreamFormat;
@@ -980,38 +982,104 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void SliceUsesSameBaseStream()
+        {
+            baseStream.Write(new byte[] { 0xCA, 0xFE });
+            using var parent = new DataStream(baseStream);
+
+            using DataStream slice = parent.Slice(1);
+
+            Assert.That(parent.BaseStream, Is.SameAs(baseStream));
+            Assert.That(slice.BaseStream, Is.SameAs(baseStream));
+        }
+
+        [Test]
         public void SliceStream()
         {
-            DataStream stream = new DataStream();
+            using var stream = new DataStream();
             stream.WriteByte(0xBE);
             stream.WriteByte(0xBA);
             stream.WriteByte(0xCA);
             stream.WriteByte(0xFE);
 
-            DataStream testSlice = stream.Slice(2);
-            Assert.That(
-                () => testSlice,
-                Throws.Nothing);
-            Assert.AreEqual(0, testSlice.Position);
-            Assert.AreEqual(2, testSlice.Offset);
-            Assert.AreEqual(stream.Length - testSlice.Offset, testSlice.Length);
+            using DataStream testSlice = stream.Slice(2);
+            Assert.That(testSlice, Is.Not.Null);
 
-            testSlice = stream.Slice(2, 1);
-            Assert.That(
-                () => testSlice,
-                Throws.Nothing);
-            Assert.AreEqual(0, testSlice.Position);
-            Assert.AreEqual(2, testSlice.Offset);
-            Assert.AreEqual(1, testSlice.Length);
-            Assert.That(
-                () => stream.Slice(10),
-                Throws.Exception);
-            Assert.That(
-                () => stream.Slice(10, 10),
-                Throws.Exception);
-            Assert.That(
-                () => stream.Slice(2, 10),
-                Throws.Exception);
+            Assert.Multiple(() => {
+                Assert.That(testSlice.Position, Is.EqualTo(0));
+                Assert.That(testSlice.Offset, Is.EqualTo(2));
+                Assert.That(testSlice.Length, Is.EqualTo(2));
+                Assert.That(testSlice.ReadByte(), Is.EqualTo(0xCA));
+            });
+        }
+
+        [Test]
+        public void SliceWithLength()
+        {
+            baseStream.Write(new byte[] { 0xBE, 0xBA, 0xCA, 0xFE });
+            using var stream = new DataStream(baseStream);
+
+            using DataStream testSlice = stream.Slice(2, 1);
+
+            Assert.That(testSlice, Is.Not.Null);
+            Assert.Multiple(() => {
+                Assert.That(testSlice.Position, Is.EqualTo(0));
+                Assert.That(testSlice.Offset, Is.EqualTo(2));
+                Assert.That(testSlice.Length, Is.EqualTo(1));
+                Assert.That(testSlice.ReadByte(), Is.EqualTo(0xCA));
+            });
+        }
+
+        [Test]
+        public void SliceZeroLengthSucceeds()
+        {
+            baseStream.Write(new byte[] { 0xBE, 0xBA, 0xCA, 0xFE });
+            using var stream = new DataStream(baseStream);
+
+            using DataStream testSlice = stream.Slice(2, 0);
+
+            Assert.That(testSlice, Is.Not.Null);
+            Assert.Multiple(() => {
+                Assert.That(testSlice.Offset, Is.EqualTo(2));
+                Assert.That(testSlice.Length, Is.EqualTo(0));
+            });
+
+            using DataStream endSlice = stream.Slice(4);
+            Assert.That(endSlice, Is.Not.Null);
+            Assert.Multiple(() => {
+                Assert.That(endSlice.Offset, Is.EqualTo(4));
+                Assert.That(endSlice.Length, Is.EqualTo(0));
+            });
+        }
+
+        [Test]
+        public void SliceCannotExpand()
+        {
+            baseStream.Write(new byte[] { 0xBE, 0xBA, 0xCA, 0xFE });
+            using var stream = new DataStream(baseStream);
+
+            using DataStream testSlice = stream.Slice(2, 1);
+
+            testSlice.Position = 1;
+            Assert.That(() => testSlice.WriteByte(0xC0), Throws.InstanceOf<InvalidOperationException>());
+
+            using DataStream endSlice = stream.Slice(4, 0);
+            Assert.That(() => endSlice.WriteByte(0xC0), Throws.InstanceOf<InvalidOperationException>());
+        }
+
+        [Test]
+        public void SliceThrowsWithInvalidArgs()
+        {
+            baseStream.Write(new byte[] { 0xBE, 0xBA, 0xCA, 0xFE });
+            using var stream = new DataStream(baseStream);
+
+            Assert.Multiple(() => {
+                Assert.That(() => stream.Slice(-1), Throws.InstanceOf<ArgumentOutOfRangeException>());
+                Assert.That(() => stream.Slice(5), Throws.InstanceOf<ArgumentOutOfRangeException>());
+                Assert.That(() => stream.Slice(-1, 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
+                Assert.That(() => stream.Slice(5, 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
+                Assert.That(() => stream.Slice(0, 5), Throws.InstanceOf<ArgumentOutOfRangeException>());
+            });
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -954,7 +954,7 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
-        public void ReadFormAfeterDisposeThrowException()
+        public void ReadFormAfterDisposeThrowException()
         {
             DataStream stream = new DataStream();
             stream.WriteByte(0xAF);
@@ -963,6 +963,32 @@ namespace Yarhl.UnitTests.IO
             stream.Dispose();
             Assert.IsTrue(stream.Disposed);
             Assert.Throws<ObjectDisposedException>(() => stream.ReadFormat<byte>());
+        }
+
+        [Test]
+        public void SliceStream()
+        {
+            DataStream stream = new DataStream();
+            stream.WriteByte(0xBE);
+            stream.WriteByte(0xBA);
+            stream.WriteByte(0xCA);
+            stream.WriteByte(0xFE);
+
+            Assert.That(
+                () => stream.Slice(2),
+                Throws.Nothing);
+            Assert.That(
+                () => stream.Slice(2, 2),
+                Throws.Nothing);
+            Assert.That(
+                () => stream.Slice(10),
+                Throws.Exception);
+            Assert.That(
+                () => stream.Slice(10, 10),
+                Throws.Exception);
+            Assert.That(
+                () => stream.Slice(2, 10),
+                Throws.Exception);
         }
 
         [Test]

--- a/src/Yarhl.UnitTests/IO/DataStreamTests.cs
+++ b/src/Yarhl.UnitTests/IO/DataStreamTests.cs
@@ -982,13 +982,13 @@ namespace Yarhl.UnitTests.IO
             Assert.AreEqual(2, testSlice.Offset);
             Assert.AreEqual(stream.Length - testSlice.Offset, testSlice.Length);
 
-            testSlice = stream.Slice(2, 2);
+            testSlice = stream.Slice(2, 1);
             Assert.That(
                 () => testSlice,
                 Throws.Nothing);
             Assert.AreEqual(0, testSlice.Position);
             Assert.AreEqual(2, testSlice.Offset);
-            Assert.AreEqual(2, testSlice.Length);
+            Assert.AreEqual(1, testSlice.Length);
             Assert.That(
                 () => stream.Slice(10),
                 Throws.Exception);

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -640,6 +640,29 @@ namespace Yarhl.IO
         }
 
         /// <summary>
+        /// Creates a substream starting in a defined position.
+        /// </summary>
+        /// <returns>The substream defined by offset and length parameters.</returns>
+        /// <param name="start">Defined starting position.</param>
+        public DataStream Slice(long start)
+        {
+            // TODO
+            return ParentDataStream;
+        }
+
+        /// <summary>
+        /// Creates a substream starting in a defined position and with a defined length.
+        /// </summary>
+        /// <returns>The substream defined by offset and length parameters.</returns>
+        /// <param name="start">Defined starting position.</param>
+        /// <param name="length">Defined length to be written.</param>
+        public DataStream Slice(long start, long length)
+        {
+            // TODO
+            return ParentDataStream;
+        }
+
+        /// <summary>
         /// Releases all resource used by the <see cref="DataStream"/>
         /// object.
         /// </summary>

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -649,10 +649,7 @@ namespace Yarhl.IO
             if (start < 0 || start > Length)
                 throw new ArgumentOutOfRangeException(nameof(start));
 
-            DataStream slicedStream = new DataStream();
-            WriteSegmentTo(start, slicedStream);
-
-            return slicedStream;
+            return new DataStream(this, start, Length - start);
         }
 
         /// <summary>
@@ -668,10 +665,7 @@ namespace Yarhl.IO
             if (length < 0 || start + length > Length)
                 throw new ArgumentOutOfRangeException(nameof(length));
 
-            DataStream slicedStream = new DataStream();
-            WriteSegmentTo(start, length, slicedStream);
-
-            return slicedStream;
+            return new DataStream(this, start, length);
         }
 
         /// <summary>

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -727,8 +727,9 @@ namespace Yarhl.IO
         /// <param name="start">Defined starting position.</param>
         public DataStream Slice(long start)
         {
-            if (start < 0 || start > Length)
+            if (start < 0 || start > Length) {
                 throw new ArgumentOutOfRangeException(nameof(start));
+            }
 
             return new DataStream(this, start, Length - start);
         }
@@ -741,10 +742,13 @@ namespace Yarhl.IO
         /// <param name="length">Defined length to be written.</param>
         public DataStream Slice(long start, long length)
         {
-            if (start < 0 || start > Length)
+            if (start < 0 || start > Length) {
                 throw new ArgumentOutOfRangeException(nameof(start));
-            if (length < 0 || start + length > Length)
+            }
+
+            if (length < 0 || start + length > Length) {
                 throw new ArgumentOutOfRangeException(nameof(length));
+            }
 
             return new DataStream(this, start, length);
         }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -646,6 +646,9 @@ namespace Yarhl.IO
         /// <param name="start">Defined starting position.</param>
         public DataStream Slice(long start)
         {
+            if (start < 0 || start > Length)
+                throw new ArgumentOutOfRangeException(nameof(start));
+
             // TODO
             return ParentDataStream;
         }
@@ -658,6 +661,11 @@ namespace Yarhl.IO
         /// <param name="length">Defined length to be written.</param>
         public DataStream Slice(long start, long length)
         {
+            if (start < 0 || start > Length)
+                throw new ArgumentOutOfRangeException(nameof(start));
+            if (length < 0 || start + length > Length)
+                throw new ArgumentOutOfRangeException(nameof(length));
+
             // TODO
             return ParentDataStream;
         }

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -649,8 +649,10 @@ namespace Yarhl.IO
             if (start < 0 || start > Length)
                 throw new ArgumentOutOfRangeException(nameof(start));
 
-            // TODO
-            return ParentDataStream;
+            DataStream slicedStream = new DataStream();
+            WriteSegmentTo(start, slicedStream);
+
+            return slicedStream;
         }
 
         /// <summary>
@@ -666,8 +668,10 @@ namespace Yarhl.IO
             if (length < 0 || start + length > Length)
                 throw new ArgumentOutOfRangeException(nameof(length));
 
-            // TODO
-            return ParentDataStream;
+            DataStream slicedStream = new DataStream();
+            WriteSegmentTo(start, length, slicedStream);
+
+            return slicedStream;
         }
 
         /// <summary>


### PR DESCRIPTION
Implement a new API `Slice` that helps to create sub stream from a DataStream.
This PR finished the work from #150 

This PR closes #143

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- New API `Slice` that creates a new DataStream from a start and length.

## Follow-up work

None

## Example

```csharp
stream.Slice(long start)
stream.Slice(long start, long length)
```

