### PR TITLE
✨ Enhace debugging view

### DIFF
--- a/src/Yarhl/FileSystem/Node.cs
+++ b/src/Yarhl/FileSystem/Node.cs
@@ -21,12 +21,14 @@ namespace Yarhl.FileSystem
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using Yarhl.FileFormat;
     using Yarhl.IO;
 
     /// <summary>
     /// Node in the FileSystem with an associated format.
     /// </summary>
+    [DebuggerDisplay("{Name} [{Format}]")]
     public partial class Node : NavigableNode<Node>
     {
         /// <summary>

--- a/src/Yarhl/FileSystem/NodeContainerFormat.cs
+++ b/src/Yarhl/FileSystem/NodeContainerFormat.cs
@@ -20,12 +20,14 @@
 namespace Yarhl.FileSystem
 {
     using System;
+    using System.Diagnostics;
     using System.Linq;
     using Yarhl.FileFormat;
 
     /// <summary>
     /// Node container format for unpack / pack files.
     /// </summary>
+    [DebuggerDisplay("Container: count={Root.Children.Count}")]
     public class NodeContainerFormat : IDisposable, ICloneableFormat
     {
         bool manageRoot;

--- a/src/Yarhl/IO/BinaryFormat.cs
+++ b/src/Yarhl/IO/BinaryFormat.cs
@@ -20,12 +20,14 @@
 namespace Yarhl.IO
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
     using Yarhl.FileFormat;
 
     /// <summary>
     /// Binary format.
     /// </summary>
+    [DebuggerDisplay("Binary: {Stream}")]
     public class BinaryFormat : IBinary, IDisposable, ICloneableFormat
     {
         /// <summary>

--- a/src/Yarhl/IO/DataStream.cs
+++ b/src/Yarhl/IO/DataStream.cs
@@ -23,10 +23,10 @@ namespace Yarhl.IO
     using System.Buffers;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;
-    using Yarhl.FileFormat;
     using Yarhl.IO.StreamFormat;
 
     /// <summary>
@@ -43,6 +43,10 @@ namespace Yarhl.IO
         "",
         "S3881",
         Justification = "Historical reasons: https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.dispose")]
+    [DebuggerDisplay(
+        "pos={\"0x\" + Position.ToString(\"X\")}, " +
+        "len={\"0x\" + Length.ToString(\"X\")}, " +
+        "offset={\"0x\" + Offset.ToString(\"X\")}")]
     public partial class DataStream : Stream
     {
         static readonly ConcurrentDictionary<Stream, StreamInfo> Instances = new ConcurrentDictionary<Stream, StreamInfo>();


### PR DESCRIPTION
Improve the view of the debuggers displaying the main properties of some key types:

- `Node`: display name and format between square brackets
- `DataStream`: display offset, length and position
- `BinaryFormat`: display "Binary" and info from underlying Stream
- `NodeContainerFormat`: display number of children


## Quality check list

- [x] Related code has been tested automatically or manually
- [x] ~~Related documentation is updated~~ too small to document
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- In the debug view we can see the name and format of the node like in IDEs like SceneGate

## Follow-up work

- PO? we will add it as we find other use cases useful

## Example

- DataStream:
  ![image](https://github.com/SceneGate/Yarhl/assets/3107481/7814466d-7b87-41dc-8de6-1af974f58657)
- Node with container format:
  ![image](https://github.com/SceneGate/Yarhl/assets/3107481/2b5a825d-2808-41be-b821-1c466d30ebb0)
- Node with binary format:
  ![image](https://github.com/SceneGate/Yarhl/assets/3107481/c8f90b79-6a42-4def-a7ae-79f587bd02f8)

