### PR TITLE
✨  Implement constructor to create BinaryFormat from a file

### DIFF
--- a/src/Yarhl.UnitTests/IO/BinaryFormatTests.cs
+++ b/src/Yarhl.UnitTests/IO/BinaryFormatTests.cs
@@ -177,6 +177,29 @@ namespace Yarhl.UnitTests.IO
         }
 
         [Test]
+        public void ConstructorFromFile()
+        {
+            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            File.WriteAllBytes(tempFile, new byte[] { 0xCA, 0xFE });
+
+            try {
+                using var format = new BinaryFormat(tempFile, FileOpenMode.ReadWrite);
+                Assert.That(format.Stream.BaseStream, Is.InstanceOf<LazyFileStream>());
+                Assert.That(format.Stream.Position, Is.EqualTo(0));
+                Assert.That(format.Stream.Length, Is.EqualTo(2));
+                Assert.That(format.Stream.ReadByte(), Is.EqualTo(0xCA));
+            } finally {
+                File.Delete(tempFile);
+            }
+        }
+
+        [Test]
+        public void ConstructorFromFileInvalidParams()
+        {
+            Assert.That(() => new BinaryFormat(null, FileOpenMode.Read), Throws.ArgumentNullException);
+        }
+
+        [Test]
         public void Clone()
         {
             byte[] data = { 0x01, 0x02, 0x03 };

--- a/src/Yarhl/IO/BinaryFormat.cs
+++ b/src/Yarhl/IO/BinaryFormat.cs
@@ -46,8 +46,7 @@ namespace Yarhl.IO
         /// </param>
         public BinaryFormat(Stream stream)
         {
-            if (stream == null)
-                throw new ArgumentNullException(nameof(stream));
+            ArgumentNullException.ThrowIfNull(stream);
 
             Stream = stream as DataStream ?? DataStreamFactory.FromStream(stream);
         }
@@ -67,14 +66,28 @@ namespace Yarhl.IO
         /// <param name="length">Length of the substream.</param>
         public BinaryFormat(Stream stream, long offset, long length)
         {
-            if (stream == null)
-                throw new ArgumentNullException(nameof(stream));
-            if (offset < 0 || offset > stream.Length)
+            ArgumentNullException.ThrowIfNull(stream);
+            if (offset < 0 || offset > stream.Length) {
                 throw new ArgumentOutOfRangeException(nameof(offset));
-            if (length < 0 || offset + length > stream.Length)
+            }
+
+            if (length < 0 || offset + length > stream.Length) {
                 throw new ArgumentOutOfRangeException(nameof(length));
+            }
 
             Stream = DataStreamFactory.FromStream(stream, offset, length);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BinaryFormat"/> class.
+        /// </summary>
+        /// <param name="path">The path of the file.</param>
+        /// <param name="mode">The mode to open the file.</param>
+        public BinaryFormat(string path, FileOpenMode mode)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+
+            Stream = DataStreamFactory.FromFile(path, mode);
         }
 
         /// <summary>
@@ -126,8 +139,9 @@ namespace Yarhl.IO
         /// </param>
         protected virtual void Dispose(bool disposing)
         {
-            if (Disposed)
+            if (Disposed) {
                 return;
+            }
 
             Disposed = true;
             if (disposing) {


### PR DESCRIPTION
As it's a common operation, add a constructor to create a new instance of `BinaryFormat` from a file path. To create from a part of a file, use `DataStreamFactory`, we don't want to port the full API in the constructor.

This PR closes #195

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] ~~Related documentation is updated~~
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- Shortcut to create BinaryFormat from a file path.

## Follow-up work

None

## Example

```csharp
using var binary = new BinaryFormat("file1.bin", FileOpenMode.Read);
```
